### PR TITLE
Link layer keepalives

### DIFF
--- a/cpp/libs/asiodnp3/src/asiodnp3/IStack.h
+++ b/cpp/libs/asiodnp3/src/asiodnp3/IStack.h
@@ -28,6 +28,7 @@
 #include <opendnp3/StackStatistics.h>
 #include <opendnp3/link/ILinkStatusListener.h>
 
+#include <assert.h>
 #include <vector>
 #include <functional>
 
@@ -41,6 +42,8 @@ namespace asiodnp3
 class IStack : public DestructorHook , public opendnp3::ILinkStatusListener
 {
 public:	
+
+	IStack() : current_status(opendnp3::LinkStatus::TIMEOUT) {}
 
 	virtual ~IStack() {}	
 
@@ -64,20 +67,22 @@ public:
 	*/
 	void AddLinkStatusListener(const std::function<void(opendnp3::LinkStatus)>& listener)
 	{
+		listener(current_status);
 		callbacks.push_back(listener);
 	};
 
-	virtual void OnStateChange(opendnp3::LinkStatus state)
+	virtual void OnStateChange(opendnp3::LinkStatus status)
 	{
+		current_status = status;
 		for (auto& cb : callbacks)
 		{
-			cb(state);
+			cb(status);
 		}
 	}
 
 private:
 	std::vector<std::function<void(opendnp3::LinkStatus)>> callbacks;
-
+	opendnp3::LinkStatus current_status;
 };
 
 }

--- a/cpp/libs/opendnp3/src/opendnp3/LayerInterfaces.h
+++ b/cpp/libs/opendnp3/src/opendnp3/LayerInterfaces.h
@@ -67,6 +67,10 @@ public:
 	// Layers can only have 1 outstanding send operation. The callback is guaranteed
 	// unless the the OnLowerLayerDown() function is called beforehand
 	virtual void OnSendResult(bool isSucccess) = 0;
+	// Called by lower layer to notify of a send operation originating from a lower layer
+	// Layers can only have 1 outstanding send operation. So higher layers need to know not to
+	// request another send - return false if a request is already started, so the lower layer can abort
+	virtual bool OnLowerSend() = 0;
 
 };
 

--- a/cpp/libs/opendnp3/src/opendnp3/gen/LinkStatus.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/gen/LinkStatus.cpp
@@ -30,8 +30,10 @@ char const* LinkStatusToString(LinkStatus arg)
       return "UNRESET";
     case(LinkStatus::RESET):
       return "RESET";
+	case(LinkStatus::TIMEOUT) :
+		return "TIMEOUT";
   }
-  return "RESET";
+  return "TIMEOUT";
 }
 
 }

--- a/cpp/libs/opendnp3/src/opendnp3/gen/LinkStatus.h
+++ b/cpp/libs/opendnp3/src/opendnp3/gen/LinkStatus.h
@@ -30,10 +30,12 @@ namespace opendnp3 {
 */
 enum class LinkStatus : int
 {
-  /// DOWN
+  /// Transition to UnReset
   UNRESET = 0,
-  /// UP
-  RESET = 1
+  /// Transition to Reset
+  RESET = 1,
+  /// Timeout transition
+  TIMEOUT = 2
 };
 
 char const* LinkStatusToString(LinkStatus arg);

--- a/cpp/libs/opendnp3/src/opendnp3/link/LinkConfig.h
+++ b/cpp/libs/opendnp3/src/opendnp3/link/LinkConfig.h
@@ -37,14 +37,16 @@ struct LinkConfig
 	    uint32_t aNumRetry,
 	    uint16_t aLocalAddr,
 	    uint16_t aRemoteAddr,
-	    openpal::TimeDuration aTimeout) :
+	    openpal::TimeDuration aTimeout,
+        openpal::TimeDuration aKeepAlive) :
 
 		IsMaster(aIsMaster),
 		UseConfirms(aUseConfirms),
 		NumRetry(aNumRetry),
 		LocalAddr(aLocalAddr),
 		RemoteAddr(aRemoteAddr),
-		Timeout(aTimeout)
+		Timeout(aTimeout),
+        KeepAlive(aKeepAlive)
 	{}
 
 	LinkConfig(
@@ -56,7 +58,8 @@ struct LinkConfig
 		NumRetry(0),
 		LocalAddr(aIsMaster ? 1 : 1024),
 		RemoteAddr(aIsMaster ? 1024 : 1),
-		Timeout(openpal::TimeDuration::Seconds(1))
+		Timeout(openpal::TimeDuration::Seconds(1)),
+        KeepAlive(openpal::TimeDuration::Seconds(60))
 	{}
 
 	/// The master/outstation bit set on all messages
@@ -77,6 +80,9 @@ struct LinkConfig
 	/// the response timeout in milliseconds for confirmed requests
 	openpal::TimeDuration Timeout;
 
+    /// the idle time in milliseconds to transmit request link status keep alive
+    openpal::TimeDuration KeepAlive;
+    
 private:
 
 	LinkConfig() {}

--- a/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.cpp
@@ -437,6 +437,7 @@ void LinkLayer::TestLinkStatus(bool aIsMaster, bool aFcb, uint16_t aDest, uint16
 	if (this->Validate(aIsMaster, aSrc, aDest))
 	{
 		pSecState->TestLinkStatus(this, aFcb);
+		pPriState->OtherFunction(this);
 	}
 }
 
@@ -445,6 +446,7 @@ void LinkLayer::ResetLinkStates(bool aIsMaster, uint16_t aDest, uint16_t aSrc)
 	if (this->Validate(aIsMaster, aSrc, aDest))
 	{
 		pSecState->ResetLinkStates(this);
+		pPriState->OtherFunction(this);
 	}
 }
 
