### PR TITLE
C# Master leaks memory when calling Shutdown() and re-creating.

### DIFF
--- a/dotnet/bindings/CLRAdapter/src/DNP3ManagerAdapter.cpp
+++ b/dotnet/bindings/CLRAdapter/src/DNP3ManagerAdapter.cpp
@@ -36,9 +36,14 @@ namespace Automatak
 
 			}
 
-			DNP3ManagerAdapter::~DNP3ManagerAdapter()
+			DNP3ManagerAdapter::!DNP3ManagerAdapter()
 			{
 				delete manager;				
+			}
+
+			DNP3ManagerAdapter::~DNP3ManagerAdapter()
+			{
+				this->!DNP3ManagerAdapter();				
 			}
 
 			void DNP3ManagerAdapter::Shutdown()

--- a/dotnet/bindings/CLRAdapter/src/DNP3ManagerAdapter.h
+++ b/dotnet/bindings/CLRAdapter/src/DNP3ManagerAdapter.h
@@ -49,6 +49,7 @@ namespace Automatak
 			public:
 
 				DNP3ManagerAdapter(System::Int32 concurrency, ILogHandler^ logHandler);
+				!DNP3ManagerAdapter();
 				~DNP3ManagerAdapter();
 
 				virtual void Shutdown() sealed;				


### PR DESCRIPTION
Added a finalizer to .NET wrapper manager due to a memory leak when releasing manager resources.
#215