### PR TITLE
Formatting changes to README for consistency in user experience

### DIFF
--- a/README
+++ b/README
@@ -2,7 +2,10 @@ opendnp3
 Copyright (c) 2010, 2011 Green Energy Corp.
 Copyright (c) 2013 Automatak LLC
 
-Partially licensed under the terms of the Apache Public License v2.0.  Modifications made by Automatak, LLC are licensed under the terms GNU Affero General Public License Version 3.0. Contact Automatak, LLC for a commercial license to these modifications.
+Partially licensed under the terms of the Apache Public License v2.0.
+Modifications made by Automatak, LLC are licensed under the terms GNU
+Affero General Public License Version 3.0. Contact Automatak, LLC for a
+commercial license to these modifications.
 
 Documentation
 =============
@@ -19,20 +22,22 @@ https://github.com/automatakllc/dnp3/wiki
 Overview
 ========
 
-OpenDNP3 is a portable, scalable, and rigorously tested implementation 
-of the DNP3 (www.dnp.org) protocol stack written in C++. The library 
-is optimized for the largest front end processor implementations
-and slave device simulations, although it performs very well on 
-embedded linux ARM in a single outstation configuration.
+OpenDNP3 is a portable, scalable, and rigorously tested implementation
+of the DNP3 (www.dnp.org) protocol stack written in C++. The library is
+optimized for the largest front end processor implementations and slave
+device simulations, although it performs very well on embedded linux ARM
+in a single outstation configuration.
 
-Custom written, idiomatic bindings are available for the 
-Microsoft CLR family of languages (C#, VB.NET, F#, etc) and JVM-based
-languages (Java, Scala, Clojure, etc).
+Custom written, idiomatic bindings are available for the Microsoft CLR
+family of languages (C#, VB.NET, F#, etc) and JVM-based languages (Java,
+Scala, Clojure, etc).
 
 About AGPLv3
 ============
 
-AGPLv3 is a copyleft license that triggers even if you are only using the library against a 3rd party over a network. You must either abide by the terms of the license or purchase a proprietary friendly license.
+AGPLv3 is a copyleft license that triggers even if you are only using
+the library against a 3rd party over a network. You must either abide by
+the terms of the license or purchase a proprietary friendly license.
 
 History
 =======


### PR DESCRIPTION
The README had several lines which were unwrapped.  Reformatting to wrap
at a particular column allows the README to show up in a consistent
manner.
