### PR TITLE
EventLists::IsAnyTypeFull properly returns false when buffer of 0 capacity is updated.

### DIFF
--- a/cpp/libs/src/opendnp3/outstation/event/EventBuffer.cpp
+++ b/cpp/libs/src/opendnp3/outstation/event/EventBuffer.cpp
@@ -233,28 +233,4 @@ void EventBuffer::ClearWritten()
 	this->storage.ClearWritten();
 }
 
-/*
-bool EventBuffer::IsTypeOverflown(EventType type) const
-{
-	auto max = config.GetMaxEventsForType(type);
-	return  (max > 0) ? (totalCounts.NumOfType(type) >= max) : false;
-}
-
-bool EventBuffer::IsAnyTypeOverflown() const
-{
-	return	IsTypeOverflown(EventType::Binary) ||
-	        IsTypeOverflown(EventType::DoubleBitBinary) ||
-	        IsTypeOverflown(EventType::BinaryOutputStatus) ||
-	        IsTypeOverflown(EventType::Counter) ||
-	        IsTypeOverflown(EventType::FrozenCounter) ||
-	        IsTypeOverflown(EventType::Analog) ||
-	        IsTypeOverflown(EventType::AnalogOutputStatus);
-}
-
-bool EventBuffer::HasEnoughSpaceToClearOverflow() const
-{
-	return !(events.IsFull() || IsAnyTypeOverflown());
-}
-*/
-
 }

--- a/cpp/libs/src/opendnp3/outstation/event/EventLists.cpp
+++ b/cpp/libs/src/opendnp3/outstation/event/EventLists.cpp
@@ -39,14 +39,14 @@ EventLists::EventLists(const EventBufferConfig& config) :
 bool EventLists::IsAnyTypeFull() const
 {
 	return
-	    this->binary.IsFull() ||
-	    this->doubleBinary.IsFull() ||
-	    this->counter.IsFull() ||
-	    this->frozenCounter.IsFull() ||
-	    this->analog.IsFull() ||
-	    this->binaryOutputStatus.IsFull() ||
-	    this->analogOutputStatus.IsFull() ||
-	    this->octetString.IsFull();
+	    this->binary.IsFullAndCapacityNotZero() ||
+	    this->doubleBinary.IsFullAndCapacityNotZero() ||
+	    this->counter.IsFullAndCapacityNotZero() ||
+	    this->frozenCounter.IsFullAndCapacityNotZero() ||
+	    this->analog.IsFullAndCapacityNotZero() ||
+	    this->binaryOutputStatus.IsFullAndCapacityNotZero() ||
+	    this->analogOutputStatus.IsFullAndCapacityNotZero() ||
+	    this->octetString.IsFullAndCapacityNotZero();
 }
 
 template <>

--- a/cpp/libs/src/opendnp3/outstation/event/EventUpdate.h
+++ b/cpp/libs/src/opendnp3/outstation/event/EventUpdate.h
@@ -46,7 +46,7 @@ bool EventUpdate::Update(EventLists& lists, const Event<T>& event)
 	bool overflow = false;
 
 
-	if (list.IsFull())
+	if (list.IsFullAndCapacityNotZero())
 	{
 		// we must make space
 

--- a/cpp/libs/src/opendnp3/outstation/event/List.h
+++ b/cpp/libs/src/opendnp3/outstation/event/List.h
@@ -259,7 +259,7 @@ void List<T>::Remove(Node<T>* node)
 template <class T>
 bool List<T>::IsFull() const
 {
-	return !(this->free);
+	return Capacity() > 0 && !(this->free);
 }
 
 template <class T>

--- a/cpp/libs/src/opendnp3/outstation/event/List.h
+++ b/cpp/libs/src/opendnp3/outstation/event/List.h
@@ -130,7 +130,7 @@ public:
 
 	void Remove(Node<T>* node);
 
-	inline bool IsFull() const;
+	inline bool IsFullAndCapacityNotZero() const;
 
 private:
 
@@ -257,9 +257,9 @@ void List<T>::Remove(Node<T>* node)
 }
 
 template <class T>