@@ -453,6 +455,7 @@ void LinkLayer::RequestLinkStatus(bool aIsMaster, uint16_t aDest, uint16_t aSrc)
 	if (this->Validate(aIsMaster, aSrc, aDest))
 	{
 		pSecState->RequestLinkStatus(this);
+		pPriState->OtherFunction(this);
 	}
 }
 
@@ -461,6 +464,7 @@ void LinkLayer::ConfirmedUserData(bool aIsMaster, bool aFcb, uint16_t aDest, uin
 	if (this->Validate(aIsMaster, aSrc, aDest))
 	{
 		pSecState->ConfirmedUserData(this, aFcb, input);
+		pPriState->OtherFunction(this);
 	}
 }
 
@@ -468,6 +472,7 @@ void LinkLayer::UnconfirmedUserData(bool aIsMaster, uint16_t aDest, uint16_t aSr
 {
 	if (this->Validate(aIsMaster, aSrc, aDest))
 	{
+		pPriState->OtherFunction(this);
 		this->DoDataUp(input);
 	}
 }

--- a/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.cpp
@@ -342,11 +342,13 @@ void LinkLayer::ResetKeepAlive()
         pKeepAliveTimer = nullptr;
 		if (pPriState == PLLS_SecNotReset::Inst())
 		{
+			this->ResetRetry();
 			this->QueueRequestLinkStatus();
 			this->ChangeState(PLLS_RequestLinkStatusTransmitWait<PLLS_SecNotReset>::Inst());
 		}
 		else if (pPriState == PLLS_SecReset::Inst())
 		{
+			this->ResetRetry();
 			this->QueueRequestLinkStatus();
 			this->ChangeState(PLLS_RequestLinkStatusTransmitWait<PLLS_SecReset>::Inst());
 		}

--- a/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.cpp
@@ -339,6 +339,7 @@ void LinkLayer::ResetKeepAlive()
     this->CancelKeepAlive();
     if(!config.KeepAlive) return;
     auto lambda = [this]() {
+        pKeepAliveTimer = nullptr;
 		if (pPriState == PLLS_SecNotReset::Inst())
 		{
 			this->QueueRequestLinkStatus();

--- a/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.cpp
@@ -339,16 +339,26 @@ void LinkLayer::ResetKeepAlive()
     this->CancelKeepAlive();
     if(!config.KeepAlive) return;
     auto lambda = [this]() {
-        if(pTimer) return; // already waiting for a response
-        this->QueueRequestLinkStatus();
-        this->ChangeState(PLLS_RequestLinkStatusTransmitWait::Inst());
+		if (pPriState == PLLS_SecNotReset::Inst())
+		{
+			this->QueueRequestLinkStatus();
+			this->ChangeState(PLLS_RequestLinkStatusTransmitWait<PLLS_SecNotReset>::Inst());
+		}
+		else if (pPriState == PLLS_SecReset::Inst())
+		{
+			this->QueueRequestLinkStatus();
+			this->ChangeState(PLLS_RequestLinkStatusTransmitWait<PLLS_SecReset>::Inst());
+		}
     };
     pKeepAliveTimer = this->pExecutor->Start(TimeDuration(config.KeepAlive), Action0::Bind(lambda));
 }
     
 void LinkLayer::CancelKeepAlive()
 {
-	if(pKeepAliveTimer == nullptr) return;
+	if (pKeepAliveTimer == nullptr)
+	{
+		return;
+	}
     pKeepAliveTimer->Cancel();
 	pKeepAliveTimer = nullptr;
 }

--- a/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.cpp
@@ -46,6 +46,7 @@ LinkLayer::LinkLayer(openpal::LogRoot& root, openpal::IExecutor* pExecutor_, con
 	numRetryRemaining(0),
 	pExecutor(pExecutor_),
 	pTimer(nullptr),
+    pKeepAliveTimer(nullptr),
 	nextReadFCB(false),
 	nextWriteFCB(false),
 	isOnline(false),
@@ -154,6 +155,7 @@ void LinkLayer::OnLowerLayerUp()
 	else
 	{
 		isOnline = true;
+        this->ResetKeepAlive();
 
 		if (pUpperLayer)
 		{

--- a/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.h
+++ b/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.h
@@ -103,6 +103,15 @@ public:
 		}
 	}
 
+	bool DoLowerSend()
+	{
+		if (pUpperLayer)
+		{
+			return pUpperLayer->OnLowerSend();
+		}
+		return true;
+	}
+
 	void PostSendResult(bool isSuccess);
 
 	void ResetReadFCB()
@@ -137,7 +146,7 @@ public:
 
 	// Helpers for sending frames
 	void QueueAck();
-    void QueueRequestLinkStatus();
+	void QueueRequestLinkStatus();
 	void QueueLinkStatus();
 	void QueueResetLinks();
 
@@ -156,8 +165,8 @@ public:
 		return numRetryRemaining;
 	}
     
-    void ResetKeepAlive();
-    void CancelKeepAlive();
+	void ResetKeepAlive();
+	void CancelKeepAlive();
     
 	void QueueTransmit(const openpal::ReadBufferView& buffer, bool primary);
 

--- a/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.h
+++ b/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.h
@@ -192,6 +192,7 @@ private:
 	bool nextReadFCB;
 	bool nextWriteFCB;
 	bool isOnline;
+	bool TimedOut;
 
 	bool Validate(bool isMaster, uint16_t src, uint16_t dest);	
 

--- a/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.h
+++ b/cpp/libs/opendnp3/src/opendnp3/link/LinkLayer.h
@@ -68,7 +68,7 @@ public:
 	virtual void RequestLinkStatus(bool aIsMaster, uint16_t aDest, uint16_t aSrc) override final;
 	virtual void ConfirmedUserData(bool aIsMaster, bool aFcb, uint16_t aDest, uint16_t aSrc, const openpal::ReadBufferView& arBuffer) override final;
 	virtual void UnconfirmedUserData(bool aIsMaster, uint16_t aDest, uint16_t aSrc, const openpal::ReadBufferView& arBuffer) override final;
-
+    
 	// ------------- ILinkLayer --------------------
 	virtual void Send(ITransportSegment& segments) override final;
 
@@ -131,6 +131,7 @@ public:
 
 	// Helpers for sending frames
 	void QueueAck();
+    void QueueRequestLinkStatus();
 	void QueueLinkStatus();
 	void QueueResetLinks();
 
@@ -148,8 +149,11 @@ public:
 	{
 		return numRetryRemaining;
 	}
-
-	void QueueTransmit(const openpal::ReadBufferView& buffer, bool primary);	
+    
+    void ResetKeepAlive();
+    void CancelKeepAlive();
+    
+	void QueueTransmit(const openpal::ReadBufferView& buffer, bool primary);
 
 	// buffers used for primary and secondary requests	
 	uint8_t priTxBuffer[LPDU_MAX_FRAME_SIZE];
@@ -174,6 +178,7 @@ private:
 
 	openpal::IExecutor* pExecutor;
 	openpal::ITimer* pTimer;
+    openpal::ITimer* pKeepAliveTimer;
 
 	// callback from the active timer
 	void OnTimeout();

--- a/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.cpp
@@ -56,6 +56,11 @@ void PriStateBase::NotSupported (LinkLayer* pLinkLayer, bool receiveBuffFull)
 	SIMPLE_LOG_BLOCK_WITH_CODE(pLinkLayer->GetLogger(), flags::WARN, DLERR_UNEXPECTED_LPDU, "Frame context not understood");
 }
 
+void PriStateBase::OtherFunction (LinkLayer* pLinkLayer)
+{
+	SIMPLE_LOG_BLOCK_WITH_CODE(pLinkLayer->GetLogger(), flags::WARN, DLERR_UNEXPECTED_LPDU, "Frame context not understood");
+}
+
 void PriStateBase::OnTransmitResult(LinkLayer* pLinkLayer, bool success)
 {
 	FORMAT_LOG_BLOCK(pLinkLayer->GetLogger(), flags::ERR, "Invalid action for state: %s", this->Name());	

--- a/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.cpp
@@ -256,7 +256,6 @@ void PLLS_LinkStatusWait::Failure(LinkLayer* pLinkLayer)
 {
 	pLinkLayer->CancelTimer();
 	pLinkLayer->ChangeState(PLLS_SecNotReset::Inst());
-	pLinkLayer->DoSendResult(false);
 }
 
 ////////////////////////////////////////////////////////

--- a/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.cpp
@@ -135,6 +135,7 @@ void PLLS_LinkStatusWait<PLLS_SecNotReset>::OnTimeout(LinkLayer* pLinkLayer)
 	}
 	else
 	{
+		pLinkLayer->CallStatusCallback(opendnp3::LinkStatus::TIMEOUT);
 		SIMPLE_LOG_BLOCK(pLinkLayer->GetLogger(), flags::WARN, "Request link status final timeout, no retries remain");
 		pLinkLayer->ChangeState(PLLS_SecNotReset::Inst());
 	}
@@ -151,7 +152,7 @@ void PLLS_LinkStatusWait<PLLS_SecReset>::OnTimeout(LinkLayer* pLinkLayer)
 	}
 	else
 	{
-		pLinkLayer->CallStatusCallback(opendnp3::LinkStatus::UNRESET);
+		pLinkLayer->CallStatusCallback(opendnp3::LinkStatus::TIMEOUT);
 		SIMPLE_LOG_BLOCK(pLinkLayer->GetLogger(), flags::WARN, "Request link status final timeout, no retries remain");
 		pLinkLayer->ChangeState(PLLS_SecNotReset::Inst());
 	}
