### PR TITLE
upgrade default ASIO version to 1-12-2 and migrate to new names for i…

### DIFF
--- a/cpp/libs/include/asiopal/Executor.h
+++ b/cpp/libs/include/asiopal/Executor.h
@@ -81,7 +81,7 @@ public:
 		return Create(this->io);
 	}
 
-	asio::strand strand;
+	asio::io_context::strand strand;
 
 private:
 

--- a/cpp/libs/include/asiopal/IO.h
+++ b/cpp/libs/include/asiopal/IO.h
@@ -27,7 +27,7 @@ namespace asiopal
 {
 
 /**
-*	Container class for an asio::io_service
+*	Container class for an asio::io_context
 */
 class IO
 {
@@ -36,7 +36,7 @@ public:
 
 	virtual ~IO() {}
 
-	asio::io_service service;
+	asio::io_context service;
 
 };
 

--- a/cpp/libs/include/asiopal/SerialChannel.h
+++ b/cpp/libs/include/asiopal/SerialChannel.h
@@ -50,7 +50,7 @@ private:
 	virtual void BeginWriteImpl(const openpal::RSlice& buffer)  override;
 	virtual void ShutdownImpl()  override;
 
-	asio::basic_serial_port<> port;
+	asio::serial_port port;
 
 };
 

--- a/cpp/libs/include/asiopal/ThreadPool.h
+++ b/cpp/libs/include/asiopal/ThreadPool.h
@@ -34,7 +34,7 @@ namespace asiopal
 {
 
 /**
-*	A thread pool that calls asio::io_service::run
+*	A thread pool that calls asio::io_context::run
 */
 class ThreadPool
 {

--- a/cpp/libs/include/asiopal/Timer.h
+++ b/cpp/libs/include/asiopal/Timer.h
@@ -43,7 +43,7 @@ class Timer final : public openpal::ITimer, private openpal::Uncopyable
 
 public:
 
-	Timer(asio::io_service& service);
+	Timer(asio::io_context& service);
 
 	virtual void Cancel() override;
 

--- a/cpp/libs/src/asiopal/Executor.cpp
+++ b/cpp/libs/src/asiopal/Executor.cpp
@@ -59,7 +59,7 @@ ITimer* Executor::Start(const MonotonicTimestamp& time, const action_t& runnable
 
 openpal::ITimer* Executor::Start(const steady_clock_t::time_point& expiration, const openpal::action_t& runnable)
 {
-	auto timer = std::make_shared<Timer>(this->strand.get_io_service());
+	auto timer = std::make_shared<Timer>(this->strand.get_io_context());
 
 	timer->timer.expires_at(expiration);
 

--- a/cpp/libs/src/asiopal/SerialChannel.cpp
+++ b/cpp/libs/src/asiopal/SerialChannel.cpp
@@ -31,7 +31,7 @@
 namespace asiopal
 {
 
-SerialChannel::SerialChannel(std::shared_ptr<Executor> executor) : IAsyncChannel(executor), port(executor->strand.get_io_service())
+SerialChannel::SerialChannel(std::shared_ptr<Executor> executor) : IAsyncChannel(executor), port(executor->strand.get_io_context())
 {}
 
 bool SerialChannel::Open(const SerialSettings& settings, std::error_code& ec)

--- a/cpp/libs/src/asiopal/TCPClient.cpp
+++ b/cpp/libs/src/asiopal/TCPClient.cpp
@@ -34,9 +34,9 @@ TCPClient::TCPClient(
 	condition(logger),
 	executor(executor),
 	adapter(adapter),
-	socket(executor->strand.get_io_service()),
+	socket(executor->strand.get_io_context()),
 	localEndpoint(),
-	resolver(executor->strand.get_io_service())
+	resolver(executor->strand.get_io_context())
 {}
 
 

--- a/cpp/libs/src/asiopal/TCPServer.cpp
+++ b/cpp/libs/src/asiopal/TCPServer.cpp
@@ -41,8 +41,8 @@ TCPServer::TCPServer(
 	logger(logger),
 	executor(executor),
 	endpoint(ip::tcp::v4(), endpoint.port),
-	acceptor(executor->strand.get_io_service()),
-	socket(executor->strand.get_io_service())
+	acceptor(executor->strand.get_io_context()),
+	socket(executor->strand.get_io_context())
 {
 	this->Configure(endpoint.address, ec);
 }

--- a/cpp/libs/src/asiopal/Timer.cpp
+++ b/cpp/libs/src/asiopal/Timer.cpp
@@ -39,7 +39,7 @@ MonotonicTimestamp Timer::ExpiresAt()
 	return MonotonicTimestamp(millisec);
 }
 
-Timer::Timer(asio::io_service& service) : timer(service)
+Timer::Timer(asio::io_context& service) : timer(service)
 {}
 
 }

--- a/cpp/tests/asiopal/src/TestASIO.cpp
+++ b/cpp/tests/asiopal/src/TestASIO.cpp
@@ -49,7 +49,7 @@ TEST_CASE(SUITE("TimerCancel"))
 {
 	bool flag = false;
 
-	io_service io;
+	io_context io;
 	steady_timer t1(io, std::chrono::seconds(0));
 	steady_timer t2(io, std::chrono::seconds(1));
 

--- a/cpp/tests/asiopal/src/mocks/MockIO.cpp
+++ b/cpp/tests/asiopal/src/mocks/MockIO.cpp
@@ -26,7 +26,7 @@
 namespace asiopal
 {
 
-MockIO::Timeout::Timeout(asio::io_service& service, std::chrono::steady_clock::duration timeout) :
+MockIO::Timeout::Timeout(asio::io_context& service, std::chrono::steady_clock::duration timeout) :
 	timer(std::make_shared<asio::basic_waitable_timer<std::chrono::steady_clock>>(service, timeout))
 {
 	auto callback = [t = timer](const std::error_code & ec)

--- a/cpp/tests/asiopal/src/mocks/MockIO.h
+++ b/cpp/tests/asiopal/src/mocks/MockIO.h
@@ -36,7 +36,7 @@ class MockIO final : public IO, public std::enable_shared_from_this<MockIO>
 
 	public:
 
-		Timeout(asio::io_service& service, std::chrono::steady_clock::duration timeout);
+		Timeout(asio::io_context& service, std::chrono::steady_clock::duration timeout);
 
 		~Timeout();
 


### PR DESCRIPTION
…o_context (previously io_service) and asio::io_context::string (previously asio::strand)