### PR TITLE
interface fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ coverage.info
 cpp/demos/cover.info
 cpp/demos/cover_html/
 
+# out-of-directory builds
+_build/
+.build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cmake"]
+	path = cmake
+	url = https://github.com/VlinderSoftware/cmake.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ set(OPENDNP3_MINOR_VERSION 1)
 set(OPENDNP3_MICRO_VERSION 0)
 set(OPENDNP3_VERSION ${OPENDNP3_MAJOR_VERSION}.${OPENDNP3_MINOR_VERSION}.${OPENDNP3_MICRO_VERSION})
 
+set(USING_ASIO ON)
+include(${CMAKE_SOURCE_DIR}/cmake/settings.cmake)
+
 # various optional libraries and projects
 option(DEMO "Build demo applications" OFF)
 option(TEST "Build tests" OFF)
@@ -50,10 +53,6 @@ if(WIN32)
   set_property(GLOBAL PROPERTY USE_FOLDERS ON) #allows the creation of solution folders
 
    # for ASIO
-  add_definitions(-D_WIN32_WINNT=0x0501)
-  add_definitions(-DASIO_HAS_STD_SYSTEM_ERROR)  
-
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /MP")
 
   set(LIB_TYPE STATIC) #default to static on MSVC
   

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,8 @@ cache:
 - C:\asio
 - C:\OpenSSL-Win32
 build_script:
+- cmd: git submodule init
+- cmd: git submodule update
 - cmd: MKDIR build
 - cmd: CD build
 - cmd: MKDIR lib

--- a/cpp/libs/include/opendnp3/outstation/IDatabase.h
+++ b/cpp/libs/include/opendnp3/outstation/IDatabase.h
@@ -31,6 +31,7 @@
 namespace opendnp3
 {
 class IResponseLoader;
+class IStaticSelector;
 /**
 * An interface used to update measurement values.
 */
@@ -184,6 +185,7 @@ public:
 
 
 	virtual IResponseLoader& GetResponseLoader() noexcept = 0;
+	virtual IStaticSelector& GetStaticSelector() noexcept = 0;
 };
 
 }

--- a/cpp/libs/include/opendnp3/outstation/IDatabase.h
+++ b/cpp/libs/include/opendnp3/outstation/IDatabase.h
@@ -32,6 +32,7 @@ namespace opendnp3
 {
 class IResponseLoader;
 class IStaticSelector;
+class IClassAssigner;
 /**
 * An interface used to update measurement values.
 */
@@ -186,6 +187,7 @@ public:
 
 	virtual IResponseLoader& GetResponseLoader() noexcept = 0;
 	virtual IStaticSelector& GetStaticSelector() noexcept = 0;
+	virtual IClassAssigner& GetClassAssigner() noexcept = 0;
 };
 
 }

--- a/cpp/libs/include/opendnp3/outstation/IDatabase.h
+++ b/cpp/libs/include/opendnp3/outstation/IDatabase.h
@@ -30,7 +30,7 @@
 
 namespace opendnp3
 {
-
+class IResponseLoader;
 /**
 * An interface used to update measurement values.
 */
@@ -182,6 +182,8 @@ public:
 	*/
 	virtual bool Modify(const openpal::Function1<const TimeAndInterval&, TimeAndInterval>& modify, uint16_t index) = 0;
 
+
+	virtual IResponseLoader& GetResponseLoader() noexcept = 0;
 };
 
 }

--- a/cpp/libs/src/opendnp3/outstation/Database.h
+++ b/cpp/libs/src/opendnp3/outstation/Database.h
@@ -67,6 +67,7 @@ public:
 
 	IResponseLoader& GetResponseLoader() noexcept override final { return buffers; }
 	IStaticSelector& GetStaticSelector() noexcept override final { return buffers; }
+	IClassAssigner& GetClassAssigner() noexcept override final { return buffers; }
 
 	/**
 	* @return A view of all the static data for configuration purposes
@@ -75,9 +76,6 @@ public:
 	{
 		return buffers.buffers.GetView();
 	}
-
-	// stores the most recent values, selected values, and metadata
-	DatabaseBuffers buffers;
 
 private:
 
@@ -98,6 +96,9 @@ private:
 
 	template <class T>
 	bool UpdateAny(Cell<T>& cell, const T& value, EventMode mode);
+
+	// stores the most recent values, selected values, and metadata
+	DatabaseBuffers buffers;
 };
 
 template <class T>

--- a/cpp/libs/src/opendnp3/outstation/Database.h
+++ b/cpp/libs/src/opendnp3/outstation/Database.h
@@ -65,6 +65,8 @@ public:
 
 	// ------- Misc ---------------
 
+	IResponseLoader& GetResponseLoader() noexcept override final { return buffers; }
+
 	/**
 	* @return A view of all the static data for configuration purposes
 	*/