@@ -229,6 +230,7 @@ void PLLS_ResetLinkWait::OnTimeout(LinkLayer* pLinkLayer)
 	}
 	else
 	{
+		pLinkLayer->CallStatusCallback(opendnp3::LinkStatus::TIMEOUT);
 		SIMPLE_LOG_BLOCK(pLinkLayer->GetLogger(), flags::WARN, "Link reset final timeout, no retries remain");
 		pLinkLayer->ChangeState(PLLS_SecNotReset::Inst());
 		pLinkLayer->DoSendResult(false);
@@ -268,6 +270,7 @@ void PLLS_ConfDataWait::Ack(LinkLayer* pLinkLayer, bool receiveBuffFull)
 
 void PLLS_ConfDataWait::Nack(LinkLayer* pLinkLayer, bool receiveBuffFull)
 {
+	pLinkLayer->CallStatusCallback(opendnp3::LinkStatus::UNRESET);
 	if (receiveBuffFull)
 	{
 		Failure(pLinkLayer);
@@ -279,7 +282,6 @@ void PLLS_ConfDataWait::Nack(LinkLayer* pLinkLayer, bool receiveBuffFull)
 		pLinkLayer->ChangeState(PLLS_LinkResetTransmitWait::Inst());
 		pLinkLayer->QueueResetLinks();
 	}
-	pLinkLayer->CallStatusCallback(opendnp3::LinkStatus::UNRESET);
 }
 
 void PLLS_ConfDataWait::Failure(LinkLayer* pLinkLayer)
@@ -300,10 +302,10 @@ void PLLS_ConfDataWait::OnTimeout(LinkLayer* pLinkLayer)
 	}
 	else
 	{
+		pLinkLayer->CallStatusCallback(opendnp3::LinkStatus::TIMEOUT);
 		SIMPLE_LOG_BLOCK(pLinkLayer->GetLogger(), flags::WARN, "Confirmed data final timeout, no retries remain");
 		pLinkLayer->ChangeState(PLLS_SecNotReset::Inst());
 		pLinkLayer->DoSendResult(false);
-		pLinkLayer->CallStatusCallback(opendnp3::LinkStatus::UNRESET);
 	}
 }
 

