### PR TITLE
interface fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ coverage.info
 cpp/demos/cover.info
 cpp/demos/cover_html/
 
+# out-of-directory builds
+_build/
+.build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ set(OPENDNP3_MINOR_VERSION 1)
 set(OPENDNP3_MICRO_VERSION 0)
 set(OPENDNP3_VERSION ${OPENDNP3_MAJOR_VERSION}.${OPENDNP3_MINOR_VERSION}.${OPENDNP3_MICRO_VERSION})
 
+set(USING_ASIO ON)
+include(${CMAKE_SOURCE_DIR}/cmake/settings.cmake)
+
 # various optional libraries and projects
 option(DEMO "Build demo applications" OFF)
 option(TEST "Build tests" OFF)
@@ -34,76 +37,13 @@ if(DNP3_TLS)
 		include_directories(${OPENSSL_INCLUDE_DIR})
 	endif()   	
 endif()
- 
-if(WIN32)
-
-  set_property(GLOBAL PROPERTY USE_FOLDERS ON) #allows the creation of solution folders
-
-   # for ASIO
-  add_definitions(-D_WIN32_WINNT=0x0501)
-  add_definitions(-DASIO_HAS_STD_SYSTEM_ERROR)  
-
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /MP")
-
-  set(LIB_TYPE STATIC) #default to static on MSVC
-  
-else()
-
-  set(PTHREAD pthread)   
-
-  if(STATICLIBS)
-	set(LIB_TYPE STATIC)
-  else()
-	set(LIB_TYPE SHARED)
-  endif()
-
-  set(CMAKE_CXX_FLAGS "-Wall -std=c++11")
-
-  # different release and debug flags
-  set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-  set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
-  
-  if(COVERAGE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -g -O0")
-    #set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage -g -O0")
-  endif()
-
-  if (WERROR)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-  endif()
-
-endif()
-
-# There's problem with detecting usage of pthread with gcc 4.8.x
-# http://ubuntuforums.org/showthread.php?t=2183408
-if(CMAKE_COMPILER_IS_GNUCXX)      
-  if(CMAKE_CXX_COMPILER_VERSION MATCHES 4.8.*)
-    message("Adding pthread workaround for GCC version: ${CMAKE_CXX_COMPILER_VERSION}")
-    SET( CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-as-needed" )            
-  endif()
-endif()
 
 set(CMAKE_REQUIRED_FLAGS ${CMAKE_CXX_FLAGS})
-
-if (ASIO_HOME)
-  message("ASIO_HOME defined in cache: ${ASIO_HOME}")
-  include_directories(${ASIO_HOME})  
-else()
-  if(DEFINED ENV{ASIO_HOME})
-    message("ASIO_HOME defined in environment: $ENV{ASIO_HOME}")  
-    include_directories($ENV{ASIO_HOME})    
-  else()
-    message("ASIO_HOME was not defined. ASIO expected to be on include path")  
-  endif()
-endif()
 
 # include paths for all the local libraries
 include_directories(./cpp/libs/src)
 include_directories(./cpp/libs/include)
 include_directories(./cpp/tests/libs/src)
-
-# required for ASIO in C++11 only mode
-add_definitions(-DASIO_STANDALONE)
 
 # ---- openpal library ----
 file(GLOB_RECURSE openpal_SRC ./cpp/libs/src/openpal/*.cpp ./cpp/libs/src/openpal/*.h ./cpp/libs/include/openpal/*.h)

--- a/cmake/inc/asio.cmake
+++ b/cmake/inc/asio.cmake
@@ -1,0 +1,14 @@
+if (ASIO_HOME)
+	message("ASIO_HOME defined in cache: ${ASIO_HOME}")
+	include_directories(${ASIO_HOME})  
+else()
+	if(DEFINED ENV{ASIO_HOME})
+		message("ASIO_HOME defined in environment: $ENV{ASIO_HOME}")  
+		include_directories($ENV{ASIO_HOME})    
+	else()
+		message("ASIO_HOME was not defined. ASIO expected to be on include path")  
+	endif()
+endif()
+
+# required for ASIO in C++11 only mode
+add_definitions(-DASIO_STANDALONE)

--- a/cmake/inc/msvc.cmake
+++ b/cmake/inc/msvc.cmake
@@ -1,0 +1,17 @@
+if (WIN32)
+
+	set(VLINDER_TARGET_PLATFORM_NAME win32)
+	if (USING_ASIO)
+		add_definitions(-D_WIN32_WINNT=0x0501)
+		add_definitions(-DASIO_HAS_STD_SYSTEM_ERROR)  
+	else ()
+		set(WINSOCKAPI "-D_WINSOCKAPI_")
+		set(PLATFORM_SOCKET_LIBRARIES ws2_32)
+	endif()
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /MP")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS ${WINSOCKAPI} /wd4251 /wd4996 /wd4273 /wd4275 /wd4018 /wd4146 /EHsc")
+
+	set_property(GLOBAL PROPERTY USE_FOLDERS ON) #allows the creation of solution folders
+	set(LIB_TYPE STATIC) #default to static on MSVC
+endif()
+

--- a/cmake/inc/posix.cmake
+++ b/cmake/inc/posix.cmake
@@ -1,0 +1,65 @@
+if (UNIX)
+	set(PTHREAD pthread)   
+	find_package(Threads)
+		if(STATICLIBS)
+		set(LIB_TYPE STATIC)
+	else()
+		set(LIB_TYPE SHARED)
+	endif()
+
+	
+	include (CheckLibraryExists)
+	check_library_exists(pthread pthread_timedjoin_np "" HAVE_PHTREAD_TIMEDJOIN_NP)
+	set(CMAKE_C_FLAGS "-g -O2 -Wall -W -Wno-multichar -Wshadow -Wunused-variable -Wno-unused-parameter -Wunused-function -Wunused -Wno-unused-local-typedefs -Wno-system-headers -Wwrite-strings -fprofile-arcs -ftest-coverage -save-temps -DVLINDER_TARGET_POSIX")
+	if (${CYGWIN})
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DVLINDER_TARGET_CYGWIN -DVLINDER_TARGET_WIN32")
+	elseif(${MINGW})
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DVLINDER_TARGET_MINGW -DVLINDER_TARGET_WIN32")
+	else()
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+	endif()
+	set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated -Woverloaded-virtual")
+ 
+	set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g")
+	set(CMAKE_CXX_FLAGS_MINSIZEREL     "-Os -DNDEBUG")
+	set(CMAKE_CXX_FLAGS_RELEASE        "-O4 -DNDEBUG")
+	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
+
+	set(CMAKE_CXX_FLAGS                "${CMAKE_CXX_FLAGS} -Wall -std=c++11")
+
+	#find_library(ATOMIC_LIB atomic)
+	#list(APPEND EXTRA_LIBS ${ATOMIC_LIB})
+
+	# Compiler-specific C++11 activation.
+	if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+		execute_process(
+		COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+		if (NOT (GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7))
+			message(FATAL_ERROR "${PROJECT_NAME} requires g++ 4.7 or greater.")
+		endif ()
+	elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+	else ()
+		message(FATAL_ERROR "Your C++ compiler does not support C++11.")
+	endif ()
+	# different release and debug flags
+	set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+	set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
+	if(COVERAGE)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -g -O0")
+		#set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage -g -O0")
+	endif()
+
+	if (WERROR)
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+	endif()
+
+	# There's problem with detecting usage of pthread with gcc 4.8.x
+	# http://ubuntuforums.org/showthread.php?t=2183408
+	if(CMAKE_COMPILER_IS_GNUCXX)      
+		if(CMAKE_CXX_COMPILER_VERSION MATCHES 4.8.*)
+			message("Adding pthread workaround for GCC version: ${CMAKE_CXX_COMPILER_VERSION}")
+			SET( CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-as-needed" )            
+		endif()
+	endif()
+endif()

--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -1,0 +1,9 @@
+get_filename_component(settings_cmake_dir "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+include("${settings_cmake_dir}/inc/msvc.cmake")
+include("${settings_cmake_dir}/inc/posix.cmake")
+if (USING_ASIO)
+	include("${settings_cmake_dir}/inc/asio.cmake")
+endif()
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/cpp/libs/include/opendnp3/outstation/IDatabase.h
+++ b/cpp/libs/include/opendnp3/outstation/IDatabase.h
@@ -31,6 +31,7 @@
 namespace opendnp3
 {
 class IResponseLoader;
+class IStaticSelector;
 /**
 * An interface used to update measurement values.
 */
@@ -184,6 +185,7 @@ public:
 
 
 	virtual IResponseLoader& GetResponseLoader() noexcept = 0;
+	virtual IStaticSelector& GetStaticSelector() noexcept = 0;
 };
 
 }

--- a/cpp/libs/include/opendnp3/outstation/IDatabase.h
+++ b/cpp/libs/include/opendnp3/outstation/IDatabase.h
@@ -185,9 +185,9 @@ public:
 	virtual bool Modify(const openpal::Function1<const TimeAndInterval&, TimeAndInterval>& modify, uint16_t index) = 0;
 
 
-	virtual IResponseLoader& GetResponseLoader() noexcept = 0;
-	virtual IStaticSelector& GetStaticSelector() noexcept = 0;
-	virtual IClassAssigner& GetClassAssigner() noexcept = 0;
+	virtual IResponseLoader& GetResponseLoader() = 0;
+	virtual IStaticSelector& GetStaticSelector() = 0;
+	virtual IClassAssigner& GetClassAssigner() = 0;
 };
 
 }

