### PR TITLE
Add missing ControlCode and CommandStatus

### DIFF
--- a/cpp/libs/opendnp3/src/opendnp3/gen/CommandStatus.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/gen/CommandStatus.cpp
@@ -50,6 +50,26 @@ CommandStatus CommandStatusFromType(uint8_t arg)
       return CommandStatus::TOO_MANY_OPS;
     case(9):
       return CommandStatus::NOT_AUTHORIZED;
+    case(10):
+      return CommandStatus::AUTOMATION_INHIBIT;
+    case(11):
+      return CommandStatus::PROCESSING_LIMITED;
+    case(12):
+      return CommandStatus::OUT_OF_RANGE;
+    case(13):
+      return CommandStatus::DOWNSTREAM_LOCAL;
+    case(14):
+      return CommandStatus::ALREADY_COMPLETE;
+    case(15):
+      return CommandStatus::BLOCKED;
+    case(16):
+      return CommandStatus::CANCELLED;
+    case(17):
+      return CommandStatus::BLOCKED_OTHER_MASTER;
+    case(18):
+      return CommandStatus::DOWNSTREAM_FAIL;
+    case(126):
+      return CommandStatus::NON_PARTICIPATING;
     case(127):
       return CommandStatus::UNDEFINED;
   }
@@ -79,6 +99,26 @@ char const* CommandStatusToString(CommandStatus arg)
       return "TOO_MANY_OPS";
     case(CommandStatus::NOT_AUTHORIZED):
       return "NOT_AUTHORIZED";
+    case(CommandStatus::AUTOMATION_INHIBIT):
+      return "AUTOMATION_INHIBIT";
+    case(CommandStatus::PROCESSING_LIMITED):
+      return "PROCESSING_LIMITED";
+    case(CommandStatus::OUT_OF_RANGE):
+      return "OUT_OF_RANGE";
+    case(CommandStatus::DOWNSTREAM_LOCAL):
+      return "DOWNSTREAM_LOCAL";
+    case(CommandStatus::ALREADY_COMPLETE):
+      return "ALREADY_COMPLETE";
+    case(CommandStatus::BLOCKED):
+      return "BLOCKED";
+    case(CommandStatus::CANCELLED):
+      return "CANCELLED";
+    case(CommandStatus::BLOCKED_OTHER_MASTER):
+      return "BLOCKED_OTHER_MASTER";
+    case(CommandStatus::DOWNSTREAM_FAIL):
+      return "DOWNSTREAM_FAIL";
+    case(CommandStatus::NON_PARTICIPATING):
+      return "NON_PARTICIPATING";
     case(CommandStatus::UNDEFINED):
       return "UNDEFINED";
   }

--- a/cpp/libs/opendnp3/src/opendnp3/gen/CommandStatus.h
+++ b/cpp/libs/opendnp3/src/opendnp3/gen/CommandStatus.h
@@ -51,7 +51,27 @@ enum class CommandStatus : uint8_t
   TOO_MANY_OPS = 8,
   /// the command was rejected because the device denied it or an RTU intercepted it
   NOT_AUTHORIZED = 9,
-  /// 10 to 126 are currently reserved
+  /// command not accepted because it was prevented or inhibited by a local automation process, such as interlocking logic or synchrocheck
+  AUTOMATION_INHIBIT = 10,
+  /// command not accepted because the device cannot process any more activities than are presently in progress
+  PROCESSING_LIMITED = 11,
+  /// command not accepted because the value is outside the acceptable range permitted for this point
+  OUT_OF_RANGE = 12,
+  /// command not accepted because the outstation is forwarding the request to another downstream device which reported LOCAL
+  DOWNSTREAM_LOCAL = 13,
+  /// command not accepted because the outstation has already completed the requested operation
+  ALREADY_COMPLETE = 14,
+  /// command not accepted because the requested function is specifically blocked at the outstation
+  BLOCKED = 15,
+  /// command not accepted because the operation was cancelled
+  CANCELLED = 16,
+  /// command not accepted because another master is communicating with the outstation and has exclusive rights to operate this control point
+  BLOCKED_OTHER_MASTER = 17,
+  /// command not accepted because the outstation is forwarding the request to another downstream device which cannot be reached or is otherwise incapable of performing the request
+  DOWNSTREAM_FAIL = 18,
+  /// (deprecated) indicates the outstation shall not issue or perform the control operation
+  NON_PARTICIPATING = 126,
+  /// command not accepted because of some other undefined reason
   UNDEFINED = 127
 };
 