--- a/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.cpp
@@ -25,7 +25,6 @@
 
 #include "opendnp3/ErrorCodes.h"
 #include "opendnp3/link/LinkLayer.h"
-#include "opendnp3/LogLevels.h"
 
 using namespace openpal;
 
@@ -120,44 +119,6 @@ void PLLS_LinkResetTransmitWait::OnTransmitResult(LinkLayer* pLinkLayer, bool su
 	{
 		pLinkLayer->ChangeState(PLLS_SecNotReset::Inst());
 		pLinkLayer->DoSendResult(success);
-	}
-}
-
-/////////////////////////////////////////////////////////////////////////////
-//  Wait for the link layer to transmit the request link status
-/////////////////////////////////////////////////////////////////////////////
-
-template <>
-void PLLS_LinkStatusWait<PLLS_SecNotReset>::OnTimeout(LinkLayer* pLinkLayer)
-{
-	if (pLinkLayer->Retry())
-	{
-		FORMAT_LOG_BLOCK(pLinkLayer->GetLogger(), flags::WARN, "Request link status timeout, retrying %i remaining", pLinkLayer->RetryRemaining());
-		pLinkLayer->QueueRequestLinkStatus();
-		pLinkLayer->ChangeState(PLLS_RequestLinkStatusTransmitWait<PLLS_SecNotReset>::Inst());
-	}
-	else
-	{
-		pLinkLayer->CallStatusCallback(opendnp3::LinkStatus::TIMEOUT);
-		SIMPLE_LOG_BLOCK(pLinkLayer->GetLogger(), flags::WARN, "Request link status final timeout, no retries remain");
-		pLinkLayer->ChangeState(PLLS_SecNotReset::Inst());
-	}
-}
-
-template <>
-void PLLS_LinkStatusWait<PLLS_SecReset>::OnTimeout(LinkLayer* pLinkLayer)
-{
-	if (pLinkLayer->Retry())
-	{
-		FORMAT_LOG_BLOCK(pLinkLayer->GetLogger(), flags::WARN, "Request link status timeout, retrying %i remaining", pLinkLayer->RetryRemaining());
-		pLinkLayer->QueueRequestLinkStatus();
-		pLinkLayer->ChangeState(PLLS_RequestLinkStatusTransmitWait<PLLS_SecReset>::Inst());
-	}
-	else
-	{
-		pLinkLayer->CallStatusCallback(opendnp3::LinkStatus::TIMEOUT);
-		SIMPLE_LOG_BLOCK(pLinkLayer->GetLogger(), flags::WARN, "Request link status final timeout, no retries remain");
-		pLinkLayer->ChangeState(PLLS_SecNotReset::Inst());
 	}
 }
 

--- a/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.cpp
@@ -121,6 +121,27 @@ void PLLS_LinkResetTransmitWait::OnTransmitResult(LinkLayer* pLinkLayer, bool su
 }
 
 /////////////////////////////////////////////////////////////////////////////
+//  Wait for the link layer to transmit the request link status
+/////////////////////////////////////////////////////////////////////////////
+
+PLLS_RequestLinkStatusTransmitWait PLLS_RequestLinkStatusTransmitWait::instance;
+
+void PLLS_RequestLinkStatusTransmitWait::OnTransmitResult(LinkLayer* pLinkLayer, bool success)
+{
+	if (success)
+	{
+		// now we're waiting for a link status response
+		pLinkLayer->StartTimer();
+		pLinkLayer->ChangeState(PLLS_LinkStatusWait::Inst());
+	}
+	else
+	{
+		pLinkLayer->ChangeState(PLLS_SecNotReset::Inst());
+		pLinkLayer->DoSendResult(success);
+	}
+}
+
+/////////////////////////////////////////////////////////////////////////////
 //  Wait for the link layer to transmit confirmed user data
 /////////////////////////////////////////////////////////////////////////////
 
@@ -198,6 +219,40 @@ void PLLS_ResetLinkWait::OnTimeout(LinkLayer* pLinkLayer)
 }
 
 void PLLS_ResetLinkWait::Failure(LinkLayer* pLinkLayer)