--- a/cpp/libs/include/opendnp3/outstation/IDatabase.h
+++ b/cpp/libs/include/opendnp3/outstation/IDatabase.h
@@ -32,6 +32,7 @@ namespace opendnp3
 {
 class IResponseLoader;
 class IStaticSelector;
+class IClassAssigner;
 /**
 * An interface used to update measurement values.
 */
@@ -186,6 +187,7 @@ public:
 
 	virtual IResponseLoader& GetResponseLoader() noexcept = 0;
 	virtual IStaticSelector& GetStaticSelector() noexcept = 0;
+	virtual IClassAssigner& GetClassAssigner() noexcept = 0;
 };
 
 }

--- a/cpp/libs/include/opendnp3/outstation/IDatabase.h
+++ b/cpp/libs/include/opendnp3/outstation/IDatabase.h
@@ -30,7 +30,7 @@
 
 namespace opendnp3
 {
-
+class IResponseLoader;
 /**
 * An interface used to update measurement values.
 */
@@ -182,6 +182,8 @@ public:
 	*/
 	virtual bool Modify(const openpal::Function1<const TimeAndInterval&, TimeAndInterval>& modify, uint16_t index) = 0;
 
+
+	virtual IResponseLoader& GetResponseLoader() noexcept = 0;
 };
 
 }