--- a/cpp/libs/opendnp3/src/opendnp3/gen/ControlCode.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/gen/ControlCode.cpp
@@ -33,7 +33,9 @@ ControlCode ControlCodeFromType(uint8_t arg)
     case(0x0):
       return ControlCode::NUL;
     case(0x1):
-      return ControlCode::PULSE;
+      return ControlCode::PULSE_ON;
+    case(0x2):
+      return ControlCode::PULSE_OFF;
     case(0x3):
       return ControlCode::LATCH_ON;
     case(0x4):
@@ -53,8 +55,10 @@ char const* ControlCodeToString(ControlCode arg)
   {
     case(ControlCode::NUL):
       return "NUL";
-    case(ControlCode::PULSE):
-      return "PULSE";
+    case(ControlCode::PULSE_ON):
+      return "PULSE_ON";
+    case(ControlCode::PULSE_OFF):
+      return "PULSE_OFF";
     case(ControlCode::LATCH_ON):
       return "LATCH_ON";
     case(ControlCode::LATCH_OFF):

--- a/cpp/libs/opendnp3/src/opendnp3/gen/ControlCode.h
+++ b/cpp/libs/opendnp3/src/opendnp3/gen/ControlCode.h
@@ -28,7 +28,7 @@ namespace opendnp3 {
 /**
   There are a number of types of controls. The best way to understand this 
   difference is to think about the hardware controls the communication protocols are 
-  emulating. The most common to use are PULSE, LATCH_ON and LATCH_OFF
+  emulating. The most common to use are PULSE_ON, LATCH_ON and LATCH_OFF
 
   NOTE: Current implementation doesn't support queue/clear.
 
@@ -40,7 +40,9 @@ enum class ControlCode : uint8_t
   /// illegal command code (used internally)
   NUL = 0x0,
   /// a 'push-button' interface, can only be pressed one way (reset button on pedometer)
-  PULSE = 0x1,
+  PULSE_ON = 0x1,
+  /// a 'push-button' interface with output remaining active following pulse
+  PULSE_OFF = 0x2,
   /// a 'light-switch' moved to the ON position
   LATCH_ON = 0x3,
   /// a 'light-switch' moved to the OFF position

--- a/cpp/tests/opendnp3tests/src/TestMasterCommandRequests.cpp
+++ b/cpp/tests/opendnp3tests/src/TestMasterCommandRequests.cpp
@@ -44,7 +44,7 @@ TEST_CASE(SUITE("ControlExecutionClosedState"))
 
 	auto pCmdProcessor = &t.master.GetCommandProcessor();
 
-	ControlRelayOutputBlock bo(ControlCode::PULSE);
+	ControlRelayOutputBlock bo(ControlCode::PULSE_ON);
 	MockCommandCallback callback;
 
 	for(int i = 0; i < 10; ++i)
@@ -62,7 +62,7 @@ TEST_CASE(SUITE("SelectAndOperate"))
 	MasterTestObject t(NoStartupTasks());
 	t.master.OnLowerLayerUp();
 
-	ControlRelayOutputBlock bo(ControlCode::PULSE);
+	ControlRelayOutputBlock bo(ControlCode::PULSE_ON);
 
 	MockCommandCallback callback;
 	t.master.GetCommandProcessor().SelectAndOperate(bo, 1, callback);
@@ -93,7 +93,7 @@ TEST_CASE(SUITE("SelectAndOperateWithConfirmResponse"))
 	MasterTestObject t(NoStartupTasks());
 	t.master.OnLowerLayerUp();
 
-	ControlRelayOutputBlock bo(ControlCode::PULSE);
+	ControlRelayOutputBlock bo(ControlCode::PULSE_ON);
 
 	MockCommandCallback callback;
 	t.master.GetCommandProcessor().SelectAndOperate(bo, 1, callback);
@@ -128,7 +128,7 @@ TEST_CASE(SUITE("ControlExecutionSelectTimeout"))
 	t.master.OnLowerLayerUp();
 
 	MockCommandCallback callback;
-	t.master.GetCommandProcessor().SelectAndOperate(ControlRelayOutputBlock(ControlCode::PULSE), 1, callback);
+	t.master.GetCommandProcessor().SelectAndOperate(ControlRelayOutputBlock(ControlCode::PULSE_ON), 1, callback);
 	t.exe.RunMany();
 
 	REQUIRE(t.lower.PopWriteAsHex() == "C0 03 " + crob); // SELECT
@@ -148,7 +148,7 @@ TEST_CASE(SUITE("ControlExecutionSelectLayerDown"))
 	t.master.OnLowerLayerUp();
 
 	MockCommandCallback callback;
-	t.master.GetCommandProcessor().SelectAndOperate(ControlRelayOutputBlock(ControlCode::PULSE), 1, callback);
+	t.master.GetCommandProcessor().SelectAndOperate(ControlRelayOutputBlock(ControlCode::PULSE_ON), 1, callback);
 	t.exe.RunMany();
 
 	REQUIRE(t.lower.PopWriteAsHex() == "C0 03 " + crob); // SELECT
@@ -167,7 +167,7 @@ TEST_CASE(SUITE("ControlExecutionSelectErrorResponse"))
 	t.master.OnLowerLayerUp();
 
 	MockCommandCallback callback;
-	t.master.GetCommandProcessor().SelectAndOperate(ControlRelayOutputBlock(ControlCode::PULSE), 1, callback);
+	t.master.GetCommandProcessor().SelectAndOperate(ControlRelayOutputBlock(ControlCode::PULSE_ON), 1, callback);
 	t.exe.RunMany();
 	t.master.OnSendResult(true);
 	t.SendToMaster("C0 81 00 00 0C 01 28 01 00 01 00 01 01 64 00 00 00 64 00 00 00 04"); // not supported
@@ -185,7 +185,7 @@ TEST_CASE(SUITE("ControlExecutionSelectPartialResponse"))
 	t.master.OnLowerLayerUp();
 
 	MockCommandCallback callback;
-	t.master.GetCommandProcessor().SelectAndOperate(ControlRelayOutputBlock(ControlCode::PULSE), 1, callback);
+	t.master.GetCommandProcessor().SelectAndOperate(ControlRelayOutputBlock(ControlCode::PULSE_ON), 1, callback);
 	t.exe.RunMany();
 	t.master.OnSendResult(true);
 
@@ -212,7 +212,7 @@ TEST_CASE(SUITE("DeferredControlExecution"))
 	t.master.OnSendResult(true);
 	
 	//issue a command while the master is waiting for a response from the outstation
-	ControlRelayOutputBlock bo(ControlCode::PULSE);
+	ControlRelayOutputBlock bo(ControlCode::PULSE_ON);
 	MockCommandCallback callback;
 	t.master.GetCommandProcessor().SelectAndOperate(bo, 1, callback);
 	REQUIRE(t.exe.RunMany() > 0);

--- a/dotnet/bindings/CLRInterface/gen/CommandStatus.cs
+++ b/dotnet/bindings/CLRInterface/gen/CommandStatus.cs
@@ -67,7 +67,47 @@ namespace Automatak.DNP3.Interface
     /// </summary>
     NOT_AUTHORIZED = 9,
     /// <summary>
-    /// 10 to 126 are currently reserved
+    /// command not accepted because it was prevented or inhibited by a local automation process, such as interlocking logic or synchrocheck
+    /// </summary>
+    AUTOMATION_INHIBIT = 10,
+    /// <summary>
+    /// command not accepted because the device cannot process any more activities than are presently in progress
+    /// </summary>
+    PROCESSING_LIMITED = 11,
+    /// <summary>
+    /// command not accepted because the value is outside the acceptable range permitted for this point
+    /// </summary>
+    OUT_OF_RANGE = 12,
+    /// <summary>
+    /// command not accepted because the outstation is forwarding the request to another downstream device which reported LOCAL
+    /// </summary>
+    DOWNSTREAM_LOCAL = 13,
+    /// <summary>
+    /// command not accepted because the outstation has already completed the requested operation
+    /// </summary>
+    ALREADY_COMPLETE = 14,
+    /// <summary>
+    /// command not accepted because the requested function is specifically blocked at the outstation
+    /// </summary>
+    BLOCKED = 15,
+    /// <summary>
+    /// command not accepted because the operation was cancelled
+    /// </summary>
+    CANCELLED = 16,
+    /// <summary>
+    /// command not accepted because another master is communicating with the outstation and has exclusive rights to operate this control point
+    /// </summary>
+    BLOCKED_OTHER_MASTER = 17,
+    /// <summary>
+    /// command not accepted because the outstation is forwarding the request to another downstream device which cannot be reached or is otherwise incapable of performing the request
+    /// </summary>
+    DOWNSTREAM_FAIL = 18,
+    /// <summary>
+    /// (deprecated) indicates the outstation shall not issue or perform the control operation
+    /// </summary>
+    NON_PARTICIPATING = 126,
+    /// <summary>
+    /// command not accepted because of some other undefined reason
     /// </summary>
     UNDEFINED = 127
   }

--- a/dotnet/bindings/CLRInterface/gen/ControlCode.cs
+++ b/dotnet/bindings/CLRInterface/gen/ControlCode.cs
@@ -23,7 +23,7 @@ namespace Automatak.DNP3.Interface
   /// <summary>
   /// There are a number of types of controls. The best way to understand this 
   /// difference is to think about the hardware controls the communication protocols are 
-  /// emulating. The most common to use are PULSE, LATCH_ON and LATCH_OFF
+  /// emulating. The most common to use are PULSE_ON, LATCH_ON and LATCH_OFF
   /// 
   /// NOTE: Current implementation doesn't support queue/clear.
   /// 
@@ -39,7 +39,11 @@ namespace Automatak.DNP3.Interface
     /// <summary>
     /// a 'push-button' interface, can only be pressed one way (reset button on pedometer)
     /// </summary>
-    PULSE = 0x1,
+    PULSE_ON = 0x1,
+    /// <summary>
+    /// a 'push-button' interface with output remaining active following pulse
+    /// </summary>
+    PULSE_OFF = 0x2,
     /// <summary>
     /// a 'light-switch' moved to the ON position
     /// </summary>

--- a/dotnet/examples/master/Program.cs
+++ b/dotnet/examples/master/Program.cs
@@ -72,7 +72,7 @@ namespace DotNetMasterDemo
                         master.ScanAllObjects(30, 0);
                         break;
                     case "c":
-                        var crob = new ControlRelayOutputBlock(ControlCode.PULSE, 1, 100, 100);
+                        var crob = new ControlRelayOutputBlock(ControlCode.PULSE_ON, 1, 100, 100);
                         var future = master.GetCommandProcessor().SelectAndOperate(crob, 0);
                         future.Listen((result) => Console.WriteLine("Result: " + result));
                         break;

--- a/generation/dnp3/src/main/scala/com/automatak/render/dnp3/enums/CommandStatus.scala
+++ b/generation/dnp3/src/main/scala/com/automatak/render/dnp3/enums/CommandStatus.scala
@@ -23,7 +23,17 @@ object CommandStatus {
     EnumValue("LOCAL", 7, "the function governed by the control is in local only control"),
     EnumValue("TOO_MANY_OPS", 8, "the command has been done too often and has been throttled"),
     EnumValue("NOT_AUTHORIZED", 9, "the command was rejected because the device denied it or an RTU intercepted it"),
-    EnumValue("UNDEFINED", 127, "10 to 126 are currently reserved")
+    EnumValue("AUTOMATION_INHIBIT", 10, "command not accepted because it was prevented or inhibited by a local automation process, such as interlocking logic or synchrocheck"),
+    EnumValue("PROCESSING_LIMITED", 11, "command not accepted because the device cannot process any more activities than are presently in progress"),
+    EnumValue("OUT_OF_RANGE", 12, "command not accepted because the value is outside the acceptable range permitted for this point"),
+    EnumValue("DOWNSTREAM_LOCAL", 13, "command not accepted because the outstation is forwarding the request to another downstream device which reported LOCAL"),
+    EnumValue("ALREADY_COMPLETE", 14, "command not accepted because the outstation has already completed the requested operation"),
+    EnumValue("BLOCKED", 15, "command not accepted because the requested function is specifically blocked at the outstation"),
+    EnumValue("CANCELLED", 16, "command not accepted because the operation was cancelled"),
+    EnumValue("BLOCKED_OTHER_MASTER", 17, "command not accepted because another master is communicating with the outstation and has exclusive rights to operate this control point"),
+    EnumValue("DOWNSTREAM_FAIL", 18, "command not accepted because the outstation is forwarding the request to another downstream device which cannot be reached or is otherwise incapable of performing the request"),
+    EnumValue("NON_PARTICIPATING", 126, "(deprecated) indicates the outstation shall not issue or perform the control operation"),
+    EnumValue("UNDEFINED", 127, "command not accepted because of some other undefined reason")
   )
 
 

--- a/generation/dnp3/src/main/scala/com/automatak/render/dnp3/enums/ControlCode.scala
+++ b/generation/dnp3/src/main/scala/com/automatak/render/dnp3/enums/ControlCode.scala
@@ -8,7 +8,7 @@ object ControlCode {
   private val comments = List(
     "There are a number of types of controls. The best way to understand this ",
     "difference is to think about the hardware controls the communication protocols are ",
-    "emulating. The most common to use are PULSE, LATCH_ON and LATCH_OFF",
+    "emulating. The most common to use are PULSE_ON, LATCH_ON and LATCH_OFF",
     "",
     "NOTE: Current implementation doesn't support queue/clear.",
     "",
@@ -20,7 +20,8 @@ object ControlCode {
 
   private val codes = List(
     EnumValue("NUL", 0x00, "illegal command code (used internally)"),
-    EnumValue("PULSE", 0x01, "a 'push-button' interface, can only be pressed one way (reset button on pedometer)"),
+    EnumValue("PULSE_ON", 0x01, "a 'push-button' interface, can only be pressed one way (reset button on pedometer)"),
+    EnumValue("PULSE_OFF", 0x02, "a 'push-button' interface with output remaining active following pulse"),
     EnumValue("LATCH_ON", 0x03, "a 'light-switch' moved to the ON position"),
     EnumValue("LATCH_OFF", 0x04, "a 'light-switch' moved to the OFF position"),
     EnumValue("PULSE_CLOSE", 0x41, " a 'doorbell' that rings while the button is depressed"),


### PR DESCRIPTION
Resolves #115 - Adds NUL PULSE_OFF only. There are still several other non-interoperable combinations, however I didn't see the need to add them.

resolves #116 - Also includes the deprecated NON_PARTICIPATING status.