+{
+	pLinkLayer->CancelTimer();
+	pLinkLayer->ChangeState(PLLS_SecNotReset::Inst());
+	pLinkLayer->DoSendResult(false);
+}
+
+////////////////////////////////////////////////////////
+//	Class PLLS_LinkStatusWait
+////////////////////////////////////////////////////////
+
+PLLS_LinkStatusWait PLLS_LinkStatusWait::instance;
+
+void PLLS_LinkStatusWait::LinkStatus(LinkLayer* pLinkLayer, bool receiveBuffFull)
+{
+	pLinkLayer->CancelTimer();
+    pLinkLayer->ChangeState(PLLS_SecReset::Inst());
+}
+
+void PLLS_LinkStatusWait::OnTimeout(LinkLayer* pLinkLayer)
+{
+	if(pLinkLayer->Retry())
+	{
+		FORMAT_LOG_BLOCK(pLinkLayer->GetLogger(), flags::WARN, "Request link status timeout, retrying %i remaining", pLinkLayer->RetryRemaining());
+		pLinkLayer->QueueRequestLinkStatus();
+		pLinkLayer->ChangeState(PLLS_RequestLinkStatusTransmitWait::Inst());
+	}
+	else
+	{
+		SIMPLE_LOG_BLOCK(pLinkLayer->GetLogger(), flags::WARN, "Request link status final timeout, no retries remain");
+		pLinkLayer->ChangeState(PLLS_SecNotReset::Inst());
+	}
+}
+
+void PLLS_LinkStatusWait::Failure(LinkLayer* pLinkLayer)
 {
 	pLinkLayer->CancelTimer();
 	pLinkLayer->ChangeState(PLLS_SecNotReset::Inst());

--- a/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.cpp
@@ -57,9 +57,7 @@ void PriStateBase::NotSupported (LinkLayer* pLinkLayer, bool receiveBuffFull)
 }
 
 void PriStateBase::OtherFunction (LinkLayer* pLinkLayer)
-{
-	SIMPLE_LOG_BLOCK_WITH_CODE(pLinkLayer->GetLogger(), flags::WARN, DLERR_UNEXPECTED_LPDU, "Frame context not understood");
-}
+{}
 
 void PriStateBase::OnTransmitResult(LinkLayer* pLinkLayer, bool success)
 {

--- a/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.h
+++ b/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.h
@@ -104,6 +104,17 @@ class PLLS_LinkResetTransmitWait : public PriStateBase
 };
 
 /////////////////////////////////////////////////////////////////////////////
+//  Wait for the link layer to transmit the request link status
+/////////////////////////////////////////////////////////////////////////////
+
+class PLLS_RequestLinkStatusTransmitWait : public PriStateBase
+{
+	MACRO_STATE_SINGLETON_INSTANCE(PLLS_RequestLinkStatusTransmitWait);
+
+	virtual void OnTransmitResult(LinkLayer* apLL, bool success);
+};
+    
+/////////////////////////////////////////////////////////////////////////////
 //  Wait for the link layer to transmit confirmed user data
 /////////////////////////////////////////////////////////////////////////////
 
@@ -141,6 +152,31 @@ class PLLS_ResetLinkWait : public PriStateBase
 	{
 		Failure(apLL);
 	}
+	void NotSupported (LinkLayer*  apLL, bool)
+	{
+		Failure(apLL);
+	}
+
+	void OnTimeout(LinkLayer*);
+
+private:
+	void Failure(LinkLayer*);
+};
+
+//	@section desc As soon as we get a link status, return to base state
+class PLLS_LinkStatusWait : public PriStateBase
+{
+	MACRO_STATE_SINGLETON_INSTANCE(PLLS_LinkStatusWait);
+
+	void Ack(LinkLayer* apLL, bool)
+	{
+		Failure(apLL);
+	}
+	void Nack(LinkLayer*  apLL, bool)
+	{
+		Failure(apLL);
+	}
+	void LinkStatus(LinkLayer* apLL, bool);
 	void NotSupported (LinkLayer*  apLL, bool)
 	{
 		Failure(apLL);

--- a/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.h
+++ b/cpp/libs/opendnp3/src/opendnp3/link/PriLinkLayerStates.h
@@ -40,6 +40,7 @@ public:
 	virtual void Nack(LinkLayer*, bool receiveBuffFull);
 	virtual void LinkStatus(LinkLayer*, bool receiveBuffFull);
 	virtual void NotSupported(LinkLayer*, bool receiveBuffFull);
+	virtual void OtherFunction(LinkLayer*);
 
 	virtual void OnTransmitResult(LinkLayer*, bool success);
 
@@ -119,6 +120,10 @@ class PLLS_LinkStatusWait : public PriStateBase
 	}
 	void LinkStatus(LinkLayer* apLL, bool);
 	void NotSupported (LinkLayer*  apLL, bool)
+	{
+		Failure(apLL);
+	}
+	void OtherFunction (LinkLayer*  apLL, bool)
 	{
 		Failure(apLL);
 	}
@@ -219,6 +224,10 @@ class PLLS_ResetLinkWait : public PriStateBase
 	{
 		Failure(apLL);
 	}
+	void OtherFunction (LinkLayer*  apLL, bool)
+	{
+		Failure(apLL);
+	}
 
 	void OnTimeout(LinkLayer*);
 
@@ -240,6 +249,10 @@ class PLLS_ConfDataWait : public PriStateBase
 	void NotSupported (LinkLayer* apLL, bool)
 	{
 		Failure(apLL);
+	}
+	void OtherFunction(LinkLayer* pLinkLayer)
+	{
+		Failure(pLinkLayer);
 	}
 	void OnTimeout(LinkLayer*);
 

--- a/cpp/libs/opendnp3/src/opendnp3/master/Master.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/master/Master.cpp
@@ -68,6 +68,11 @@ void Master::OnSendResult(bool isSucccess)
 	context.OnSendResult(isSucccess);	
 }
 
