### PR TITLE
Changes to build under Mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,9 @@ if(DEMO)
   target_link_libraries (outstation-demo LINK_PUBLIC asiodnp3 ${PTHREAD})   
   set_target_properties(outstation-demo PROPERTIES FOLDER demos)
 
+  # When linking the demos, asiopal requires network libraries
+  target_link_libraries (asiopal LINK_PUBLIC ${NET_LIBS})
+
   if(DNP3_DECODE)
     
     # ----- decoder executable -----
@@ -167,4 +170,3 @@ if(TEST)
   add_test(testasiodnp3 testasiodnp3)  
 
 endif()
-

--- a/cmake/inc/msvc.cmake
+++ b/cmake/inc/msvc.cmake
@@ -1,4 +1,6 @@
 if (WIN32)
+    if(MSVS)
+
 		
 	add_definitions(-D_WIN32_WINNT=0x0501)
 	add_definitions(-DASIO_HAS_STD_SYSTEM_ERROR)  
@@ -8,5 +10,13 @@ if (WIN32)
 
 	set_property(GLOBAL PROPERTY USE_FOLDERS ON) #allows the creation of solution folders
 	set(LIB_TYPE STATIC) #default to static on MSVC
+    else()
+      if (MINGW)
+        add_definitions(-D_WIN32_WINNT=0x0501)
+        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+        set(LIB_TYPE STATIC) #default to static on MinGW
+      endif()
+    endif()
 endif()
 

--- a/cmake/inc/msvc.cmake
+++ b/cmake/inc/msvc.cmake
@@ -1,5 +1,5 @@
 if (WIN32)
-    if(MSVS)
+    if(MSVC)
 	add_definitions(-D_WIN32_WINNT=0x0501)
 	add_definitions(-DASIO_HAS_STD_SYSTEM_ERROR)  
 	

--- a/cmake/inc/msvc.cmake
+++ b/cmake/inc/msvc.cmake
@@ -1,7 +1,5 @@
 if (WIN32)
     if(MSVS)
-
-		
 	add_definitions(-D_WIN32_WINNT=0x0501)
 	add_definitions(-DASIO_HAS_STD_SYSTEM_ERROR)  
 	
@@ -12,10 +10,14 @@ if (WIN32)
 	set(LIB_TYPE STATIC) #default to static on MSVC
     else()
       if (MINGW)
+        # MINGW is a hybred between the Windows system and GCC compiler
         add_definitions(-D_WIN32_WINNT=0x0501)
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
         set(LIB_TYPE STATIC) #default to static on MinGW
+
+        # We need to link the demos with these
+        set(NET_LIBS "ws2_32" "wsock32") 
       endif()
     endif()
 endif()


### PR DESCRIPTION
These changes allow opendnp3 to be built with the mingw environment.  I used the mingw compiler libraries with strawberry perl to verify.
