### PR TITLE
Set OPENDNP3_DIR in build-dotnet.bat

### DIFF
--- a/build-dotnet.bat
+++ b/build-dotnet.bat
@@ -16,10 +16,12 @@ IF ["%OSSL_LIB32_DIR%"]==[] (
 	ECHO OpenSSL could not be found
 	GOTO :QUIT
 )
+ECHO OSSL_LIB32_DIR is %OSSL_LIB32_DIR%
 IF ["%VS140COMNTOOLS%"]==[] (
 	ECHO VS2015 could not be found
 	GOTO: QUIT
 )
+ECHO VS140COMNTOOLS is %VS140COMNTOOLS%
 
 :BUILD
 CALL "%VS140COMNTOOLS%VsDevCmd.bat"
@@ -27,6 +29,9 @@ CALL "%VS140COMNTOOLS%VsDevCmd.bat"
 IF EXIST build RMDIR build /s /q
 MKDIR build\lib
 CD build
+
+SET OPENDNP3_DIR=%CD%\lib
+ECHO OPENDNP3_DIR is %OPENDNP3_DIR%
 
 cmake .. -DCMAKE_INSTALL_PREFIX=lib -DDNP3_TEST=ON -DDNP3_TLS=ON -DCMAKE_BUILD_TYPE=%CONFIGURATION% -G"Visual Studio 14 2015"
 msbuild opendnp3.sln /p:Configuration=%CONFIGURATION% /p:Platform=%PLATFORM%


### PR DESCRIPTION
Setting the OPENDNP3_DIR environment variable appeared to fix the build for me. Possibly not the error you were seeing though as I was seeing the same errors when building in VS2015 due to the environment variable not being set.