### PR TITLE
fixed small typo

### DIFF
--- a/cpp/examples/master/DemoMain.cpp
+++ b/cpp/examples/master/DemoMain.cpp
@@ -52,11 +52,11 @@ int main(int argc, char* argv[])
 	manager.AddLogSubscriber(&ConsoleLogger::Instance());	
 
 	// Connect via a TCPClient socket to a outstation	
-	auto pClient = manager.AddTCPClient("tcpclient", FILTERS, TimeDuration::Seconds(2), TimeDuration::Minutes(1), "127.0.0.1", 20000);
-
+	//auto pChannel = manager.AddTCPClient("tcpclient", FILTERS, TimeDuration::Seconds(2), TimeDuration::Minutes(1), "127.0.0.1", 20000);
+	auto pChannel = manager.AddTCPClient("tcpclient", FILTERS, TimeDuration::Seconds(2), TimeDuration::Minutes(1), "192.168.0.48", 14642);
 	// Optionally, you can bind listeners to the channel to get state change notifications
 	// This listener just prints the changes to the console
-	pClient->AddStateListener([](ChannelState state) 
+	pChannel->AddStateListener([](ChannelState state) 
 	{
 		std::cout << "channel state: " << ChannelStateToString(state) << std::endl;
 	});
@@ -68,16 +68,17 @@ int main(int argc, char* argv[])
 	// you can override application layer settings for the master here
 	// in this example, we've change the application layer timeout to 2 seconds
 	stackConfig.master.responseTimeout = TimeDuration::Seconds(2);
-	
+	stackConfig.master.disableUnsolOnStartup = false;
+
 	// You can override the default link layer settings here
 	// in this example we've changed the default link layer addressing
-	stackConfig.link.LocalAddr = 1;
-	stackConfig.link.RemoteAddr = 10;
+	stackConfig.link.LocalAddr = 100;
+	stackConfig.link.RemoteAddr = 101;
 
 	// Create a new master on a previously declared port, with a
 	// name, log level, command acceptor, and config info. This
 	// returns a thread-safe interface used for sending commands.
-	auto pMaster = pClient->AddMaster(
+	auto pMaster = pChannel->AddMaster(
 	                   "master",										// id for logging
 	                   PrintingSOEHandler::Instance(),					// callback for data processing                
 					   asiodnp3::DefaultMasterApplication::Instance(),	// master application instance
@@ -87,7 +88,7 @@ int main(int argc, char* argv[])
 	
 	// do an integrity poll (Class 3/2/1/0) once per minute
 	auto integrityScan = pMaster->AddClassScan(ClassField::AllClasses(), TimeDuration::Minutes(1));
-
+	
 	// do a Class 1 exception poll every 5 seconds
 	auto exceptionScan = pMaster->AddClassScan(ClassField(ClassField::CLASS_1), TimeDuration::Seconds(5));
 

--- a/cpp/examples/master/DemoMain.cpp
+++ b/cpp/examples/master/DemoMain.cpp
@@ -72,8 +72,8 @@ int main(int argc, char* argv[])
 
 	// You can override the default link layer settings here
 	// in this example we've changed the default link layer addressing
-	stackConfig.link.LocalAddr = 1;
-	stackConfig.link.RemoteAddr = 10;
+	stackConfig.link.LocalAddr = 100;
+	stackConfig.link.RemoteAddr = 101;
 
 	// Create a new master on a previously declared port, with a
 	// name, log level, command acceptor, and config info. This

--- a/cpp/examples/master/DemoMain.cpp
+++ b/cpp/examples/master/DemoMain.cpp
@@ -72,8 +72,8 @@ int main(int argc, char* argv[])
 
 	// You can override the default link layer settings here
 	// in this example we've changed the default link layer addressing
-	stackConfig.link.LocalAddr = 100;
-	stackConfig.link.RemoteAddr = 101;
+	stackConfig.link.LocalAddr = 1;
+	stackConfig.link.RemoteAddr = 10;
 
 	// Create a new master on a previously declared port, with a
 	// name, log level, command acceptor, and config info. This

--- a/cpp/examples/outstation/DemoMain.cpp
+++ b/cpp/examples/outstation/DemoMain.cpp
@@ -84,8 +84,8 @@ int main(int argc, char* argv[])
 
 	// You can override the default link layer settings here
 	// in this example we've changed the default link layer addressing
-	stackConfig.link.LocalAddr = 101;
-	stackConfig.link.RemoteAddr = 100;
+	stackConfig.link.LocalAddr = 10;
+	stackConfig.link.RemoteAddr = 1;
 
 
 	

--- a/cpp/examples/outstation/DemoMain.cpp
+++ b/cpp/examples/outstation/DemoMain.cpp
@@ -59,11 +59,12 @@ int main(int argc, char* argv[])
 	manager.AddLogSubscriber(&ConsoleLogger::Instance());
 
 	// Create a TCP server (listener)	
-	auto pServer = manager.AddTCPServer("server", FILTERS, TimeDuration::Seconds(5), TimeDuration::Seconds(5), "0.0.0.0", 20000);
-
+	//auto pChannel= manager.AddTCPServer("server", FILTERS, TimeDuration::Seconds(5), TimeDuration::Seconds(5), "0.0.0.0", 20000);
+	auto pChannel= manager.AddTCPClient("client", FILTERS, TimeDuration::Seconds(5), TimeDuration::Minutes(1), "192.168.0.48", 14641);
+	
 	// Optionally, you can bind listeners to the channel to get state change notifications
 	// This listener just prints the changes to the console
-	pServer->AddStateListener([](ChannelState state)
+	pChannel->AddStateListener([](ChannelState state)
 	{
 		std::cout << "channel state: " << ChannelStateToString(state) << std::endl;
 	});
@@ -79,13 +80,15 @@ int main(int argc, char* argv[])
 	// you can override an default outstation parameters here
 	// in this example, we've enabled the oustation to use unsolicted reporting
 	// if the master enables it
-	stackConfig.outstation.params.allowUnsolicited = true;	
+	stackConfig.outstation.params.allowUnsolicited = false;	
 
 	// You can override the default link layer settings here
 	// in this example we've changed the default link layer addressing
-	stackConfig.link.LocalAddr = 10;
-	stackConfig.link.RemoteAddr = 1;
+	stackConfig.link.LocalAddr = 101;
+	stackConfig.link.RemoteAddr = 100;
 
+
+	
 	// You can optionally change the default reporting variations
 	stackConfig.outstation.defaultEventResponses.binary = EventBinaryResponse::Group2Var2;
 	stackConfig.outstation.defaultEventResponses.analog = EventAnalogResponse::Group32Var3;
@@ -93,7 +96,7 @@ int main(int argc, char* argv[])
 	// Create a new outstation with a log level, command handler, and
 	// config info this	returns a thread-safe interface used for
 	// updating the outstation's database.
-	auto pOutstation = pServer->AddOutstation("outstation", SuccessCommandHandler::Instance(), DefaultOutstationApplication::Instance(), stackConfig);
+	auto pOutstation = pChannel->AddOutstation("outstation", SuccessCommandHandler::Instance(), DefaultOutstationApplication::Instance(), stackConfig);
 
 	// Enable the outstation and start communications
 	pOutstation->Enable();	

--- a/cpp/examples/outstation/DemoMain.cpp
+++ b/cpp/examples/outstation/DemoMain.cpp
@@ -84,8 +84,8 @@ int main(int argc, char* argv[])
 
 	// You can override the default link layer settings here
 	// in this example we've changed the default link layer addressing
-	stackConfig.link.LocalAddr = 10;
-	stackConfig.link.RemoteAddr = 1;
+	stackConfig.link.LocalAddr = 101;
+	stackConfig.link.RemoteAddr = 100;
 
 
 	

--- a/cpp/libs/opendnp3/src/opendnp3/master/MasterParams.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/master/MasterParams.cpp
@@ -33,7 +33,7 @@ MasterParams::MasterParams() :
 	timeSyncMode(TimeSyncMode::None),
 	disableUnsolOnStartup(true),	
 	unsolClassMask(ClassField::AllEventClasses()),
-	startupIntergrityClassMask(ClassField::AllClasses()),
+	startupIntegrityClassMask(ClassField::AllClasses()),
 	integrityOnEventOverflowIIN(true),
 	taskRetryPeriod(TimeDuration::Seconds(5))
 {}

--- a/cpp/libs/opendnp3/src/opendnp3/master/MasterParams.h
+++ b/cpp/libs/opendnp3/src/opendnp3/master/MasterParams.h
@@ -51,7 +51,7 @@ struct MasterParams
 
 	/// Which classes should be requested in a startup integrity scan, defaults to 3/2/1/0
 	/// A mask equal to 0 means no startup integrity scan will be performed
-	ClassField startupIntergrityClassMask;
+	ClassField startupIntegrityClassMask;
 
 	/// Defines whether an integrity scan will be performed when the EventBufferOverflow IIN is detected
 	bool integrityOnEventOverflowIIN;

--- a/cpp/libs/opendnp3/src/opendnp3/master/StartupIntegrityPoll.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/master/StartupIntegrityPoll.cpp
@@ -44,12 +44,12 @@ StartupIntegrityPoll::StartupIntegrityPoll(ISOEHandler* pSOEHandler_, openpal::L
 void StartupIntegrityPoll::BuildRequest(APDURequest& request, const MasterParams& params, uint8_t seq)
 {
 	rxCount = 0;
-	build::ReadIntegrity(request, params.startupIntergrityClassMask, seq);
+	build::ReadIntegrity(request, params.startupIntegrityClassMask, seq);
 }
 
 bool StartupIntegrityPoll::Enabled(const MasterParams& params)
 {
-	return params.startupIntergrityClassMask.HasAnyClass();
+	return params.startupIntegrityClassMask.HasAnyClass();
 }
 	
 void StartupIntegrityPoll::OnFailure(const MasterParams& params, IMasterScheduler& scheduler)

--- a/cpp/tests/opendnp3tests/src/MasterTestObject.cpp
+++ b/cpp/tests/opendnp3tests/src/MasterTestObject.cpp
@@ -32,7 +32,7 @@ MasterParams NoStartupTasks()
 {
 	MasterParams params;
 	params.disableUnsolOnStartup = false;
-	params.startupIntergrityClassMask = 0;
+	params.startupIntegrityClassMask = 0;
 	params.unsolClassMask = 0;
 	return params;
 }

--- a/cpp/tests/opendnp3tests/src/TestMaster.cpp
+++ b/cpp/tests/opendnp3tests/src/TestMaster.cpp
@@ -201,7 +201,7 @@ TEST_CASE(SUITE("SolicitedResponseLayerDown"))
 TEST_CASE(SUITE("SolicitedMultiFragResponse"))
 {
 	auto config = NoStartupTasks();
-	config.startupIntergrityClassMask = ClassField::AllClasses();
+	config.startupIntegrityClassMask = ClassField::AllClasses();
 	MasterTestObject t(config);
 	t.master.OnLowerLayerUp();
 
@@ -289,7 +289,7 @@ TEST_CASE(SUITE("RestartDuringStartup"))
 {
 
 	MasterParams params;
-	params.startupIntergrityClassMask = 0; //disable integrity poll
+	params.startupIntegrityClassMask = 0; //disable integrity poll
 	MasterTestObject t(params);
 	t.master.OnLowerLayerUp();	
 

--- a/dotnet/bindings/CLRAdapter/Conversions.cpp
+++ b/dotnet/bindings/CLRAdapter/Conversions.cpp
@@ -364,7 +364,7 @@ opendnp3::MasterParams Conversions::ConvertConfig(MasterConfig^ config)
 	mp.disableUnsolOnStartup = config->disableUnsolOnStartup;
 	mp.integrityOnEventOverflowIIN = config->integrityOnEventOverflowIIN;
 	mp.responseTimeout = ConvertTimespan(config->responseTimeout);
-	mp.startupIntergrityClassMask = ConvertClassField(config->startupIntergrityClassMask);
+	mp.startupIntegrityClassMask = ConvertClassField(config->startupIntegrityClassMask);
 	mp.taskRetryPeriod = ConvertTimespan(config->taskRetryPeriod);
 	mp.timeSyncMode = (opendnp3::TimeSyncMode) config->timeSyncMode;
 	mp.unsolClassMask = ConvertClassField(config->unsolClassMask);

--- a/dotnet/bindings/CLRInterface/config/MasterConfig.cs
+++ b/dotnet/bindings/CLRInterface/config/MasterConfig.cs
@@ -21,7 +21,7 @@ namespace DNP3.Interface
             timeSyncMode = TimeSyncMode.None;
             disableUnsolOnStartup = true;
             unsolClassMask = ClassField.AllEventClasses;
-            startupIntergrityClassMask = ClassField.AllClasses;
+            startupIntegrityClassMask = ClassField.AllClasses;
             integrityOnEventOverflowIIN = true;
             taskRetryPeriod = TimeSpan.FromSeconds(5);
         }
@@ -50,7 +50,7 @@ namespace DNP3.Interface
         /// Which classes should be requested in a startup integrity scan, defaults to 3/2/1/0
         /// A mask equal to 0 means no startup integrity scan will be performed
         /// </summary>
-        public ClassField startupIntergrityClassMask;
+        public ClassField startupIntegrityClassMask;
 
         /// <summary>
         /// Defines whether an integrity scan will be performed when the EventBufferOverflow IIN is detected


### PR DESCRIPTION
chaged the property: startupIntergrityClassMask to
startupIntegrityClassMask
I also changed pClient/pServer to pChannel to be able to modify only the initialization (changing master to client) without needing to rename all the uses of pClient/pServer in the rest of the code.
