### PR TITLE
Use only distributed headers in outstation example

### DIFF
--- a/cpp/examples/outstation/main.cpp
+++ b/cpp/examples/outstation/main.cpp
@@ -27,7 +27,7 @@
 #include <asiopal/UTCTimeSource.h>
 #include <opendnp3/outstation/SimpleCommandHandler.h>
 
-#include <opendnp3/outstation/Database.h>
+#include <opendnp3/outstation/IUpdateHandler.h>
 
 #include <opendnp3/LogLevels.h>
 


### PR DESCRIPTION
Probably need to fix in other places too