--- a/cpp/libs/src/opendnp3/outstation/Database.h
+++ b/cpp/libs/src/opendnp3/outstation/Database.h
@@ -64,6 +64,7 @@ public:
 
 	IResponseLoader& GetResponseLoader() noexcept override final { return buffers; }
 	IStaticSelector& GetStaticSelector() noexcept override final { return buffers; }
+	IClassAssigner& GetClassAssigner() noexcept override final { return buffers; }
 
 	/**
 	* @return A view of all the static data for configuration purposes
@@ -72,9 +73,6 @@ public:
 	{
 		return buffers.buffers.GetView();
 	}
-
-	// stores the most recent values, selected values, and metadata
-	DatabaseBuffers buffers;
 
 private:
 
@@ -95,6 +93,9 @@ private:
 
 	template <class T>
 	bool UpdateAny(Cell<T>& cell, const T& value, EventMode mode);
+
+	// stores the most recent values, selected values, and metadata
+	DatabaseBuffers buffers;
 };
 
 template <class T>

--- a/cpp/libs/src/opendnp3/outstation/Database.h
+++ b/cpp/libs/src/opendnp3/outstation/Database.h
@@ -62,9 +62,9 @@ public:
 
 	// ------- Misc ---------------
 
-	IResponseLoader& GetResponseLoader() noexcept override final { return buffers; }
-	IStaticSelector& GetStaticSelector() noexcept override final { return buffers; }
-	IClassAssigner& GetClassAssigner() noexcept override final { return buffers; }
+	IResponseLoader& GetResponseLoader() override final { return buffers; }
+	IStaticSelector& GetStaticSelector() override final { return buffers; }
+	IClassAssigner& GetClassAssigner() override final { return buffers; }
 
 	/**
 	* @return A view of all the static data for configuration purposes

--- a/cpp/libs/src/opendnp3/outstation/Database.h
+++ b/cpp/libs/src/opendnp3/outstation/Database.h
@@ -62,6 +62,8 @@ public:
 
 	// ------- Misc ---------------
 
+	IResponseLoader& GetResponseLoader() noexcept override final { return buffers; }
+
 	/**
 	* @return A view of all the static data for configuration purposes
 	*/

