### PR TITLE
Change `CMAKE_SOURCE_DIR` to `PROJECT_SOURCE_DIR`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(OPENDNP3_MINOR_VERSION 1)
 set(OPENDNP3_MICRO_VERSION 0)
 set(OPENDNP3_VERSION ${OPENDNP3_MAJOR_VERSION}.${OPENDNP3_MINOR_VERSION}.${OPENDNP3_MICRO_VERSION})
 
-include(${CMAKE_SOURCE_DIR}/cmake/settings.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/settings.cmake)
 
 # various optional libraries and projects
 option(DEMO "Build demo applications" OFF)


### PR DESCRIPTION
I created a new project that will use OpenDNP3. After checking-out a Git
submodule under "vendor/dnp3", I added the following lines to my CMakeLists.txt:

```
add_subdirectory(vendor/dnp3)
include_directories(vendor/dnp3/cpp/libs/include)
```

This, however, led to an error:

```
Error: include could not find load file:
    /Users/<user>/<project root>/cmake/settings.cmake
```

According to [this](http://stackoverflow.com/questions/22214349/modify-cmake-source-dir), `CMAKE_SOURCE_DIR` is always the project root,
which in this case is my project's root, not OpenDNP3's root. Changing to
`PROJECT_SOURCE_DIR` resolves this issue.
