### PR TITLE
Add optional support for the serial port locking mechanism.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ option(WERROR "Set all warnings to errors" OFF)
 option(STATICLIBS "Builds static versions of all installed libraries" OFF)
 option(COVERAGE "Builds the libraries with coverage info for gcov (gcc only)" OFF)
 option(PROFILE "Builds the libraries with profiling support (gcc only)" OFF)
+option(FLOCK "Builds the libraries with lock serial port (flock, Linux and BSD)" OFF)
 
 if(DNP3_ALL)
 	message("enabling all optional components")
@@ -128,6 +129,10 @@ endif()
 target_link_libraries(asiopal ${asiopal_link_libraries})
 install(TARGETS asiopal DESTINATION lib)
 set_target_properties(asiopal PROPERTIES FOLDER libs VERSION ${OPENDNP3_VERSION} SOVERSION ${OPENDNP3_MAJOR_VERSION})
+
+if(FLOCK)
+  add_definitions(-DUSE_FLOCK)
+endif()
 
 # ---- asiodnp3 library ----
 file(GLOB_RECURSE asiodnp3_HPP ./cpp/libs/src/asiodnp3/*.h ./cpp/libs/include/asiodnp3/*.h)


### PR DESCRIPTION
Uses flock function (see: http://man7.org/linux/man-pages/man2/flock.2.html)
To compile the code with it, you have to set 'FLOCK' option as 'on'
for example: cmake CMakeLists.txt -DFLOCK=on .