### PR TITLE
Fixed stack overflow in RequestIndex property

### DIFF
--- a/dotnet/CLRInterface/src/CommandResultTypes.cs
+++ b/dotnet/CLRInterface/src/CommandResultTypes.cs
@@ -47,7 +47,7 @@ namespace Automatak.DNP3.Interface
 
         public UInt16 RequestIndex
         {
-            get { return RequestIndex; }
+            get { return requestIndex; }
         }
 
         public CommandPointState PointState


### PR DESCRIPTION
RequestIndex property is using itself rather than the private field, causing a stack overflow when accessed.