### PR TITLE
Update build to use VS2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,8 @@ unittest.log
 
 # visual studio generated files
 ipch
+*.db
+*.opendb
 **/**/Debug
 **/**/Release
 java/Debug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ build_script:
 - cmd: MKDIR build
 - cmd: CD build
 - cmd: MKDIR lib
-- cmd: cmake .. -DCMAKE_INSTALL_PREFIX=lib -DFULL=ON -DCMAKE_BUILD_TYPE=Release
+- cmd: cmake .. -DCMAKE_INSTALL_PREFIX=lib -DDNP3_TEST=ON -DDNP3_TLS=ON -DCMAKE_BUILD_TYPE=Release
 - cmd: msbuild opendnp3.sln /p:Configuration=Release /p:Platform=Win32
 - cmd: msbuild INSTALL.vcxproj /p:Configuration=Release /p:Platform=Win32
 - cmd: cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,8 @@ version: 2.0.{build}
 branches:
   only:
   - 2.0.x
-os: Visual Studio 2013
+  - vs2015
+os: Visual Studio 2015
 configuration: Release
 platform: x86
 clone_folder: C:\projects\dnp3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,25 +8,10 @@ configuration: Release
 platform: x86
 clone_folder: C:\projects\dnp3
 environment:
-  ASIO_HOME: C:\asio\asio-1.10.6\include
   OSSL_LIB32_DIR: C:\OpenSSL-Win32\lib\VC
   OPENDNP3_DIR: C:\projects\dnp3\build\lib
 install:
-- ps: >-
-    if (-not (Test-Path C:\asio)){
-      Start-FileDownload "https://github.com/chriskohlhoff/asio/archive/asio-1-10-6.zip" -FileName asio-1-10-6.zip
-      7z x -y asio-1-10-6.zip
-      New-Item C:\asio -ItemType Directory
-      Move-Item .\asio-asio-1-10-6\asio C:\asio\asio-1.10.6
-    }
-- ps: >-
-    if (-not (Test-Path C:\OpenSSL-Win32)){
-      Start-FileDownload "https://slproweb.com/download/Win32OpenSSL-1_0_2e.exe" -FileName "Win32OpenSSL-1_0_2e.exe"
-      Start-Process "Win32OpenSSL-1_0_2e.exe" -ArgumentList "/silent /verysilent /sp- /suppressmsgboxes" -Wait
-    }
-cache:
-- C:\asio
-- C:\OpenSSL-Win32
+- git submodule update --init --recursive
 build_script:
 - cmd: MKDIR build
 - cmd: CD build

--- a/build-dotnet.bat
+++ b/build-dotnet.bat
@@ -5,7 +5,7 @@ SETLOCAL
 SET CONFIGURATION=Release
 IF NOT [%1]==[] (SET CONFIGURATION=%1)
 SET PLATFORM=Win32
