### PR TITLE
Added the maven release plugin to the main pom.xml.

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -57,6 +57,11 @@
             <name>Sonatype Snapshots</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
+		<repository>
+			<id>percival</id>
+			<name>Percival Nexus</name>
+			<url>http://nexus.percivaleng.com:8081/nexus/repository/maven-public</url>
+		</repository>
     </distributionManagement>
 	
 	<repositories>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -58,6 +58,14 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
+	
+	<repositories>
+        <repository>
+            <id>percival</id>
+            <name>Percival Nexus</name>
+            <url>http://nexus.percivaleng.com:8081/nexus/repository/maven-public</url>
+        </repository>
+    </repositories>
 
 
     <build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.automatak.dnp3</groupId>
     <artifactId>opendnp3-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0-Windows-VS15</version>
     <packaging>pom</packaging>
 
     <name>opendnp3</name>
@@ -24,7 +24,7 @@
         <maven-scala.plugin.version>3.1.3</maven-scala.plugin.version>
         <scala.version>2.11.8</scala.version>
         <maven-source-plugin.version>2.1.2</maven-source-plugin.version>
-        <opendnp3.version>2.2.0-SNAPSHOT</opendnp3.version>
+        <opendnp3.version>${version}</opendnp3.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <surefire-plugin.version>2.12.4</surefire-plugin.version>
     </properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -39,7 +39,8 @@
 
     <scm>
         <url>https://github.com/automatak/dnp3.git</url>
-        <connection></connection>
+        <connection>scm:git:https://github.com/automatak/dnp3.git</connection>
+		<developerConnection>scm:git:https://github.com/automatak/dnp3.git</developerConnection>
     </scm>
 
     <developers>
@@ -83,7 +84,7 @@
                 <configuration>
                     <strictCheck>true</strictCheck>
                     <failIfMissing>true</failIfMissing>
-                    <header>AUTOMATAK_FILE_HEADER</header>
+                    <header>${session.executionRootDirectory}\AUTOMATAK_FILE_HEADER</header>
                     <mapping>
                         <h>SLASHSTAR_STYLE</h>
                         <hpp>SLASHSTAR_STYLE</hpp>
@@ -193,7 +194,19 @@
                     <useFile>false</useFile>
                 </configuration>
             </plugin>
-        </plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-scm-plugin</artifactId>
+				<version>1.9.5</version>				
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>2.5.3</version>				
+			</plugin>
+			
+			
+    </plugins>
 
     </build>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -63,14 +63,6 @@
 			<url>http://nexus.percivaleng.com:8081/nexus/repository/maven-public</url>
 		</repository>
     </distributionManagement>
-	
-	<repositories>
-        <repository>
-            <id>percival</id>
-            <name>Percival Nexus</name>
-            <url>http://nexus.percivaleng.com:8081/nexus/repository/maven-public</url>
-        </repository>
-    </repositories>
 
 
     <build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.automatak.dnp3</groupId>
     <artifactId>opendnp3-parent</artifactId>
-    <version>2.2.0-Windows-VS15</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>opendnp3</name>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -56,12 +56,7 @@
             <id>sonatype-snapshots</id>
             <name>Sonatype Snapshots</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-		<repository>
-			<id>percival</id>
-			<name>Percival Nexus</name>
-			<url>http://nexus.percivaleng.com:8081/nexus/repository/maven-public</url>
-		</repository>
+        </snapshotRepository>		
     </distributionManagement>
 
 


### PR DESCRIPTION
Added the maven release plugin.  This will make it very easy to cut a release in the future.  mvn release:deploy

It will remove the snapshot label from the version, commit the release as a tag, then update the version string to the next snapshot version.