--- a/cpp/libs/src/opendnp3/outstation/Database.h
+++ b/cpp/libs/src/opendnp3/outstation/Database.h
@@ -66,6 +66,7 @@ public:
 	// ------- Misc ---------------
 
 	IResponseLoader& GetResponseLoader() noexcept override final { return buffers; }
+	IStaticSelector& GetStaticSelector() noexcept override final { return buffers; }
 
 	/**
 	* @return A view of all the static data for configuration purposes
@@ -73,12 +74,6 @@ public:
 	DatabaseConfigView GetConfigView()
 	{
 		return buffers.buffers.GetView();
-	}
-
-	// used to clear the static selection for a new read
-	void Unselect()
-	{
-		buffers.Unselect();
 	}
 
 	// stores the most recent values, selected values, and metadata

--- a/cpp/libs/src/opendnp3/outstation/IStaticSelector.h
+++ b/cpp/libs/src/opendnp3/outstation/IStaticSelector.h
@@ -35,6 +35,8 @@ public:
 	virtual IINField SelectAll(GroupVariation gv) = 0;
 
 	virtual IINField SelectRange(GroupVariation gv, const Range& range) = 0;
+
+	virtual void Unselect() = 0;
 };
 
 }

--- a/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
+++ b/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
@@ -63,7 +63,7 @@ OContext::OContext(
 	pApplication(&application),
 	eventBuffer(config.eventBufferConfig),
 	database(dbTemplate, eventBuffer, config.params.indexMode, config.params.typesAllowedInClass0),
-	rspContext(database.buffers, eventBuffer),
+	rspContext(database.GetResponseLoader(), eventBuffer),
 	params(config.params),
 	isOnline(false),
 	isTransmitting(false),

--- a/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
+++ b/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
@@ -709,7 +709,7 @@ IINField OContext::HandleAssignClass(const openpal::RSlice& objects)
 {
 	if (this->pApplication->SupportsAssignClass())
 	{
-		AssignClassHandler handler(this->logger, *this->pExecutor, *this->pApplication, this->database.buffers);
+		AssignClassHandler handler(this->logger, *this->pExecutor, *this->pApplication, this->database.GetClassAssigner());
 		auto result = APDUParser::Parse(objects, handler, &this->logger, ParserSettings::NoContents());
 		return (result == ParseResult::OK) ? handler.Errors() : IINFromParseResult(result);
 	}

--- a/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
+++ b/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
@@ -553,7 +553,7 @@ Pair<IINField, AppControlField> OContext::HandleRead(const openpal::RSlice& obje
 	this->eventBuffer.Unselect(); // always un-select any previously selected points when we start a new read request
 	this->database.GetStaticSelector().Unselect();
 
-	ReadHandler handler(this->logger, this->database.buffers, this->eventBuffer);
+	ReadHandler handler(this->logger, this->database.GetStaticSelector(), this->eventBuffer);
 	auto result = APDUParser::Parse(objects, handler, &this->logger, ParserSettings::NoContents()); // don't expect range/count context on a READ
 	if (result == ParseResult::OK)
 	{

--- a/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
+++ b/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
@@ -551,7 +551,7 @@ Pair<IINField, AppControlField> OContext::HandleRead(const openpal::RSlice& obje
 {
 	this->rspContext.Reset();
 	this->eventBuffer.Unselect(); // always un-select any previously selected points when we start a new read request
-	this->database.Unselect();
+	this->database.GetStaticSelector().Unselect();
 
 	ReadHandler handler(this->logger, this->database.buffers, this->eventBuffer);
 	auto result = APDUParser::Parse(objects, handler, &this->logger, ParserSettings::NoContents()); // don't expect range/count context on a READ


### PR DESCRIPTION
Built on top of the previous pull request, this one works towards decoupling the implementation of the Outstation from that of the Database by not directly accessing the `buffer` member.

It adds a bunch of accessors to interfaces to the `IDatabase` class and implements them in `Database`.

AFAICT, this doesn't break anything.