-IF NOT [%2]==[] (SET PLATFORM=%1)
+IF NOT [%2]==[] (SET PLATFORM=%2)
 
 where cmake 1>nul
 IF ERRORLEVEL 1 (
@@ -20,19 +20,19 @@ IF ["%OSSL_LIB32_DIR%"]==[] (
 	ECHO OpenSSL could not be found
 	GOTO :QUIT
 )
-IF ["%VS120COMNTOOLS%"]==[] (
-	ECHO VS2013 could not be found
+IF ["%VS140COMNTOOLS%"]==[] (
+	ECHO VS2015 could not be found
 	GOTO: QUIT
 )
 
 :BUILD
-CALL "%VS120COMNTOOLS%VsDevCmd.bat"
+CALL "%VS140COMNTOOLS%VsDevCmd.bat"
 
 IF EXIST build RMDIR build /s /q
 MKDIR build\lib
 CD build
 
-cmake .. -DCMAKE_INSTALL_PREFIX=lib -DFULL=ON -DCMAKE_BUILD_TYPE=%CONFIGURATION% -G"Visual Studio 12 2013"
+cmake .. -DCMAKE_INSTALL_PREFIX=lib -DFULL=ON -DCMAKE_BUILD_TYPE=%CONFIGURATION% -G"Visual Studio 14 2015"
 msbuild opendnp3.sln /p:Configuration=%CONFIGURATION% /p:Platform=%PLATFORM%
 msbuild INSTALL.vcxproj /p:Configuration=%CONFIGURATION% /p:Platform=%PLATFORM%
 msbuild ..\dotnet\bindings.sln /target:Clean

--- a/build-dotnet.bat
+++ b/build-dotnet.bat
@@ -12,10 +12,6 @@ IF ERRORLEVEL 1 (
 	ECHO cmake could not be found
 	GOTO :QUIT
 )
-IF ["%ASIO_HOME%"]==[] (
-	ECHO ASIO could not be found
-	GOTO :QUIT
-)
 IF ["%OSSL_LIB32_DIR%"]==[] (
 	ECHO OpenSSL could not be found
 	GOTO :QUIT

--- a/build-dotnet.bat
+++ b/build-dotnet.bat
@@ -28,7 +28,7 @@ IF EXIST build RMDIR build /s /q
 MKDIR build\lib
 CD build
 
-cmake .. -DCMAKE_INSTALL_PREFIX=lib -DFULL=ON -DCMAKE_BUILD_TYPE=%CONFIGURATION% -G"Visual Studio 14 2015"
+cmake .. -DCMAKE_INSTALL_PREFIX=lib -DDNP3_TEST=ON -DDNP3_TLS=ON -DCMAKE_BUILD_TYPE=%CONFIGURATION% -G"Visual Studio 14 2015"
 msbuild opendnp3.sln /p:Configuration=%CONFIGURATION% /p:Platform=%PLATFORM%
 msbuild INSTALL.vcxproj /p:Configuration=%CONFIGURATION% /p:Platform=%PLATFORM%
 msbuild ..\dotnet\bindings.sln /target:Clean

--- a/dotnet/bindings.sln
+++ b/dotnet/bindings.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "bindings", "bindings", "{DB6D1D7E-C26B-45B2-9189-480985D8927B}"
 EndProject

--- a/dotnet/bindings/CLRAdapter/CLRAdapter.vcxproj
+++ b/dotnet/bindings/CLRAdapter/CLRAdapter.vcxproj
@@ -107,7 +107,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;shell32.lib;advapi32.lib;gdi32.lib;User32.lib;$(OPENDNP3_DIR)\lib\asiodnp3.lib;$(OPENDNP3_DIR)\lib\asiopal.lib;$(OPENDNP3_DIR)\lib\opendnp3.lib;$(OPENDNP3_DIR)\lib\openpal.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;shell32.lib;legacy_stdio_definitions.lib;advapi32.lib;gdi32.lib;User32.lib;$(OPENDNP3_DIR)\lib\asiodnp3.lib;$(OPENDNP3_DIR)\lib\asiopal.lib;$(OPENDNP3_DIR)\lib\opendnp3.lib;$(OPENDNP3_DIR)\lib\openpal.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -119,7 +119,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;shell32.lib;advapi32.lib;gdi32.lib;User32.lib;$(OPENDNP3_DIR)\lib\asiodnp3.lib;$(OPENDNP3_DIR)\lib\asiopal.lib;$(OPENDNP3_DIR)\lib\opendnp3.lib;$(OPENDNP3_DIR)\lib\openpal.lib;$(OPENDNP3_DIR)\lib\osslcrypto.lib;$(OPENDNP3_DIR)\lib\secauth.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;shell32.lib;legacy_stdio_definitions.lib;advapi32.lib;gdi32.lib;User32.lib;$(OPENDNP3_DIR)\lib\asiodnp3.lib;$(OPENDNP3_DIR)\lib\asiopal.lib;$(OPENDNP3_DIR)\lib\opendnp3.lib;$(OPENDNP3_DIR)\lib\openpal.lib;$(OPENDNP3_DIR)\lib\osslcrypto.lib;$(OPENDNP3_DIR)\lib\secauth.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -130,7 +130,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;shell32.lib;advapi32.lib;gdi32.lib;User32.lib;$(OPENDNP3_DIR)\lib\asiodnp3.lib;$(OPENDNP3_DIR)\lib\asiopal.lib;$(OPENDNP3_DIR)\lib\opendnp3.lib;$(OPENDNP3_DIR)\lib\openpal.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;shell32.lib;legacy_stdio_definitions.lib;advapi32.lib;gdi32.lib;User32.lib;$(OPENDNP3_DIR)\lib\asiodnp3.lib;$(OPENDNP3_DIR)\lib\asiopal.lib;$(OPENDNP3_DIR)\lib\opendnp3.lib;$(OPENDNP3_DIR)\lib\openpal.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -141,7 +141,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>ws2_32.lib;shell32.lib;advapi32.lib;gdi32.lib;User32.lib;$(OPENDNP3_DIR)\lib\asiodnp3.lib;$(OPENDNP3_DIR)\lib\asiopal.lib;$(OPENDNP3_DIR)\lib\opendnp3.lib;$(OPENDNP3_DIR)\lib\openpal.lib;$(OPENDNP3_DIR)\lib\osslcrypto.lib;$(OPENDNP3_DIR)\lib\secauth.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;shell32.lib;legacy_stdio_definitions.lib;advapi32.lib;gdi32.lib;User32.lib;$(OPENDNP3_DIR)\lib\asiodnp3.lib;$(OPENDNP3_DIR)\lib\asiopal.lib;$(OPENDNP3_DIR)\lib\opendnp3.lib;$(OPENDNP3_DIR)\lib\openpal.lib;$(OPENDNP3_DIR)\lib\osslcrypto.lib;$(OPENDNP3_DIR)\lib\secauth.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -197,6 +197,7 @@
     <ClCompile Include="src\OutstationCommandHandlerAdapter.cpp" />
     <ClCompile Include="src\SessionAcceptorAdapter.cpp" />
     <ClCompile Include="src\SOEHandlerAdapter.cpp" />
+    <ClCompile Include="src\StdIOWorkaround.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="ReadMe.txt" />

--- a/dotnet/bindings/CLRAdapter/CLRAdapter.vcxproj.filters
+++ b/dotnet/bindings/CLRAdapter/CLRAdapter.vcxproj.filters
@@ -152,6 +152,9 @@
     <ClCompile Include="src\MasterAdapter.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\StdIOWorkaround.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Text Include="ReadMe.txt" />

--- a/dotnet/bindings/CLRAdapter/src/StdIOWorkaround.cpp
+++ b/dotnet/bindings/CLRAdapter/src/StdIOWorkaround.cpp
@@ -1,0 +1,13 @@
+
+#include "StdIOWorkaround.h"
+
+#if (_MSC_VER >= 1900)
+
+FILE _iob[] = { *stdin, *stdout, *stderr };
+
+extern "C" FILE * __cdecl __iob_func(void)
+{
+	return _iob;
+}
+
+#endif

--- a/dotnet/bindings/CLRAdapter/src/StdIOWorkaround.h
+++ b/dotnet/bindings/CLRAdapter/src/StdIOWorkaround.h
@@ -1,0 +1,13 @@
+
+
+#if (_MSC_VER >= 1900)
+
+/*
+http://stackoverflow.com/questions/30412951/unresolved-external-symbol-imp-fprintf-and-imp-iob-func-sdl2
+*/
+
+#include <cstdio>
+
+extern "C" FILE * __cdecl __iob_func(void);
+
+#endif

--- a/dotnet/bindings/CLRInterface/DNP3CLRInterface.csproj
+++ b/dotnet/bindings/CLRInterface/DNP3CLRInterface.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/dotnet/examples/master-gprs-tls/CLRMasterGPRSTLSDemo.csproj
+++ b/dotnet/examples/master-gprs-tls/CLRMasterGPRSTLSDemo.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/dotnet/examples/master-gprs/CLRMasterGPRSDemo.csproj
+++ b/dotnet/examples/master-gprs/CLRMasterGPRSDemo.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/dotnet/examples/master/CLRMasterDemo.csproj
+++ b/dotnet/examples/master/CLRMasterDemo.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/dotnet/examples/outstation/CLROutstationDemo.csproj
+++ b/dotnet/examples/outstation/CLROutstationDemo.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
Includes updating appveyor.yml.

ASIO is now a submodule so updated to init submodules during install, replacing the download step.
OpenSSL is already installed on the build worker, so download step now redundant.

Will need clean-up to remove vs2015 branch from appveyor.yml.