--- a/cpp/libs/src/opendnp3/outstation/Database.h
+++ b/cpp/libs/src/opendnp3/outstation/Database.h
@@ -63,6 +63,7 @@ public:
 	// ------- Misc ---------------
 
 	IResponseLoader& GetResponseLoader() noexcept override final { return buffers; }
+	IStaticSelector& GetStaticSelector() noexcept override final { return buffers; }
 
 	/**
 	* @return A view of all the static data for configuration purposes
@@ -70,12 +71,6 @@ public:
 	DatabaseConfigView GetConfigView()
 	{
 		return buffers.buffers.GetView();
-	}
-
-	// used to clear the static selection for a new read
-	void Unselect()
-	{
-		buffers.Unselect();
 	}
 
 	// stores the most recent values, selected values, and metadata

--- a/cpp/libs/src/opendnp3/outstation/IStaticSelector.h
+++ b/cpp/libs/src/opendnp3/outstation/IStaticSelector.h
@@ -35,6 +35,8 @@ public:
 	virtual IINField SelectAll(GroupVariation gv) = 0;
 
 	virtual IINField SelectRange(GroupVariation gv, const Range& range) = 0;
+
+	virtual void Unselect() = 0;
 };
 
 }

--- a/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
+++ b/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
@@ -63,7 +63,7 @@ OContext::OContext(
 	pApplication(&application),
 	eventBuffer(config.eventBufferConfig),
 	database(dbTemplate, eventBuffer, config.params.indexMode, config.params.typesAllowedInClass0),
-	rspContext(database.buffers, eventBuffer),
+	rspContext(database.GetResponseLoader(), eventBuffer),
 	params(config.params),
 	isOnline(false),
 	isTransmitting(false),

--- a/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
+++ b/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
@@ -709,7 +709,7 @@ IINField OContext::HandleAssignClass(const openpal::RSlice& objects)
 {
 	if (this->pApplication->SupportsAssignClass())
 	{
-		AssignClassHandler handler(this->logger, *this->pExecutor, *this->pApplication, this->database.buffers);
+		AssignClassHandler handler(this->logger, *this->pExecutor, *this->pApplication, this->database.GetClassAssigner());
 		auto result = APDUParser::Parse(objects, handler, &this->logger, ParserSettings::NoContents());
 		return (result == ParseResult::OK) ? handler.Errors() : IINFromParseResult(result);
 	}

--- a/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
+++ b/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
@@ -553,7 +553,7 @@ Pair<IINField, AppControlField> OContext::HandleRead(const openpal::RSlice& obje
 	this->eventBuffer.Unselect(); // always un-select any previously selected points when we start a new read request
 	this->database.GetStaticSelector().Unselect();
 
-	ReadHandler handler(this->logger, this->database.buffers, this->eventBuffer);
+	ReadHandler handler(this->logger, this->database.GetStaticSelector(), this->eventBuffer);
 	auto result = APDUParser::Parse(objects, handler, &this->logger, ParserSettings::NoContents()); // don't expect range/count context on a READ
 	if (result == ParseResult::OK)
 	{

--- a/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
+++ b/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
@@ -551,7 +551,7 @@ Pair<IINField, AppControlField> OContext::HandleRead(const openpal::RSlice& obje
 {
 	this->rspContext.Reset();
 	this->eventBuffer.Unselect(); // always un-select any previously selected points when we start a new read request
-	this->database.Unselect();
+	this->database.GetStaticSelector().Unselect();
 
 	ReadHandler handler(this->logger, this->database.buffers, this->eventBuffer);
 	auto result = APDUParser::Parse(objects, handler, &this->logger, ParserSettings::NoContents()); // don't expect range/count context on a READ


### PR DESCRIPTION
De-couples the database implementation from the Outstation implementation.
AFAICT, this doesn't break anything. The step after this (next pull request) is a breaking change in that client code will have to create its own instance of the database. With these changes, that is not yet necessary.