+bool Master::OnLowerSend()
+{
+	return context.OnLowerSend();
+}
+
 ICommandProcessor& Master::GetCommandProcessor()
 {
 	return commandMarshaller;

--- a/cpp/libs/opendnp3/src/opendnp3/master/Master.h
+++ b/cpp/libs/opendnp3/src/opendnp3/master/Master.h
@@ -54,6 +54,8 @@ class Master : public IUpperLayer
 	
 	virtual void OnSendResult(bool isSucccess) override final;
 
+	virtual bool OnLowerSend() override final;
+
 	/// ----- Misc public members -------
 	
 	ICommandProcessor& GetCommandProcessor();

--- a/cpp/libs/opendnp3/src/opendnp3/master/MasterContext.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/master/MasterContext.cpp
@@ -197,6 +197,17 @@ void MasterContext::OnSendResult(bool isSucccess)
 	}
 }
 
+bool MasterContext::OnLowerSend()
+{
+	if (isSending)
+	{
+		SIMPLE_LOG_BLOCK(logger, flags::WARN, "Lower layer send blocked - send request already in progress");
+		return false;
+	}
+	isSending = true;
+	return isSending;
+}
+
 void MasterContext::OnReceive(const ReadBufferView& apdu)
 {
 	if (isOnline)

--- a/cpp/libs/opendnp3/src/opendnp3/master/MasterContext.h
+++ b/cpp/libs/opendnp3/src/opendnp3/master/MasterContext.h
@@ -84,6 +84,7 @@ class MasterContext : public ICommandProcessor, public IScheduleCallback
 	bool OnLayerUp();
 	bool OnLayerDown();
 	void OnSendResult(bool isSucccess);
+	bool OnLowerSend();
 	void OnReceive(const openpal::ReadBufferView& apdu);
 
 	// ------- internal events -------

--- a/cpp/libs/opendnp3/src/opendnp3/outstation/Outstation.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/outstation/Outstation.cpp
@@ -92,6 +92,11 @@ void Outstation::OnSendResult(bool isSuccess)
 	}	
 }
 
+bool Outstation::OnLowerSend()
+{
+	return context.OnLowerSend();
+}
+
 void Outstation::SetRestartIIN()
 {
 	context.staticIIN.SetBit(IINBit::DEVICE_RESTART);

--- a/cpp/libs/opendnp3/src/opendnp3/outstation/Outstation.h
+++ b/cpp/libs/opendnp3/src/opendnp3/outstation/Outstation.h
@@ -51,6 +51,8 @@ class Outstation : public IUpperLayer
 	
 	virtual void OnSendResult(bool isSucccess) override final;
 
+	virtual bool OnLowerSend() override final;
+
 	
 	/// ---- Other public members
 

--- a/cpp/libs/opendnp3/src/opendnp3/outstation/OutstationContext.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/outstation/OutstationContext.cpp
@@ -246,6 +246,17 @@ void OutstationContext::OnSendResult(bool isSuccess)
 	}	
 }
 
+bool OutstationContext::OnLowerSend()
+{
+	if (isTransmitting)
+	{
+		SIMPLE_LOG_BLOCK(logger, flags::WARN, "Lower layer send blocked - send request already in progress");
+		return false;
+	}
+	isTransmitting = true;
+	return isTransmitting;
+}
+
 OutstationSolicitedStateBase* OutstationContext::OnReceiveSolRequest(const APDUHeader& header, const openpal::ReadBufferView& apdu)
 {
 	// analyze this request to see how it compares to the last request

--- a/cpp/libs/opendnp3/src/opendnp3/outstation/OutstationContext.h
+++ b/cpp/libs/opendnp3/src/opendnp3/outstation/OutstationContext.h
@@ -124,6 +124,7 @@ class OutstationContext
 	void OnReceiveAPDU(const openpal::ReadBufferView& apdu);
 
 	void OnSendResult(bool isSuccess);
+	bool OnLowerSend();
 
 	OutstationSolicitedStateBase* OnReceiveSolRequest(const APDUHeader& header, const openpal::ReadBufferView& apdu);	
 

--- a/cpp/libs/opendnp3/src/opendnp3/transport/TransportLayer.cpp
+++ b/cpp/libs/opendnp3/src/opendnp3/transport/TransportLayer.cpp
@@ -135,6 +135,20 @@ void TransportLayer::OnSendResult(bool isSuccess)
 	}
 }
 
