### PR TITLE
Fixed Java getStatistics binding.

### DIFF
--- a/java/bindings/src/test/java/com/automatak/dnp3/impl/StackStatisticsTest.java
+++ b/java/bindings/src/test/java/com/automatak/dnp3/impl/StackStatisticsTest.java
@@ -1,0 +1,78 @@
+package com.automatak.dnp3.impl;
+
+/**
+ * Copyright 2013-2016 Automatak, LLC
+ *
+ * Licensed to Automatak, LLC (www.automatak.com) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. Automatak, LLC
+ * licenses this file to you under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import com.automatak.dnp3.*;
+import com.automatak.dnp3.impl.mocks.NullLogHandler;
+import com.automatak.dnp3.mock.*;
+import junit.framework.TestCase;
+import org.junit.Test;
+
+public class StackStatisticsTest extends TestCase {
+
+    @Test
+    public void testGetMasterStatistics() throws DNP3Exception {
+        DNP3Manager manager = DNP3ManagerFactory.createManager(4, new NullLogHandler());
+
+        Channel channel = manager.addTCPClient(
+                "client",
+                LogMasks.NORMAL | LogMasks.APP_COMMS,
+                ChannelRetry.getDefault(),
+                "127.0.0.1",
+                "0.0.0.0",
+                20000,
+                PrintingChannelListener.getInstance()
+        );
+        Master master = channel.addMaster("master",
+                PrintingSOEHandler.getInstance(),
+                DefaultMasterApplication.getInstance(),
+                new MasterStackConfig()
+        );
+
+        // This used to return nullptr, see issue #268
+        assertNotNull(master.getStatistics().link);
+        assertNotNull(master.getStatistics().transport);
+    }
+
+    @Test
+    public void testGetOutstationStatistics() throws DNP3Exception {
+        DNP3Manager manager = DNP3ManagerFactory.createManager(4, new NullLogHandler());
+
+        Channel channel = manager.addTCPClient(
+                "client",
+                LogMasks.NORMAL | LogMasks.APP_COMMS,
+                ChannelRetry.getDefault(),
+                "127.0.0.1",
+                "0.0.0.0",
+                20000,
+                PrintingChannelListener.getInstance()
+        );
+        Outstation outstation = channel.addOutstation("outstation",
+                SuccessCommandHandler.getInstance(),
+                DefaultOutstationApplication.getInstance(),
+                new OutstationStackConfig(DatabaseConfig.allValues(5), EventBufferConfig.allTypes(5))
+        );
+
+        // This used to return nullptr, see issue #268
+        assertNotNull(outstation.getStatistics().link);
+        assertNotNull(outstation.getStatistics().transport);
+    }
+}
+

--- a/java/cpp/com_automatak_dnp3_impl_MasterImpl.cpp
+++ b/java/cpp/com_automatak_dnp3_impl_MasterImpl.cpp
@@ -40,7 +40,7 @@ JNIEXPORT jobject JNICALL Java_com_automatak_dnp3_impl_MasterImpl_get_1statistic
 {
 	const auto master = (std::shared_ptr<asiodnp3::IMaster>*) native;
 	auto stats = (*master)->GetStackStatistics();
-	return Conversions::ConvertStackStatistics(env, stats);
+	return env->NewGlobalRef(Conversions::ConvertStackStatistics(env, stats));
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_enable_1native

--- a/java/cpp/com_automatak_dnp3_impl_OutstationImpl.cpp
+++ b/java/cpp/com_automatak_dnp3_impl_OutstationImpl.cpp
@@ -34,8 +34,8 @@ JNIEXPORT jobject JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_get_1stati
 (JNIEnv* env, jobject, jlong native)
 {
 	auto outstation = (std::shared_ptr<asiodnp3::IOutstation>*) native;
-	auto stats = (*outstation)->GetStackStatistics();	
-	return Conversions::ConvertStackStatistics(env, stats);
+	auto stats = (*outstation)->GetStackStatistics();
+	return env->NewGlobalRef(Conversions::ConvertStackStatistics(env, stats));
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_enable_1native


### PR DESCRIPTION
Fix #268.

The `getStatistics` for both the master and the outstation used to return a `LocalRef` that was deleted when the native call returned, causing undefined behaviour on the Java side. Now, the reference is promoted to a global reference that will be garbage collected by the JVM.

I also added a test case to reproduce the issue.