### PR TITLE
System Clock Change Bug

### DIFF
--- a/cpp/libs/asiopal/asiopal.vcxproj
+++ b/cpp/libs/asiopal/asiopal.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\asiopal\ASIOExecutor.h" />
+    <ClInclude Include="src\asiopal\ASIOSteadyClock.h" />
     <ClInclude Include="src\asiopal\StrandGetters.h" />
     <ClInclude Include="src\asiopal\ASIOSerialHelpers.h" />
     <ClInclude Include="src\asiopal\IOServiceThreadPool.h" />

--- a/cpp/libs/asiopal/asiopal.vcxproj.filters
+++ b/cpp/libs/asiopal/asiopal.vcxproj.filters
@@ -56,6 +56,9 @@
     <ClInclude Include="src\asiopal\Synchronized.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\asiopal\ASIOSteadyClock.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\asiopal\ASIOExecutor.cpp">

--- a/cpp/libs/asiopal/src/asiopal/ASIOExecutor.cpp
+++ b/cpp/libs/asiopal/src/asiopal/ASIOExecutor.cpp
@@ -25,6 +25,8 @@
 #include <asio.hpp>
 #include <functional>
 
+#include "ASIOSteadyClock.h"
+
 using namespace std;
 
 namespace asiopal
@@ -78,22 +80,22 @@ void ASIOExecutor::CheckForShutdown()
 
 openpal::MonotonicTimestamp ASIOExecutor::GetTime()
 {
-	return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+	return std::chrono::duration_cast<std::chrono::milliseconds>(asiopal::ASIOSteadyClock::now().time_since_epoch()).count();
 }
 
 openpal::ITimer* ASIOExecutor::Start(const openpal::TimeDuration& delay, const openpal::Action0& runnable)
 {	
-	auto expiration = std::chrono::steady_clock::now() + std::chrono::milliseconds(delay.GetMilliseconds());
+	auto expiration = asiopal::ASIOSteadyClock::now() + std::chrono::milliseconds(delay.GetMilliseconds());
 	return Start(expiration, runnable);
 }
 
 openpal::ITimer* ASIOExecutor::Start(const openpal::MonotonicTimestamp& time, const openpal::Action0& runnable)
 {	
-	std::chrono::steady_clock::time_point expiration(std::chrono::milliseconds(time.milliseconds));
+	asiopal::ASIOSteadyClock::time_point expiration(std::chrono::milliseconds(time.milliseconds));
 	return Start(expiration, runnable);
 }
 