+bool TransportLayer::OnLowerSend()
+{
+	if (isSending)
+	{
+		SIMPLE_LOG_BLOCK(logger, flags::WARN, "Lower layer send blocked - send request already in progress");
+		return false;
+	}
+	if(this->pUpperLayer->OnLowerSend())
+	{
+		isSending = true;
+		return isSending;
+	}
+}
+
 void TransportLayer::SetAppLayer(IUpperLayer* pUpperLayer_)
 {
 	assert(pUpperLayer_ != nullptr);

--- a/cpp/libs/opendnp3/src/opendnp3/transport/TransportLayer.h
+++ b/cpp/libs/opendnp3/src/opendnp3/transport/TransportLayer.h
@@ -55,6 +55,7 @@ public:
 	virtual void OnLowerLayerUp() override final;
 	virtual void OnLowerLayerDown() override final;
 	virtual void OnSendResult(bool isSuccess) override final;
+	virtual bool OnLowerSend() override final;
 
 	void SetAppLayer(IUpperLayer* pUpperLayer_);
 	void SetLinkLayer(ILinkLayer* pLinkLayer_);

--- a/cpp/tests/opendnp3tests/src/MockTransportLayer.h
+++ b/cpp/tests/opendnp3tests/src/MockTransportLayer.h
@@ -90,6 +90,7 @@ public:
 	// these are the NVII delegates
 	virtual void OnReceive(const openpal::ReadBufferView& buffer) override final;
 	virtual void OnSendResult(bool isSuccess) override final;
+	virtual bool OnLowerSend() override final{return true;}
 	virtual void OnLowerLayerUp() override final;
 	virtual void OnLowerLayerDown() override final;
 

--- a/cpp/tests/opendnp3tests/src/MockUpperLayer.h
+++ b/cpp/tests/opendnp3tests/src/MockUpperLayer.h
@@ -96,6 +96,7 @@ public:
 	//these are the NVII delegates
 	virtual void OnReceive(const openpal::ReadBufferView& buffer) override final;
 	virtual void OnSendResult(bool isSuccess) override final;
+	virtual bool OnLowerSend() override final{return true;}
 	virtual void OnLowerLayerUp() override final;
 	virtual void OnLowerLayerDown() override final;
 

--- a/cpp/tests/opendnp3tests/src/TestLinkLayer.cpp
+++ b/cpp/tests/opendnp3tests/src/TestLinkLayer.cpp
@@ -322,9 +322,9 @@ TEST_CASE(SUITE("KeepAliveExpiry"))
         auto frame = LinkFrame::FormatRequestLinkStatus(writeTo, true, 1024, 1, nullptr);
         REQUIRE(toHex(t.lastWrite) == toHex(frame));
     }
-
     t.link.LinkStatus(false, false, 1, 1024);
-    t.exe.AdvanceTime(cfg.KeepAlive);
+    
+    
     t.exe.AdvanceTime(cfg.KeepAlive);
 	REQUIRE(t.exe.RunOne()); // trigger the keep alive timer callback
 	REQUIRE(t.numWrites ==  2);
@@ -334,16 +334,13 @@ TEST_CASE(SUITE("KeepAliveExpiry"))
         auto frame = LinkFrame::FormatRequestLinkStatus(writeTo, true, 1024, 1, nullptr);
         REQUIRE(toHex(t.lastWrite) == toHex(frame));
     }
+	REQUIRE(t.upper.CountersEqual(0, 0));
+        
+    REQUIRE(t.log.IsLogErrorFree());
     t.exe.AdvanceTime(cfg.Timeout);
 	REQUIRE(t.exe.RunOne()); // trigger the keep alive timer callback
-	REQUIRE(t.numWrites ==  2);
-	t.link.OnTransmitResult(true);
-    {
-        auto writeTo = buffer.GetWriteBufferView();
-        auto frame = LinkFrame::FormatRequestLinkStatus(writeTo, true, 1024, 1, nullptr);
-        REQUIRE(toHex(t.lastWrite) == toHex(frame));
-    }
-
+	REQUIRE(t.upper.CountersEqual(0, 1));
+	REQUIRE(t.log.PopOneEntry(flags::WARN));
 
 }
 

--- a/cpp/tests/opendnp3tests/src/TestLinkLayer.cpp
+++ b/cpp/tests/opendnp3tests/src/TestLinkLayer.cpp
@@ -304,10 +304,10 @@ TEST_CASE(SUITE("CloseBehavior"))
 }
 
 // Send request link status after keep alive timer expiry
-TEST_CASE(SUITE("KeepAliveExpiry"))
+TEST_CASE(SUITE("NotResetKeepAliveExpiry"))
 {
     LinkConfig cfg = LinkLayerTest::DefaultConfig();
-    
+	cfg.NumRetry = 1;
 	DynamicBuffer buffer(292);
 
 	LinkLayerTest t(cfg);
@@ -324,8 +324,9 @@ TEST_CASE(SUITE("KeepAliveExpiry"))
     }
     t.link.LinkStatus(false, false, 1, 1024);
     
-    
     t.exe.AdvanceTime(cfg.KeepAlive);
+	REQUIRE(t.log.IsLogErrorFree());
+
 	REQUIRE(t.exe.RunOne()); // trigger the keep alive timer callback
 	REQUIRE(t.numWrites ==  2);
 	t.link.OnTransmitResult(true);
@@ -334,15 +335,96 @@ TEST_CASE(SUITE("KeepAliveExpiry"))
         auto frame = LinkFrame::FormatRequestLinkStatus(writeTo, true, 1024, 1, nullptr);
         REQUIRE(toHex(t.lastWrite) == toHex(frame));
     }
-	REQUIRE(t.upper.CountersEqual(0, 0));
         
     REQUIRE(t.log.IsLogErrorFree());
     t.exe.AdvanceTime(cfg.Timeout);
