### PR TITLE
Fixed timeSyncMode parameter in MasterParams so that it only performs Time Syncs when set

### DIFF
--- a/cpp/libs/src/opendnp3/master/MasterContext.cpp
+++ b/cpp/libs/src/opendnp3/master/MasterContext.cpp
@@ -237,7 +237,13 @@ void MContext::ProcessIIN(const IINField& iin)
 
 	if (iin.IsSet(IINBit::NEED_TIME))
 	{
-		this->tasks.timeSync.Demand();
+        switch(this->params.timeSyncMode) {
+            case(TimeSyncMode::SerialTimeSync):
+		        this->tasks.timeSync.Demand();
+                break;
+            default:
+                break;
+        }
 	}
 
 	if ((iin.IsSet(IINBit::CLASS1_EVENTS) && this->params.eventScanOnEventsAvailableClassMask.HasClass1()) ||

--- a/cpp/libs/src/opendnp3/master/MasterTasks.cpp
+++ b/cpp/libs/src/opendnp3/master/MasterTasks.cpp
@@ -31,7 +31,7 @@ MasterTasks::MasterTasks(const MasterParams& params, const openpal::Logger& logg
 	assignClass(app, params.taskRetryPeriod, logger),
 	startupIntegrity(app, SOEHandler, params.startupIntegrityClassMask, params.taskRetryPeriod, logger),
 	disableUnsol(app, params.disableUnsolOnStartup, params.taskRetryPeriod, logger),
-	timeSync(app, logger),
+	timeSync(app, params.timeSyncMode, logger),
 	eventScan(app, SOEHandler, params.eventScanOnEventsAvailableClassMask, params.taskRetryPeriod, logger)
 {
 

--- a/cpp/libs/src/opendnp3/master/MasterTasks.cpp
+++ b/cpp/libs/src/opendnp3/master/MasterTasks.cpp
@@ -31,7 +31,7 @@ MasterTasks::MasterTasks(const MasterParams& params, const openpal::Logger& logg
 	assignClass(app, params.taskRetryPeriod, logger),
 	startupIntegrity(app, SOEHandler, params.startupIntegrityClassMask, params.taskRetryPeriod, logger),
 	disableUnsol(app, params.disableUnsolOnStartup, params.taskRetryPeriod, logger),
-	timeSync(app, params.timeSyncMode, logger),
+	timeSync(app, logger),
 	eventScan(app, SOEHandler, params.eventScanOnEventsAvailableClassMask, params.taskRetryPeriod, logger)
 {
 

--- a/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.cpp
+++ b/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.cpp
@@ -27,15 +27,19 @@
 
 #include <openpal/serialization/Serialization.h>
 
+#include "opendnp3/gen/TimeSyncMode.h"
+
 using namespace openpal;
 
 namespace opendnp3
 {
 
-SerialTimeSyncTask::SerialTimeSyncTask(IMasterApplication& app, openpal::Logger logger) :
+SerialTimeSyncTask::SerialTimeSyncTask(IMasterApplication& app, TimeSyncMode mode, openpal::Logger logger) :
 	IMasterTask(app, MonotonicTimestamp::Max(), logger, TaskConfig::Default()),
 	delay(-1)
-{}
+{
+    enabled = (mode == TimeSyncMode::SerialTimeSync);
+}
 
 void SerialTimeSyncTask::Initialize()
 {

--- a/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.cpp
+++ b/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.cpp
@@ -27,18 +27,16 @@
 
 #include <openpal/serialization/Serialization.h>
 
-#include "opendnp3/gen/TimeSyncMode.h"
 
 using namespace openpal;
 
 namespace opendnp3
 {
 
-SerialTimeSyncTask::SerialTimeSyncTask(IMasterApplication& app, TimeSyncMode mode, openpal::Logger logger) :
+SerialTimeSyncTask::SerialTimeSyncTask(IMasterApplication& app, openpal::Logger logger) :
 	IMasterTask(app, MonotonicTimestamp::Max(), logger, TaskConfig::Default()),
 	delay(-1)
 {
-	enabled = (mode == TimeSyncMode::SerialTimeSync);
 }
 
 void SerialTimeSyncTask::Initialize()

--- a/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.cpp
+++ b/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.cpp
@@ -38,7 +38,7 @@ SerialTimeSyncTask::SerialTimeSyncTask(IMasterApplication& app, TimeSyncMode mod
 	IMasterTask(app, MonotonicTimestamp::Max(), logger, TaskConfig::Default()),
 	delay(-1)
 {
-    enabled = (mode == TimeSyncMode::SerialTimeSync);
+	enabled = (mode == TimeSyncMode::SerialTimeSync);
 }
 
 void SerialTimeSyncTask::Initialize()

--- a/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.h
+++ b/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.h
@@ -36,7 +36,7 @@ class SerialTimeSyncTask : public IMasterTask
 {
 
 public:
-	SerialTimeSyncTask(IMasterApplication& app, TimeSyncMode mode, openpal::Logger logger);
+	SerialTimeSyncTask(IMasterApplication& app, openpal::Logger logger);
 
 	virtual char const* Name() const override final
 	{
@@ -62,7 +62,6 @@ public:
 
 private:
 
-	bool enabled;
 
 	virtual MasterTaskType GetTaskType() const override final
 	{
@@ -71,7 +70,7 @@ private:
 
 	virtual bool IsEnabled() const override
 	{
-		return enabled;
+		return true;
 	}
 
 	virtual IMasterTask::TaskState OnTaskComplete(TaskCompletion result, openpal::MonotonicTimestamp now) override final;

--- a/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.h
+++ b/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.h
@@ -62,7 +62,7 @@ public:
 
 private:
 
-    bool enabled;
+	bool enabled;
 
 	virtual MasterTaskType GetTaskType() const override final
 	{
@@ -71,7 +71,7 @@ private:
 
 	virtual bool IsEnabled() const override
 	{
-        return enabled;
+		return enabled;
 	}
 
 	virtual IMasterTask::TaskState OnTaskComplete(TaskCompletion result, openpal::MonotonicTimestamp now) override final;

--- a/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.h
+++ b/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.h
@@ -26,6 +26,8 @@
 #include "opendnp3/master/IMasterTask.h"
 #include "opendnp3/master/TaskPriority.h"
 
+#include "opendnp3/gen/TimeSyncMode.h"
+
 namespace opendnp3
 {
 
@@ -34,7 +36,7 @@ class SerialTimeSyncTask : public IMasterTask
 {
 
 public:
-	SerialTimeSyncTask(IMasterApplication& app, openpal::Logger logger);
+	SerialTimeSyncTask(IMasterApplication& app, TimeSyncMode mode, openpal::Logger logger);
 
 	virtual char const* Name() const override final
 	{
@@ -60,14 +62,16 @@ public:
 
 private:
 
+    bool enabled;
+
 	virtual MasterTaskType GetTaskType() const override final
 	{
 		return MasterTaskType::SERIAL_TIME_SYNC;
 	}
 
-	virtual bool IsEnabled() const override final
+	virtual bool IsEnabled() const override
 	{
-		return true;
+        return enabled;
 	}
 
 	virtual IMasterTask::TaskState OnTaskComplete(TaskCompletion result, openpal::MonotonicTimestamp now) override final;


### PR DESCRIPTION
The timeSyncMode parameter in MasterParams is supposed to allow a master to ignore a time sync when an outstation sets NEED_TIME in the IIN bit when set to None.  However, this parameter is never actually used or checked, and in the current implementation will always start a time sync when the NEED_TIME bit in the IIN is set. I fixed this parameter so it will only perform time syncs when the parameter is set to SerialTimeSync. 
