### PR TITLE
Add '#include <string>' to ErrorCodes.cpp to allow successful compilation on OSX

### DIFF
--- a/cpp/libs/include/asiodnp3/ErrorCodes.h
+++ b/cpp/libs/include/asiodnp3/ErrorCodes.h
@@ -23,6 +23,7 @@
 #define ASIODNP3_ERRORCODES_H
 
 #include <system_error>
+#include <string>
 
 
 namespace asiodnp3

--- a/cpp/libs/src/asiodnp3/ErrorCodes.cpp
+++ b/cpp/libs/src/asiodnp3/ErrorCodes.cpp
@@ -19,7 +19,6 @@
  * to you under the terms of the License.
  */
 
-#include <string>
 #include "asiodnp3/ErrorCodes.h"
 
 namespace asiodnp3

--- a/cpp/libs/src/asiodnp3/ErrorCodes.cpp
+++ b/cpp/libs/src/asiodnp3/ErrorCodes.cpp
@@ -19,6 +19,7 @@
  * to you under the terms of the License.
  */
 
+#include <string>
 #include "asiodnp3/ErrorCodes.h"
 
 namespace asiodnp3


### PR DESCRIPTION
Here is the compiler error I get without this change:

dnp3/cpp/libs/src/asiodnp3/ErrorCodes.cpp:29:28: error: implicit instantiation of undefined
      template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
std::string ErrorCategory::message(int ev) const
                           ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/iosfwd:193:60: note:
      template is declared here
    class __attribute__ ((__type_visibility__("default"))) basic_string;