### PR TITLE
Add link status listener to .NET bindings

### DIFF
--- a/dotnet/Simulator/DNP3/DNP3Commons/EventedOutstationApplication.cs
+++ b/dotnet/Simulator/DNP3/DNP3Commons/EventedOutstationApplication.cs
@@ -108,6 +108,10 @@ namespace Automatak.Simulator.DNP3.Commons
         public event OnRestartRequested ColdRestart;
         public event OnRestartRequested WarmRestart;
 
+        void ILinkStatusListener.OnStateChange(LinkStatus value)
+        {
+        }
+
         bool IOutstationApplication.SupportsWriteAbsoluteTime
         {
             get { return supportsWriteAbsoluteTime; }
@@ -177,6 +181,5 @@ namespace Automatak.Simulator.DNP3.Commons
 
             return warmRestartTime; 
         }
-        
     }
 }

--- a/dotnet/bindings/CLRAdapter/ChannelAdapter.cpp
+++ b/dotnet/bindings/CLRAdapter/ChannelAdapter.cpp
@@ -77,6 +77,7 @@ namespace Automatak
 				{
 					pMaster->DeleteOnDestruct(pSOEHandler);
 					pMaster->DeleteOnDestruct(pApplication);
+					AddLinkStatusListener(pMaster, application);
 					return gcnew MasterAdapter(pMaster);
 				}
 			}
@@ -102,8 +103,19 @@ namespace Automatak
 					pOutstation->DeleteOnDestruct(pCommand);
 					pOutstation->DeleteOnDestruct(pApplication);
 					ApplyDatabaseSettings(pOutstation->GetConfigView(), config->databaseTemplate);
+					AddLinkStatusListener(pOutstation, application);
 					return gcnew OutstationAdapter(pOutstation);
 				}
+			}
+
+			void ChannelAdapter::AddLinkStatusListener(asiodnp3::IStack* pStack, ILinkStatusListener^ listener)
+			{
+				System::Action<LinkStatus>^ callback = gcnew System::Action<LinkStatus>(listener, &ILinkStatusListener::OnStateChange);
+				auto convert = std::bind(&Conversions::ConvertLinkStatus, std::placeholders::_1);
+				auto pConverter = new EventConverter<opendnp3::LinkStatus, Automatak::DNP3::Interface::LinkStatus>(convert, callback);
+				std::function<void(opendnp3::LinkStatus)> trigger = pConverter->GetTrigger();
+				pStack->AddLinkStatusListener(trigger);
+				pStack->DeleteOnDestruct(pConverter);
 			}
 
 			void ChannelAdapter::ApplyDatabaseSettings(opendnp3::DatabaseConfigView view, DatabaseTemplate^ dbTemplate)

--- a/dotnet/bindings/CLRAdapter/ChannelAdapter.h
+++ b/dotnet/bindings/CLRAdapter/ChannelAdapter.h
@@ -43,6 +43,8 @@ namespace Automatak
 
 				asiodnp3::IChannel* pChannel;
 
+				static void AddLinkStatusListener(asiodnp3::IStack* pStack, ILinkStatusListener^ listener);
+
 				static void ApplyDatabaseSettings(opendnp3::DatabaseConfigView view, DatabaseTemplate^ dbTemplate);
 
 				static void ApplySettings(IReadOnlyList<BinaryRecord^>^ list, openpal::ArrayView < opendnp3::Cell<opendnp3::Binary>, uint16_t>& view);

--- a/dotnet/bindings/CLRAdapter/Conversions.cpp
+++ b/dotnet/bindings/CLRAdapter/Conversions.cpp
@@ -31,6 +31,11 @@ namespace Automatak
 				return (ChannelState)aState;
 			}
 