-openpal::ITimer* ASIOExecutor::Start(const std::chrono::steady_clock::time_point& tp, const openpal::Action0& runnable)
+openpal::ITimer* ASIOExecutor::Start(const asiopal::ASIOSteadyClock::time_point& tp, const openpal::Action0& runnable)
 {
 	TimerASIO* pTimer = GetTimer();	
 	pTimer->timer.expires_at(tp);

--- a/cpp/libs/asiopal/src/asiopal/ASIOExecutor.h
+++ b/cpp/libs/asiopal/src/asiopal/ASIOExecutor.h
@@ -29,6 +29,8 @@
 #include <queue>
 #include <set>
 
+#include <asiopal/ASIOSteadyClock.h>
+
 namespace asiopal
 {
 
@@ -55,7 +57,7 @@ public:
 
 private:
 
-	openpal::ITimer* Start(const std::chrono::steady_clock::time_point& tp, const openpal::Action0& runnable);
+	openpal::ITimer* Start(const asiopal::ASIOSteadyClock::time_point& tp, const openpal::Action0& runnable);
 
 	void InitiateShutdown(Synchronized<bool>& handler);
 

--- a/cpp/libs/asiopal/src/asiopal/ASIOSteadyClock.h
+++ b/cpp/libs/asiopal/src/asiopal/ASIOSteadyClock.h
@@ -1,0 +1,51 @@
+
+#ifndef ASIOPAL_ASIOSTEADYCLOCK_H
+#define ASIOPAL_ASIOSTEADYCLOCK_H
+
+#include<chrono>
+#include<Windows.h>
+
+namespace asiopal {
+	/*
+	Custom steady clock implementation to handle the situation where the Windows steady clock
+	implementation is not monotonic. Normal steady clock implementation is used on other platforms.
+	*/
+	struct ASIOSteadyClock
+	{
+		// Type defininitions for this clock - ticks are in nanoseconds for this clock
+		typedef LONGLONG representation;
+		typedef std::ratio_multiply<std::ratio<1, 1>, std::nano> period;
+		typedef std::chrono::duration<representation, period> duration;
+		typedef std::chrono::time_point<ASIOSteadyClock, duration> time_point;
+
+
+		static time_point now() {
+#if WIN32
+			// Special case for WIN32 because std::chrono::steady_clock is broken
+			LARGE_INTEGER freq;
+			LONGLONG nanoSecondsPerTick = 0;
+			if (QueryPerformanceFrequency(&freq)) {
+				nanoSecondsPerTick = LONGLONG(1000000000.0L / freq.QuadPart);
+			}
+
+			LARGE_INTEGER performanceCount;
+			if (nanoSecondsPerTick <= 0 || !QueryPerformanceCounter(&performanceCount)) {
+				// Error condition, return 0 time
+				return time_point();
+			}
+
+			// Return time in nanoseconds
+			LONGLONG timeNanos = performanceCount.QuadPart * nanoSecondsPerTick;
+			return time_point(duration(timeNanos));
+#else
+			// Get normal steady clock time in nanoseconds and convert to a time point for this clock
+			std::chrono::steady_clock::duration steadyClockTime = std::chrono::steady_clock::now().time_since_epoch();
+			std::chrono::duration<LONGLONG, std::nano> durationNanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(steadyClockTime);
+			LONGLONG nanoseconds = durationNanoseconds.count();
+			return time_point(duration(nanoseconds));
+#endif
+		}
+	};
+}
+
+#endif

--- a/cpp/libs/asiopal/src/asiopal/IOServiceThreadPool.cpp
+++ b/cpp/libs/asiopal/src/asiopal/IOServiceThreadPool.cpp
@@ -26,6 +26,8 @@
 #include <chrono>
 #include <sstream>
 
+#include <asiopal/ASIOSteadyClock.h>
+
 using namespace std;
 using namespace std::chrono;
 using namespace openpal;
@@ -56,7 +58,7 @@ IOServiceThreadPool::IOServiceThreadPool(
 		aConcurrency = 1;
 		SIMPLE_LOG_BLOCK(logger, logflags::WARN, "Concurrency was set to 0, defaulting to 1 thread");
 	}
-	infiniteTimer.expires_at(std::chrono::steady_clock::time_point::max());
+	infiniteTimer.expires_at(asiopal::ASIOSteadyClock::time_point::max());
 	infiniteTimer.async_wait([](const std::error_code&){});
 	for(uint32_t i = 0; i < aConcurrency; ++i)
 	{

--- a/cpp/libs/asiopal/src/asiopal/IOServiceThreadPool.h
+++ b/cpp/libs/asiopal/src/asiopal/IOServiceThreadPool.h
@@ -28,6 +28,8 @@
 #include <functional>
 #include <thread>
 
+#include <asiopal/ASIOSteadyClock.h>
+
 namespace asiopal
 {
 
@@ -62,7 +64,7 @@ private:
 	void Run();
 
 	asio::io_service ioservice;
-	asio::basic_waitable_timer< std::chrono::steady_clock > infiniteTimer;
+	asio::basic_waitable_timer< asiopal::ASIOSteadyClock > infiniteTimer;
 	std::vector<std::thread*> threads;
 };
 

--- a/cpp/libs/asiopal/src/asiopal/TimerASIO.h
+++ b/cpp/libs/asiopal/src/asiopal/TimerASIO.h
@@ -27,6 +27,8 @@
 
 #include <openpal/executor/IExecutor.h>
 
+#include <asiopal/ASIOSteadyClock.h>
+
 namespace asiopal
 {
 
@@ -63,7 +65,7 @@ private:
 
 	bool canceled;
 
-	asio::basic_waitable_timer< std::chrono::steady_clock > timer;
+	asio::basic_waitable_timer< asiopal::ASIOSteadyClock > timer;
 };
 
 }

--- a/cpp/tests/opendnp3tests/src/StopWatch.cpp
+++ b/cpp/tests/opendnp3tests/src/StopWatch.cpp
@@ -25,19 +25,19 @@ using namespace std::chrono;
 namespace opendnp3
 {
 
-StopWatch::StopWatch() : mStartTime(std::chrono::steady_clock::now())
+StopWatch::StopWatch() : mStartTime(asiopal::ASIOSteadyClock::now())
 {
 
 }
 
-std::chrono::steady_clock::duration StopWatch::Elapsed(bool aReset)
+asiopal::ASIOSteadyClock::duration StopWatch::Elapsed(bool aReset)
 {
-	return std::chrono::steady_clock::now() - mStartTime;
+	return asiopal::ASIOSteadyClock::now() - mStartTime;
 }
 
 void StopWatch :: Restart()
 {
-	mStartTime = std::chrono::steady_clock::now();
+	mStartTime = asiopal::ASIOSteadyClock::now();
 }
 
 }

--- a/cpp/tests/opendnp3tests/src/StopWatch.h
+++ b/cpp/tests/opendnp3tests/src/StopWatch.h
@@ -22,6 +22,7 @@
 #define _STOP_WATCH_H__
 
 #include <chrono>
+#include <asiopal/ASIOSteadyClock.h>
 
 namespace opendnp3
 {
@@ -37,13 +38,13 @@ public:
 
 	//get the elapsed time since creation or the last restart
 	//by default each call to Elapsed restarts the timer.
-	std::chrono::steady_clock::duration Elapsed(bool aReset = true);
+	asiopal::ASIOSteadyClock::duration Elapsed(bool aReset = true);
 
 	//restart or re-zero the StopWatch.
 	void Restart();
 
 private:
-	std::chrono::steady_clock::time_point mStartTime;
+	asiopal::ASIOSteadyClock::time_point mStartTime;
 };
 
 

--- a/cpp/tests/opendnp3tests/src/Timeout.cpp
+++ b/cpp/tests/opendnp3tests/src/Timeout.cpp
@@ -25,20 +25,20 @@ using namespace std::chrono;
 namespace opendnp3
 {
 
-Timeout::Timeout(std::chrono::steady_clock::duration aTimeout)
-	: mExpireTime(std::chrono::steady_clock::now() + aTimeout)
+	Timeout::Timeout(asiopal::ASIOSteadyClock::duration aTimeout)
+		: mExpireTime(asiopal::ASIOSteadyClock::now() + aTimeout)
 {
 
 }
 
 bool Timeout :: IsExpired()
 {
-	return std::chrono::steady_clock::now() >= mExpireTime;
+	return asiopal::ASIOSteadyClock::now() >= mExpireTime;
 }
 
-std::chrono::steady_clock::duration Timeout::Remaining()
+asiopal::ASIOSteadyClock::duration Timeout::Remaining()
 {
-	return mExpireTime - std::chrono::steady_clock::now();
+	return mExpireTime - asiopal::ASIOSteadyClock::now();
 }
 
 }

--- a/cpp/tests/opendnp3tests/src/Timeout.h
+++ b/cpp/tests/opendnp3tests/src/Timeout.h
@@ -22,6 +22,7 @@
 #define _TIMEOUT_H__
 
 #include <chrono>
+#include <asiopal/ASIOSteadyClock.h>
 
 namespace opendnp3
 {
@@ -48,18 +49,18 @@ class Timeout
 {
 public:
 	// constuctor, timeout will expire this many mills in the future
-	Timeout(std::chrono::steady_clock::duration aTimeout);
+	Timeout(asiopal::ASIOSteadyClock::duration aTimeout);
 
 	// returns whether its expired
 	bool IsExpired();
 
 	// returns how much time is left
-	std::chrono::steady_clock::duration Remaining();
+	asiopal::ASIOSteadyClock::duration Remaining();
 
 
 private:
 
-	std::chrono::steady_clock::time_point mExpireTime;
+	asiopal::ASIOSteadyClock::time_point mExpireTime;
 
 };
 


### PR DESCRIPTION
This pull request fixes the issue on Windows where std::steady_clock changes with the system time. I have implemented a new ASIOSteadyClock and replaced instances of std::steady_clock with this clock instead. On Windows, this clock makes use of QueryPerformanceCounter and on all other platforms just passes through to std::steady_clock with a bit of preprocessor.
