### PR TITLE
Fixes undefined #define when using OPENPAL_STRIP_LOGGING

### DIFF
--- a/cpp/libs/include/asiopal/LoggingConnectionCondition.h
+++ b/cpp/libs/include/asiopal/LoggingConnectionCondition.h
@@ -21,6 +21,7 @@
 #ifndef ASIOPAL_LOGGING_CONNECTION_CONDITION_H
 #define ASIOPAL_LOGGING_CONNECTION_CONDITION_H
 
+#include <openpal/logging/Logger.h>
 #include <openpal/logging/LogMacros.h>
 #include <openpal/logging/LogLevels.h>
 

--- a/cpp/libs/include/openpal/logging/LogMacros.h
+++ b/cpp/libs/include/openpal/logging/LogMacros.h
@@ -76,13 +76,13 @@
 
 #define SAFE_STRING_FORMAT(dest, size, format, ...)
 
-#define SIMPLE_LOG_BLOCK_WITH_CODE(logger, filters, message)
+#define SIMPLE_LOG_BLOCK(logger, filters, message)
 
-#define SIMPLE_LOGGER_BLOCK_WITH_CODE(pLogger, filters, message)
+#define SIMPLE_LOGGER_BLOCK(pLogger, filters, message)
 
-#define FORMAT_LOG_BLOCK_WITH_CODE(logger, filters, format, ...)
+#define FORMAT_LOG_BLOCK(logger, filters, format, ...)
 
-#define FORMAT_LOGGER_BLOCK_WITH_CODE(pLogger, filters, format, ...)
+#define FORMAT_LOGGER_BLOCK(pLogger, filters, format, ...)
 
 #define FORMAT_HEX_BLOCK(logger, filters, buffer, firstSize, otherSize)
 


### PR DESCRIPTION
When using the OPENPAL_STRIP_LOGGING define, there are inconsistencies in the defines leading to a compilation error. This bug was introduced in commit e9c2ec4447e6e2d56d66ac86e4aaef1e0d523c9d where the renaming was not done properly.

I also added a missing include of Logger.h in asiopal. Otherwise, the code won't compile with OPENPAL_STRIP_LOGGING.