+			LinkStatus Conversions::ConvertLinkStatus(opendnp3::LinkStatus aState)
+			{
+				return (LinkStatus)aState;
+			}
+
 			IChannelStatistics^ Conversions::ConvertChannelStats(const opendnp3::LinkChannelStatistics& stats)
 			{
 				ChannelStatistics^ ret = gcnew ChannelStatistics();

--- a/dotnet/bindings/CLRAdapter/Conversions.h
+++ b/dotnet/bindings/CLRAdapter/Conversions.h
@@ -9,6 +9,7 @@
 #include <opendnp3/LogLevels.h>
 
 #include <opendnp3/gen/ChannelState.h>
+#include <opendnp3/gen/LinkStatus.h>
 
 #include <opendnp3/app/MeasurementTypes.h>
 #include <opendnp3/app/TimeAndInterval.h>
@@ -54,6 +55,8 @@ namespace Automatak
 
 				// Converting channel state enumeration
 				static ChannelState ConvertChannelState(opendnp3::ChannelState aState);
+
+				static LinkStatus ConvertLinkStatus(opendnp3::LinkStatus aState);
 
 				static IChannelStatistics^ ConvertChannelStats(const opendnp3::LinkChannelStatistics& statistics);
 

--- a/dotnet/bindings/CLRInterface/CLRInterface.csproj
+++ b/dotnet/bindings/CLRInterface/CLRInterface.csproj
@@ -87,6 +87,7 @@
     <Compile Include="gen\IINField.cs" />
     <Compile Include="gen\IndexMode.cs" />
     <Compile Include="gen\IntervalUnits.cs" />
+    <Compile Include="gen\LinkStatus.cs" />
     <Compile Include="gen\MasterTaskType.cs" />
     <Compile Include="gen\PointClass.cs" />
     <Compile Include="gen\QualifierCode.cs" />
@@ -115,6 +116,7 @@
     <Compile Include="IChannel.cs" />
     <Compile Include="ICommandProcessor.cs" />
     <Compile Include="IFuture.cs" />
+    <Compile Include="ILinkStatusListener.cs" />
     <Compile Include="ILogHandler.cs" />
     <Compile Include="IMaster.cs">
       <SubType>Code</SubType>

--- a/dotnet/bindings/CLRInterface/ILinkStatusListener.cs
+++ b/dotnet/bindings/CLRInterface/ILinkStatusListener.cs
@@ -1,0 +1,29 @@
+﻿
+//
+// Licensed to Green Energy Corp (www.greenenergycorp.com) under one or
+// more contributor license agreements. See the NOTICE file distributed
+// with this work for additional information regarding copyright ownership.
+// Green Energy Corp licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file was forked on 01/01/2013 by Automatak, LLC and modifications
+// have been made to this file. Automatak, LLC licenses these modifications to
+// you under the terms of the License.
+//
+
+namespace Automatak.DNP3.Interface
+{
+    public interface ILinkStatusListener
+    {
+        void OnStateChange(LinkStatus value);
+    }
+}

--- a/dotnet/bindings/CLRInterface/IMasterApplication.cs
+++ b/dotnet/bindings/CLRInterface/IMasterApplication.cs
@@ -30,7 +30,7 @@ namespace Automatak.DNP3.Interface
     /// <summary>
     /// Master application code implements this interface to interface with stack
     /// </summary>
-    public interface IMasterApplication
+    public interface IMasterApplication : ILinkStatusListener
     {
         /// <summary>
         /// Get a count of milliseconds since Unix epoch for the purposes of time syncing
@@ -89,6 +89,11 @@ namespace Automatak.DNP3.Interface
         }
 
         private DefaultMasterApplication() { }
+
+        void ILinkStatusListener.OnStateChange(LinkStatus value)
+        {
+            // ignore these in the default application 
+        }
 
         UInt64 IMasterApplication.GetMillisecondsSinceEpoch()
         {

--- a/dotnet/bindings/CLRInterface/IOutstationApplication.cs
+++ b/dotnet/bindings/CLRInterface/IOutstationApplication.cs
@@ -30,7 +30,7 @@ namespace Automatak.DNP3.Interface
     /// <summary>
     /// Outstation application code implements this interface to interface with the stack
     /// </summary>
-    public interface IOutstationApplication
+    public interface IOutstationApplication : ILinkStatusListener
     {
         bool SupportsWriteAbsoluteTime { get; }
 
@@ -81,6 +81,10 @@ namespace Automatak.DNP3.Interface
         }
 
         private DefaultOutstationApplication() { }
+
+        void ILinkStatusListener.OnStateChange(LinkStatus value)
+        {
+        }
 
         bool IOutstationApplication.SupportsWriteAbsoluteTime
         {

--- a/dotnet/bindings/CLRInterface/gen/LinkStatus.cs
+++ b/dotnet/bindings/CLRInterface/gen/LinkStatus.cs
@@ -1,0 +1,37 @@
+//
+//  _   _         ______    _ _ _   _             _ _ _
+// | \ | |       |  ____|  | (_) | (_)           | | | |
+// |  \| | ___   | |__   __| |_| |_ _ _ __   __ _| | | |
+// | . ` |/ _ \  |  __| / _` | | __| | '_ \ / _` | | | |
+// | |\  | (_) | | |___| (_| | | |_| | | | | (_| |_|_|_|
+// |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
+//                                           __/ |
+//                                          |___/
+// 
+// This file is auto-generated. Do not edit manually
+// 
+// Copyright 2013 Automatak LLC
+// 
+// Automatak LLC (www.automatak.com) licenses this file
+// to you under the the Apache License Version 2.0 (the "License"):
+// 
+// http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+namespace Automatak.DNP3.Interface
+{
+  /// <summary>
+  /// Enumeration for reset/unreset states of a link layer
+  /// </summary>
+  public enum LinkStatus : int
+  {
+    /// <summary>
+    /// DOWN
+    /// </summary>
+    UNRESET = 0,
+    /// <summary>
+    /// UP
+    /// </summary>
+    RESET = 1
+  }
+}

--- a/generation/dnp3/src/main/scala/com/automatak/render/dnp3/enums/generators/CSharpEnumGenerator.scala
+++ b/generation/dnp3/src/main/scala/com/automatak/render/dnp3/enums/generators/CSharpEnumGenerator.scala
@@ -37,7 +37,8 @@ object CSharpEnumGenerator {
       QualifierCode(),
       GroupVariation(),
       EventMode(),
-      IndexMode()
+      IndexMode(),
+      LinkStatus()
     ).map(e => EnumConfig.apply(e, dir)) ::: events ::: qualityMasks
 
     implicit val indent = CppIndentation()


### PR DESCRIPTION
Following on from work by @neilstephens this adds the link status listener to the .NET bindings.

As suggested, I added this as an OnStateChange(LinkStatus) method to IMasterApplication/IOutstationApplication rather than exposing AddLinkStatusListener method.

No changes to the C++ bindings - the ChannelAdapter hides the complexity of hooking up an event listener and marshalling to the IMasterApplication/IOutstationApplication interface.

Sid
