### PR TITLE
Removed access violation if IMasterSession is shutdown twice.

### DIFF
--- a/cpp/libs/src/asiodnp3/MasterSessionStack.cpp
+++ b/cpp/libs/src/asiodnp3/MasterSessionStack.cpp
@@ -97,12 +97,18 @@ void MasterSessionStack::BeginShutdown()
 {
 	auto shutdown = [this]()
 	{
-		scheduler->Shutdown();
-		scheduler.reset();
+		if (scheduler)
+		{
+			scheduler->Shutdown();
+			scheduler.reset();
+		}
 
 		// now we can release the socket session
-		session->Shutdown();
-		session.reset();
+		if (session)
+		{
+			session->Shutdown();
+			session.reset();
+		}
 	};
 
 	executor->strand.post(shutdown);

--- a/cpp/libs/src/opendnp3/master/MasterSchedulerBackend.cpp
+++ b/cpp/libs/src/opendnp3/master/MasterSchedulerBackend.cpp
@@ -55,6 +55,8 @@ void MasterSchedulerBackend::Add(const std::shared_ptr<IMasterTask>& task, IMast
 
 void MasterSchedulerBackend::SetRunnerOffline(const IMasterTaskRunner& runner)
 {
+	if (this->isShutdown) return;
+
 	const auto now = this->executor->GetTime();
 
 	auto checkForOwnership = [now, &runner](const Record & record) -> bool

--- a/cpp/tests/asiodnp3/src/TestMasterServerSmoke.cpp
+++ b/cpp/tests/asiodnp3/src/TestMasterServerSmoke.cpp
@@ -33,6 +33,7 @@
 #include "asiodnp3/ConsoleLogger.h"
 #include "dnp3mocks/NullSOEHandler.h"
 
+#include <atomic>
 #include <thread>
 
 using namespace opendnp3;
@@ -90,4 +91,73 @@ TEST_CASE(SUITE("ConstructionDestruction"))
 		if (ec) throw std::logic_error(ec.message());
 		components.Enable();
 	}
+}
+
+class DoubleShutdownListenCallbacks final : public IListenCallbacks
+{
+public:
+	bool AcceptConnection(uint64_t sessionid, const std::string& ipaddress) override
+	{
+		return true;
+	}
+
+	bool AcceptCertificate(uint64_t sessionid, const X509Info& info) override
+	{
+		return true;
+	}
+
+	openpal::TimeDuration GetFirstFrameTimeout() override
+	{
+		return openpal::TimeDuration::Seconds(30);
+	}
+
+	void OnFirstFrame(uint64_t sessionid, const opendnp3::LinkHeaderFields& header, ISessionAcceptor& acceptor) override
+	{
+		MasterStackConfig config;
+		config.link.LocalAddr = header.dest;
+		config.link.RemoteAddr = header.src;
+		auto soe = std::make_shared<PrintingSOEHandler>();
+		auto app = std::make_shared<DefaultMasterApplication>();
+
+		auto masterSession = acceptor.AcceptSession(std::to_string(sessionid), soe, app, config);
+
+		// Double shutdown behaviour here
+		hasDoubleShutdown = true;
+		masterSession->BeginShutdown();
+		masterSession->BeginShutdown();
+	}
+
+	void OnConnectionClose(uint64_t sessionid, const std::shared_ptr<IMasterSession>& session) override {}
+	void OnCertificateError(uint64_t sessionid, const X509Info& info, int error) override {}
+
+	void waitForDoubleShutdown()
+	{
+		while(!hasDoubleShutdown)
+		{
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+		}
+	}
+
+private:
+	std::atomic<bool> hasDoubleShutdown = false;
+};
+
+TEST_CASE(SUITE("Double BeginShutdown"))
+{
+	DNP3Manager manager(std::thread::hardware_concurrency());
+
+	// Master listener creation
+	std::error_code ec;
+	auto listenCallbacks = std::make_shared<DoubleShutdownListenCallbacks>();
+	auto listener = manager.CreateListener("listener", levels::ALL, IPEndpoint::Localhost(20000), listenCallbacks, ec);
+
+	// Outstation
+	OutstationStackConfig outstationConfig(DatabaseSizes::Empty());
+	outstationConfig.outstation.params.allowUnsolicited = true;
+	auto channel = manager.AddTCPClient("client", levels::ALL, ChannelRetry::Default(), "127.0.0.1", "", 20000, nullptr);
+	auto outstation = channel->AddOutstation("outstation", SuccessCommandHandler::Create(), DefaultOutstationApplication::Create(), outstationConfig);
+
+	outstation->Enable();
+
+	listenCallbacks->waitForDoubleShutdown();
 }


### PR DESCRIPTION
Fix #251. I added a test case that reproduced the issue in `TestMasterServerSmoke`.