### PR TITLE
Add common settings for CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ coverage.info
 cpp/demos/cover.info
 cpp/demos/cover_html/
 
+# out-of-directory builds
+_build/
+.build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cmake"]
+	path = cmake
+	url = https://github.com/VlinderSoftware/cmake.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ set(OPENDNP3_MINOR_VERSION 1)
 set(OPENDNP3_MICRO_VERSION 0)
 set(OPENDNP3_VERSION ${OPENDNP3_MAJOR_VERSION}.${OPENDNP3_MINOR_VERSION}.${OPENDNP3_MICRO_VERSION})
 
+set(USING_ASIO ON)
+include(${CMAKE_SOURCE_DIR}/cmake/settings.cmake)
+
 # various optional libraries and projects
 option(DEMO "Build demo applications" OFF)
 option(TEST "Build tests" OFF)
@@ -50,10 +53,6 @@ if(WIN32)
   set_property(GLOBAL PROPERTY USE_FOLDERS ON) #allows the creation of solution folders
 
    # for ASIO
-  add_definitions(-D_WIN32_WINNT=0x0501)
-  add_definitions(-DASIO_HAS_STD_SYSTEM_ERROR)  
-
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /MP")
 
   set(LIB_TYPE STATIC) #default to static on MSVC
   

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,8 @@ cache:
 - C:\asio
 - C:\OpenSSL-Win32
 build_script:
+- cmd: git submodule init
+- cmd: git submodule update
 - cmd: MKDIR build
 - cmd: CD build
 - cmd: MKDIR lib


### PR DESCRIPTION
This allows us, among other things, to get rid of annoying warnings like C4996.
Furthermore, it allows the integration of opendnp3 with projects that already use a centralized set of CMake settings -- like all the Vlinder Software projects started doing for the last few months.
Comes in especially handy when integrating with other projects, either as a third-party library (note settings are included from ${CMAKE_SOURCE_DIR}/cmake/settings.cmake, so if opendnp3 is included as a submodule it will still work) or with a third-party library (such as RTIMDB ;-))
