### PR TITLE
Add session empty check before calling Shutdown

### DIFF
--- a/cpp/libs/src/asiodnp3/MasterSessionStack.cpp
+++ b/cpp/libs/src/asiodnp3/MasterSessionStack.cpp
@@ -98,6 +98,8 @@ void MasterSessionStack::SetLogFilters(const openpal::LogFilters& filters)
 
 void MasterSessionStack::BeginShutdown()
 {
+	if(!session) return;
+
 	auto shutdown = [session = session]()
 	{
 		session->Shutdown();


### PR DESCRIPTION
Fixes #251 

I'm not sure if this will fix all scenarios, especially in multi-threaded environments, however it did fix the issue with my basic repro of the issue.