-bool List<T>::IsFull() const
+bool List<T>::IsFullAndCapacityNotZero() const
 {
-	return Capacity() > 0 && !(this->free);
+	return !(this->free) && Capacity() > 0;
 }
 
 template <class T>

--- a/cpp/tests/opendnp3/src/TestEventStorage.cpp
+++ b/cpp/tests/opendnp3/src/TestEventStorage.cpp
@@ -126,6 +126,10 @@ TEST_CASE(SUITE("zero-size doesn't overflow"))
 	REQUIRE_FALSE(
 	    storage.Update(Event<AnalogSpec>(Analog(1.0), 0, EventClass::EC1, EventAnalogVariation::Group32Var1))
 	);
+
+	REQUIRE_FALSE(storage.IsAnyTypeFull());
+	REQUIRE(storage.NumUnwritten(EventClass::EC1) == 0);
+	REQUIRE(storage.NumSelected() == 0);
 }
 
 TEST_CASE(SUITE("overflows as expected"))
@@ -133,12 +137,14 @@ TEST_CASE(SUITE("overflows as expected"))
 	EventStorage storage(EventBufferConfig::AllTypes(1));
 
 	REQUIRE(storage.NumUnwritten(EventClass::EC1) == 0);
+	REQUIRE_FALSE(storage.IsAnyTypeFull());
 
 	REQUIRE_FALSE(
 	    storage.Update(Event<AnalogSpec>(Analog(1.0), 0, EventClass::EC1, EventAnalogVariation::Group32Var1))
 	);
 
 	REQUIRE(storage.NumUnwritten(EventClass::EC1) == 1);
+	REQUIRE(storage.IsAnyTypeFull());
 	REQUIRE(storage.NumSelected() == 0);
 
 	REQUIRE(

--- a/cpp/tests/opendnp3/src/TestList.cpp
+++ b/cpp/tests/opendnp3/src/TestList.cpp
@@ -31,7 +31,7 @@ TEST_CASE(SUITE("CorrectInitialState"))
 	List<int> list(3);
 
 	REQUIRE(list.IsEmpty());
-	REQUIRE(!list.IsFull());
+	REQUIRE(!list.IsFullAndCapacityNotZero());
 	REQUIRE(0 == list.Size());
 }
 
@@ -43,19 +43,19 @@ TEST_CASE(SUITE("AddsUntilFull"))
 	REQUIRE(list.Add(2));
 	REQUIRE(list.Add(3));
 
-	REQUIRE(list.IsFull());
+	REQUIRE(list.IsFullAndCapacityNotZero());
 
 	// adding to a full list returns a nullptr
 	REQUIRE_FALSE(list.Add(4));
 }
 
-TEST_CASE(SUITE("IsFull for list of capacity 0 return false"))
+TEST_CASE(SUITE("IsFullAndCapacityNotZero for list of capacity 0 return false"))
 {
 	List<int> list(0);
 
 	REQUIRE_FALSE(list.Add(1));
 
-	REQUIRE_FALSE(list.IsFull());
+	REQUIRE_FALSE(list.IsFullAndCapacityNotZero());
 }
 
 TEST_CASE(SUITE("CanRemoveHead"))

--- a/cpp/tests/opendnp3/src/TestList.cpp
+++ b/cpp/tests/opendnp3/src/TestList.cpp
@@ -49,6 +49,15 @@ TEST_CASE(SUITE("AddsUntilFull"))
 	REQUIRE_FALSE(list.Add(4));
 }
 
+TEST_CASE(SUITE("IsFull for list of capacity 0 return false"))
+{
+	List<int> list(0);
+
+	REQUIRE_FALSE(list.Add(1));
+
+	REQUIRE_FALSE(list.IsFull());
+}
+
 TEST_CASE(SUITE("CanRemoveHead"))
 {
 	List<int> list(3);


### PR DESCRIPTION
Fix #255.

Added test case in `EventStorage` and in `List`.