-	REQUIRE(t.exe.RunOne()); // trigger the keep alive timer callback
-	REQUIRE(t.upper.CountersEqual(0, 1));
+	REQUIRE(t.exe.RunOne()); // trigger the timeout retry timer callback
+	REQUIRE(t.numWrites == 3);
+	t.link.OnTransmitResult(true);
+	{
+		auto writeTo = buffer.GetWriteBufferView();
+		auto frame = LinkFrame::FormatRequestLinkStatus(writeTo, true, 1024, 1, nullptr);
+		REQUIRE(toHex(t.lastWrite) == toHex(frame));
+	}
 	REQUIRE(t.log.PopOneEntry(flags::WARN));
 
+	t.exe.AdvanceTime(cfg.Timeout);
+	REQUIRE(t.exe.RunOne()); // trigger the final timeout retry timer callback
+	REQUIRE(t.numWrites == 3);
+	REQUIRE(t.log.PopOneEntry(flags::WARN));
 }
+
+// Send request link status after keep alive timer expiry
+TEST_CASE(SUITE("ResetKeepAliveExpiry"))
+{
+	LinkConfig cfg = LinkLayerTest::DefaultConfig();
+	cfg.NumRetry = 1;
+	cfg.UseConfirms = true;
+	DynamicBuffer buffer(292);
+
+	LinkLayerTest t(cfg);
+	t.link.OnLowerLayerUp();
+
+	ByteStr bytes(250, 0);
+	BufferSegment segments(250, bytes.ToHex());
+	t.link.Send(segments); // Reset link
+	REQUIRE(t.numWrites == 1);
+	t.link.OnTransmitResult(true);
+	t.link.Ack(false, false, 1, 1024); // Ack it
+
+	REQUIRE(t.numWrites == 2);
+	{
+		auto writeTo = buffer.GetWriteBufferView();
+		auto result = LinkFrame::FormatConfirmedUserData(writeTo, true, true, 1024, 1, bytes, bytes.Size(), nullptr);
+		REQUIRE(toHex(t.lastWrite) == toHex(result)); // check that the data got sent
+	}
+	t.link.OnTransmitResult(true);
+	t.link.Ack(false, false, 1, 1024); // Ack it
+
+	REQUIRE(t.numWrites == 2);
+	t.link.OnTransmitResult(true);
+
+	t.exe.AdvanceTime(cfg.KeepAlive);
+	REQUIRE(t.exe.RunOne()); // trigger the keep alive timer callback
+	REQUIRE(t.numWrites == 3);
+	t.link.OnTransmitResult(true);
+	{
+		auto writeTo = buffer.GetWriteBufferView();
+		auto frame = LinkFrame::FormatRequestLinkStatus(writeTo, true, 1024, 1, nullptr);
+		REQUIRE(toHex(t.lastWrite) == toHex(frame));
+	}
+	t.link.LinkStatus(false, false, 1, 1024);
+
+	t.exe.AdvanceTime(cfg.KeepAlive);
+	REQUIRE(t.log.IsLogErrorFree());
+
+	REQUIRE(t.exe.RunOne()); // trigger the keep alive timer callback
+	REQUIRE(t.numWrites == 4);
+	t.link.OnTransmitResult(true);
+	{
+		auto writeTo = buffer.GetWriteBufferView();
+		auto frame = LinkFrame::FormatRequestLinkStatus(writeTo, true, 1024, 1, nullptr);
+		REQUIRE(toHex(t.lastWrite) == toHex(frame));
+	}
+
+	REQUIRE(t.log.IsLogErrorFree());
+	t.exe.AdvanceTime(cfg.Timeout);
+	REQUIRE(t.exe.RunOne()); // trigger the timeout retry timer callback
+	REQUIRE(t.numWrites == 5);
+	t.link.OnTransmitResult(true);
+	{
+		auto writeTo = buffer.GetWriteBufferView();
+		auto frame = LinkFrame::FormatRequestLinkStatus(writeTo, true, 1024, 1, nullptr);
+		REQUIRE(toHex(t.lastWrite) == toHex(frame));
+	}
+	REQUIRE(t.log.PopOneEntry(flags::WARN));
+
+	t.exe.AdvanceTime(cfg.Timeout);
+	REQUIRE(t.exe.RunOne()); // trigger the final timeout retry timer callback
+	REQUIRE(t.numWrites == 5);
+	REQUIRE(t.log.PopOneEntry(flags::WARN));
+}
+
 
 TEST_CASE(SUITE("ResetLinkTimerExpiration"))
 {

--- a/generation/dnp3/src/main/scala/com/automatak/render/dnp3/enums/LinkStatus.scala
+++ b/generation/dnp3/src/main/scala/com/automatak/render/dnp3/enums/LinkStatus.scala
@@ -9,8 +9,9 @@ object LinkStatus {
   def apply(): EnumModel = EnumModel("LinkStatus", comments, EnumModel.Integer, codes, Base10)
 
   private val codes = List(
-    EnumValue("UNRESET", 0, "DOWN"),
-    EnumValue("RESET", 1, "UP")
+    EnumValue("UNRESET", 0, "Transition to UNRESET state"),
+    EnumValue("RESET", 1, "Transition to RESET state"),
+    EnumValue("TIMEOUT", 2, "Timeout Transition")
   )
 
 }


### PR DESCRIPTION
Gday,

Here is the implementation of link layer keepalives, using link status requests. We integrated this functionality with the new link status listener, so the listener gets notified if there's a link layer timeout. After a keepalive times out, keepalives continue to be sent, and the listener is notified if the link comes back up. 

We added unit tests for all the status transitions, using confirms and not using confirms.

Now our datacon can have confirms turned off, use unsolicited and multidrop, and still fail over quickly!

Please let us know what you think.

Cheers,
Neil.
