### PR TITLE
2.0.x

### DIFF
--- a/cpp/libs/src/asiodnp3/DNP3Channel.cpp
+++ b/cpp/libs/src/asiodnp3/DNP3Channel.cpp
@@ -136,7 +136,7 @@ template <class T>
 std::shared_ptr<T> DNP3Channel::AddStack(const LinkConfig& link, const std::shared_ptr<T>& stack)
 {
 
-	auto create = [stack, route = Route(link.RemoteAddr, link.LocalAddr), self = this->shared_from_this()]()
+	auto create = [stack, &link, this, route = Route(link.RemoteAddr, link.LocalAddr), self = this->shared_from_this()]()
 	{
 
 		auto add = [stack, route, self]() -> bool

--- a/cpp/libs/src/opendnp3/master/TaskBehavior.cpp
+++ b/cpp/libs/src/opendnp3/master/TaskBehavior.cpp
@@ -92,11 +92,11 @@ TaskBehavior::TaskBehavior(
     const openpal::MonotonicTimestamp& startExpiration
 ) :
 	period(period),
-	expiration(expiration),
 	minRetryDelay(minRetryDelay),
 	maxRetryDelay(maxRetryDelay),
-	currentRetryDelay(minRetryDelay),
-	startExpiration(startExpiration)
+	startExpiration(startExpiration),
+	expiration(expiration),
+	currentRetryDelay(minRetryDelay)
 {}
 
 


### PR DESCRIPTION
Ran into the following minor issues when trying to compile on clang/llvm in Xcode.
clang-602.0.49 - based on LLVM 3.6.0svn
 - implicit lambda capture error
 - member initialisation order warning