### PR TITLE
Applied clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,10 @@
+---
+Checks:          '*,-google-readability-todo,-google-build-using-namespace,-google-readability-braces-around-statements,-hicpp-braces-around-statements'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+CheckOptions:
+  - key:             modernize-make-unique.MakeSmartPtrFunction
+    value:           'std::make_unique'
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '*,-google-readability-todo,-google-build-using-namespace,-google-readability-braces-around-statements,-hicpp-braces-around-statements'
+Checks:          '*,-google-readability-todo,-google-build-using-namespace,-google-readability-braces-around-statements,-hicpp-braces-around-statements,-modernize-return-braced-init-list,-cppcoreguidelines-pro-type-member-init,-hicpp-member-init,-modernize-use-default-member-init'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          '*,-google-readability-todo,-google-build-using-namespace,-google-readability-braces-around-statements,-hicpp-braces-around-statements,-modernize-return-braced-init-list,-cppcoreguidelines-pro-type-member-init,-hicpp-member-init,-modernize-use-default-member-init'
+Checks:          '*,-google-readability-todo,-google-build-using-namespace,-google-readability-braces-around-statements,-readability-braces-around-statements,-hicpp-braces-around-statements,-modernize-return-braced-init-list,-cppcoreguidelines-pro-type-member-init,-hicpp-member-init,-modernize-use-default-member-init'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ message("CMake build is: ${CMAKE_BUILD_TYPE}")
 
 include(./cmake/settings.cmake)
 include(./cmake/ClangFormat.cmake)
+include(./cmake/ClangTidy.cmake)
 
 # various optional libraries and projects
 
@@ -105,6 +106,8 @@ add_library(openpal ${LIB_TYPE} ${openpal_SRC})
 install(TARGETS openpal DESTINATION lib)
 set_target_properties(openpal PROPERTIES FOLDER cpp/libs VERSION ${OPENDNP3_VERSION} SOVERSION ${OPENDNP3_MAJOR_VERSION})
 clang_format(openpal)
+clang_tidy(openpal)
+
 # ---- opendnp3 library ----
 file(GLOB_RECURSE opendnp3_SRC ./cpp/libs/src/opendnp3/*.cpp ./cpp/libs/src/opendnp3/*.h ./cpp/libs/include/opendnp3/*.h)
 add_library(opendnp3 ${LIB_TYPE} ${opendnp3_SRC})
@@ -112,6 +115,7 @@ target_link_libraries(opendnp3 openpal)
 install(TARGETS opendnp3 DESTINATION lib)
 set_target_properties(opendnp3 PROPERTIES FOLDER cpp/libs VERSION ${OPENDNP3_VERSION} SOVERSION ${OPENDNP3_MAJOR_VERSION})
 clang_format(opendnp3 EXCLUDES ".*/gen/.*")
+clang_tidy(opendnp3)
 
 if(DNP3_DECODER)
   file(GLOB_RECURSE dnp3decode_SRC ./cpp/libs/src/dnp3decode/*.cpp ./cpp/libs/src/dnp3decode/*.h ./cpp/libs/include/dnp3decode/*.h)
@@ -120,6 +124,7 @@ if(DNP3_DECODER)
   install(TARGETS dnp3decode DESTINATION lib)
   set_target_properties(dnp3decode PROPERTIES FOLDER cpp/libs VERSION ${OPENDNP3_VERSION} SOVERSION ${OPENDNP3_MAJOR_VERSION})
   clang_format(dnp3decode)
+  clang_tidy(dnp3decode)
 endif()
 
 # ---- asiopal library ----
@@ -140,11 +145,12 @@ endif()
 
 target_link_libraries(asiopal ${asiopal_link_libraries})
 install(TARGETS asiopal DESTINATION lib)
-clang_format(asiopal)
 set_target_properties(asiopal PROPERTIES FOLDER cpp/libs VERSION ${OPENDNP3_VERSION} SOVERSION ${OPENDNP3_MAJOR_VERSION})
 if(FLOCK)
   add_definitions(-DUSE_FLOCK)
 endif()
+clang_format(asiopal)
+clang_tidy(asiopal)
 
 # ---- asiodnp3 library ----
 file(GLOB_RECURSE asiodnp3_HPP ./cpp/libs/src/asiodnp3/*.h ./cpp/libs/include/asiodnp3/*.h)
@@ -156,8 +162,10 @@ endif()
 add_library(asiodnp3 ${LIB_TYPE} ${asiodnp3_HPP} ${asiodnp3_CPP})
 target_link_libraries(asiodnp3 asiopal opendnp3)
 install(TARGETS asiodnp3 DESTINATION lib)
-clang_format(asiodnp3)
 set_target_properties(asiodnp3 PROPERTIES FOLDER cpp/libs VERSION ${OPENDNP3_VERSION} SOVERSION ${OPENDNP3_MAJOR_VERSION})
+clang_format(asiodnp3)
+clang_tidy(asiodnp3)
+
 if(DNP3_JAVA)
   file(GLOB_RECURSE opendnp3java_SRC ./java/cpp/*.h ./java/cpp/*.cpp)
   add_library(opendnp3java SHARED ${opendnp3java_SRC})
@@ -165,6 +173,7 @@ if(DNP3_JAVA)
   install(TARGETS opendnp3java DESTINATION lib)
   set_target_properties(opendnp3java PROPERTIES FOLDER java VERSION ${OPENDNP3_VERSION} SOVERSION ${OPENDNP3_MAJOR_VERSION})
   clang_format(opendnp3java EXCLUDES ".*/jni/.*" "com_automatak_.*h$")
+  clang_tidy(opendnp3java)
 endif()
 
 # ----- install -----
@@ -180,18 +189,21 @@ if(DNP3_DEMO)
   target_link_libraries (master-demo LINK_PUBLIC asiodnp3 ${PTHREAD})
   set_target_properties(master-demo PROPERTIES FOLDER cpp/examples)
   clang_format(master-demo)
+  clang_tidy(master-demo)
 
   # ----- master demo executable -----
   add_executable(master-gprs-demo ./cpp/examples/master-gprs/main.cpp ./cpp/examples/master-gprs/ExampleListenCallbacks.cpp ./cpp/examples/master-gprs/ExampleListenCallbacks.h)
   target_link_libraries (master-gprs-demo LINK_PUBLIC asiodnp3 ${PTHREAD})
   set_target_properties(master-gprs-demo PROPERTIES FOLDER cpp/examples)
   clang_format(master-gprs-demo)
+  clang_tidy(master-gprs-demo)
 
   # ----- outstation demo executable -----
   add_executable(outstation-demo ./cpp/examples/outstation/main.cpp)
   target_link_libraries (outstation-demo LINK_PUBLIC asiodnp3 ${PTHREAD})
   set_target_properties(outstation-demo PROPERTIES FOLDER cpp/examples)
   clang_format(outstation-demo)
+  clang_tidy(outstation-demo)
 
   if(DNP3_TLS)
 
@@ -200,18 +212,21 @@ if(DNP3_DEMO)
     target_link_libraries (master-tls-demo LINK_PUBLIC asiodnp3 ${PTHREAD})
     set_target_properties(master-tls-demo PROPERTIES FOLDER cpp/examples/tls)
     clang_format(master-tls-demo)
+    clang_tidy(master-tls-demo)
 
     # ----- outstation tls executable -----
     add_executable(outstation-tls-demo ./cpp/examples/tls/outstation/main.cpp)
     target_link_libraries (outstation-tls-demo LINK_PUBLIC asiodnp3 ${PTHREAD})
     set_target_properties(outstation-tls-demo PROPERTIES FOLDER cpp/examples/tls)
     clang_format(outstation-tls-demo)
+    clang_tidy(outstation-tls-demo)
 
     # ----- master-gprs tls executable -----
     add_executable(master-gprs-tls-demo ./cpp/examples/tls/master-gprs/main.cpp)
     target_link_libraries (master-gprs-tls-demo LINK_PUBLIC asiodnp3 ${PTHREAD})
     set_target_properties(master-gprs-tls-demo PROPERTIES FOLDER cpp/examples/tls)
     clang_format(master-gprs-tls-demo)
+    clang_tidy(master-gprs-tls-demo)
 
   endif()
 
@@ -224,6 +239,7 @@ if(DNP3_DECODER)
   target_link_libraries (decoder asiodnp3 dnp3decode ${PTHREAD})
   set_target_properties(decoder PROPERTIES FOLDER cpp/examples)
   clang_format(decoder)
+  clang_tidy(decoder)
 
 endif()
 
@@ -237,6 +253,7 @@ if(DNP3_TEST)
   target_link_libraries(testlib openpal)
   set_target_properties(testlib PROPERTIES FOLDER cpp/tests/unit/mocks)
   clang_format(testlib)
+  clang_tidy(testlib)
 
   # ----- dnp3mocks library ------
   file(GLOB_RECURSE dnp3mocks_SRC ./cpp/tests/libs/src/dnp3mocks/*.cpp ./cpp/tests/libs/src/dnp3mocks/*.h)
@@ -244,6 +261,7 @@ if(DNP3_TEST)
   target_link_libraries(dnp3mocks opendnp3 testlib)
   set_target_properties(dnp3mocks PROPERTIES FOLDER cpp/tests/unit/mocks)
   clang_format(dnp3mocks)
+  clang_tidy(dnp3mocks)
 
   # ----- openpal tests -----
   file(GLOB_RECURSE openpal_TESTSRC ./cpp/tests/openpal/src/*.cpp ./cpp/tests/openpal/src/*.h)
@@ -251,6 +269,7 @@ if(DNP3_TEST)
   target_link_libraries (testopenpal LINK_PUBLIC testlib ${PTHREAD})
   set_target_properties(testopenpal PROPERTIES FOLDER cpp/tests/unit)
   clang_format(testopenpal)
+  clang_tidy(testopenpal)
   add_test(testopenpal testopenpal)
 
   # ----- opendnp3 tests -----
@@ -259,6 +278,7 @@ if(DNP3_TEST)
   target_link_libraries (testopendnp3 LINK_PUBLIC dnp3mocks ${PTHREAD})
   set_target_properties(testopendnp3 PROPERTIES FOLDER cpp/tests/unit)
   clang_format(testopendnp3)
+  clang_tidy(testopendnp3)
   add_test(testopendnp3 testopendnp3)
 
   # ----- asiopal tests -----
@@ -271,6 +291,7 @@ if(DNP3_TEST)
   target_link_libraries (testasiopal LINK_PUBLIC asiopal testlib ${PTHREAD})
   set_target_properties(testasiopal PROPERTIES FOLDER cpp/tests/integration)
   clang_format(testasiopal)
+  clang_tidy(testasiopal)
   add_test(testasiopal testasiopal)
 
   # ----- asiodnp3 tests -----
@@ -279,6 +300,7 @@ if(DNP3_TEST)
   target_link_libraries (testasiodnp3 LINK_PUBLIC asiodnp3 dnp3mocks ${PTHREAD})
   set_target_properties(testasiodnp3 PROPERTIES FOLDER cpp/tests/integration)
   clang_format(testasiodnp3)
+  clang_tidy(testasiodnp3)
   add_test(testasiodnp3 testasiodnp3)
 
 endif()
@@ -289,16 +311,19 @@ if(DNP3_FUZZING)
   target_link_libraries (fuzzdecoder asiodnp3 dnp3decode ${PTHREAD})
   set_target_properties(fuzzdecoder PROPERTIES FOLDER cpp/tests/fuzzing)
   clang_format(fuzzdecoder)
+  clang_tidy(fuzzdecoder)
 
   add_executable (fuzzoutstation ./cpp/tests/fuzz/onefile.cpp ./cpp/tests/fuzz/fuzzoutstation.cpp)
   target_link_libraries (fuzzoutstation dnp3mocks ${PTHREAD})
   set_target_properties(fuzzoutstation PROPERTIES FOLDER cpp/tests/fuzzing)
   clang_format(fuzzoutstation)
+  clang_tidy(fuzzoutstation)
 
   add_executable (fuzzmaster ./cpp/tests/fuzz/onefile.cpp ./cpp/tests/fuzz/fuzzmaster.cpp)
   target_link_libraries (fuzzmaster dnp3mocks ${PTHREAD})
   set_target_properties(fuzzmaster PROPERTIES FOLDER cpp/tests/fuzzing)
   clang_format(fuzzmaster)
+  clang_tidy(fuzzmaster)
 endif()
 
 if(WIN32 AND DNP3_DOTNET)
@@ -324,6 +349,7 @@ endif()
 #)
 
 define_clang_format()
+define_clang_tidy()
 
 # ----- Packaging -----
 set(CPACK_PACKAGE_VERSION_MAJOR ${OPENDNP3_MAJOR_VERSION})

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -1,0 +1,58 @@
+find_program(CLANG_TIDY_EXE
+    NAMES clang-tidy
+)
+set_property(GLOBAL PROPERTY CLANG_TIDY_FILES)
+
+if(CLANG_TIDY_EXE)
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+    message(STATUS "Found clang-tidy: ${CLANG_TIDY_EXE}")
+    set(ENABLE_CLANG_TIDY OFF CACHE BOOL "Enable clang-tidy integration")
+    set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-checks=*")
+else()
+    message(STATUS "clang-tidy not found")
+endif()
+
+function(clang_tidy target)
+    if(TARGET ${target})
+        if(CLANG_TIDY_EXE)
+            # Enable CMake integration of clang-tidy when compiling
+            if(ENABLE_CLANG_TIDY)
+                set_target_properties(${target} PROPERTIES
+                    C_CLANG_TIDY "${DO_CLANG_TIDY}"
+                    CXX_CLANG_TIDY "${DO_CLANG_TIDY}")
+            endif()
+            
+            # Add the source file to the global property
+            get_target_property(source_files ${target} SOURCES)
+            get_property(all_tidy_files GLOBAL PROPERTY CLANG_TIDY_FILES)
+            foreach(file ${source_files})
+                if(NOT ${file} MATCHES "h$")
+                    list(APPEND all_tidy_files ${file})
+                endif()
+            endforeach()
+            list(REMOVE_DUPLICATES all_tidy_files)
+            set_property(GLOBAL PROPERTY CLANG_TIDY_FILES ${all_tidy_files})
+        endif()
+    else()
+        message(WARNING "Target ${target} does not exists.")
+    endif()
+endfunction()
+
+function(define_clang_tidy)
+    if(CLANG_TIDY_EXE)
+        get_property(all_tidy_files GLOBAL PROPERTY CLANG_TIDY_FILES)
+
+        #set(commands)
+        #foreach(file ${all_tidy_files})
+        #    list(APPEND commands COMMAND ${CLANG_TIDY_EXE} -fix -p ${CMAKE_BINARY_DIR} ${file})
+        #endforeach()
+
+        message(STATUS ${CMAKE_BINARY_DIR})
+        list(LENGTH all_tidy_files num_files)
+        add_custom_target(clang-tidy
+            #${commands}
+            COMMAND ${CLANG_TIDY_EXE} -fix -p ${CMAKE_BINARY_DIR} ${all_tidy_files}
+            COMMENT "Applying clang-tidy fixes on ${num_files} files"
+        )
+    endif()
+endfunction()

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -42,16 +42,15 @@ function(define_clang_tidy)
     if(CLANG_TIDY_EXE)
         get_property(all_tidy_files GLOBAL PROPERTY CLANG_TIDY_FILES)
 
-        #set(commands)
-        #foreach(file ${all_tidy_files})
-        #    list(APPEND commands COMMAND ${CLANG_TIDY_EXE} -fix -p ${CMAKE_BINARY_DIR} ${file})
-        #endforeach()
+        set(commands)
+        foreach(file ${all_tidy_files})
+            list(APPEND commands COMMAND ${CLANG_TIDY_EXE} -fix -p ${CMAKE_BINARY_DIR} ${file})
+        endforeach()
 
         message(STATUS ${CMAKE_BINARY_DIR})
         list(LENGTH all_tidy_files num_files)
         add_custom_target(clang-tidy
-            #${commands}
-            COMMAND ${CLANG_TIDY_EXE} -fix -p ${CMAKE_BINARY_DIR} ${all_tidy_files}
+            ${commands}
             COMMENT "Applying clang-tidy fixes on ${num_files} files"
         )
     endif()

--- a/cpp/examples/decoder/main.cpp
+++ b/cpp/examples/decoder/main.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/examples/master-gprs/ExampleListenCallbacks.cpp
+++ b/cpp/examples/master-gprs/ExampleListenCallbacks.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/examples/master-gprs/ExampleListenCallbacks.h
+++ b/cpp/examples/master-gprs/ExampleListenCallbacks.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/examples/master-gprs/main.cpp
+++ b/cpp/examples/master-gprs/main.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/examples/master/main.cpp
+++ b/cpp/examples/master/main.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/examples/outstation/main.cpp
+++ b/cpp/examples/outstation/main.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/examples/tls/master-gprs/main.cpp
+++ b/cpp/examples/tls/master-gprs/main.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/examples/tls/master/main.cpp
+++ b/cpp/examples/tls/master/main.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/examples/tls/outstation/main.cpp
+++ b/cpp/examples/tls/outstation/main.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/ConsoleLogger.h
+++ b/cpp/libs/include/asiodnp3/ConsoleLogger.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/DNP3Manager.h
+++ b/cpp/libs/include/asiodnp3/DNP3Manager.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -225,7 +225,7 @@ public:
     std::shared_ptr<asiopal::IListener> CreateListener(std::string loggerid,
                                                        openpal::LogFilters loglevel,
                                                        asiopal::IPEndpoint endpoint,
-                                                       std::shared_ptr<IListenCallbacks> callbacks,
+                                                       const std::shared_ptr<IListenCallbacks>& callbacks,
                                                        std::error_code& ec);
 
     /**
@@ -235,7 +235,7 @@ public:
                                                        openpal::LogFilters loglevel,
                                                        asiopal::IPEndpoint endpoint,
                                                        const asiopal::TLSConfig& config,
-                                                       std::shared_ptr<IListenCallbacks> callbacks,
+                                                       const std::shared_ptr<IListenCallbacks>& callbacks,
                                                        std::error_code& ec);
 
 private:

--- a/cpp/libs/include/asiodnp3/DatabaseConfig.h
+++ b/cpp/libs/include/asiodnp3/DatabaseConfig.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/DefaultListenCallbacks.h
+++ b/cpp/libs/include/asiodnp3/DefaultListenCallbacks.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/DefaultMasterApplication.h
+++ b/cpp/libs/include/asiodnp3/DefaultMasterApplication.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/ErrorCodes.h
+++ b/cpp/libs/include/asiodnp3/ErrorCodes.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/IChannel.h
+++ b/cpp/libs/include/asiodnp3/IChannel.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/IChannelListener.h
+++ b/cpp/libs/include/asiodnp3/IChannelListener.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/IListenCallbacks.h
+++ b/cpp/libs/include/asiodnp3/IListenCallbacks.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/IMaster.h
+++ b/cpp/libs/include/asiodnp3/IMaster.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/IMasterOperations.h
+++ b/cpp/libs/include/asiodnp3/IMasterOperations.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/IMasterScan.h
+++ b/cpp/libs/include/asiodnp3/IMasterScan.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/IMasterSession.h
+++ b/cpp/libs/include/asiodnp3/IMasterSession.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/IOutstation.h
+++ b/cpp/libs/include/asiodnp3/IOutstation.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/ISessionAcceptor.h
+++ b/cpp/libs/include/asiodnp3/ISessionAcceptor.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/IStack.h
+++ b/cpp/libs/include/asiodnp3/IStack.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/MasterStackConfig.h
+++ b/cpp/libs/include/asiodnp3/MasterStackConfig.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/MasterTCPServer.h
+++ b/cpp/libs/include/asiodnp3/MasterTCPServer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -43,8 +43,8 @@ public:
     MasterTCPServer(const openpal::Logger& logger,
                     const std::shared_ptr<asiopal::Executor>& executor,
                     const asiopal::IPEndpoint& endpoint,
-                    const std::shared_ptr<IListenCallbacks>& callbacks,
-                    const std::shared_ptr<asiopal::ResourceManager>& manager,
+                    std::shared_ptr<IListenCallbacks> callbacks,
+                    std::shared_ptr<asiopal::ResourceManager> manager,
                     std::error_code& ec);
 
     static std::shared_ptr<MasterTCPServer> Create(const openpal::Logger& logger,

--- a/cpp/libs/include/asiodnp3/OutstationStackConfig.h
+++ b/cpp/libs/include/asiodnp3/OutstationStackConfig.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/PrintingChannelListener.h
+++ b/cpp/libs/include/asiodnp3/PrintingChannelListener.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/PrintingCommandCallback.h
+++ b/cpp/libs/include/asiodnp3/PrintingCommandCallback.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/PrintingSOEHandler.h
+++ b/cpp/libs/include/asiodnp3/PrintingSOEHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/UpdateBuilder.h
+++ b/cpp/libs/include/asiodnp3/UpdateBuilder.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/Updates.h
+++ b/cpp/libs/include/asiodnp3/Updates.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiodnp3/X509Info.h
+++ b/cpp/libs/include/asiodnp3/X509Info.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/ASIOSerialHelpers.h
+++ b/cpp/libs/include/asiopal/ASIOSerialHelpers.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/ChannelRetry.h
+++ b/cpp/libs/include/asiopal/ChannelRetry.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/Executor.h
+++ b/cpp/libs/include/asiopal/Executor.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/IAsyncChannel.h
+++ b/cpp/libs/include/asiopal/IAsyncChannel.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/IChannelCallbacks.h
+++ b/cpp/libs/include/asiopal/IChannelCallbacks.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/IListener.h
+++ b/cpp/libs/include/asiopal/IListener.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/IO.h
+++ b/cpp/libs/include/asiopal/IO.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/IOpenDelayStrategy.h
+++ b/cpp/libs/include/asiopal/IOpenDelayStrategy.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/IPEndpoint.h
+++ b/cpp/libs/include/asiopal/IPEndpoint.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/IResourceManager.h
+++ b/cpp/libs/include/asiopal/IResourceManager.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/LoggingConnectionCondition.h
+++ b/cpp/libs/include/asiopal/LoggingConnectionCondition.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/ResourceManager.h
+++ b/cpp/libs/include/asiopal/ResourceManager.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/SerialChannel.h
+++ b/cpp/libs/include/asiopal/SerialChannel.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -38,7 +38,7 @@ public:
         return std::make_shared<SerialChannel>(executor);
     }
 
-    SerialChannel(std::shared_ptr<Executor> executor);
+    SerialChannel(const std::shared_ptr<Executor>& executor);
 
     bool Open(const SerialSettings& settings, std::error_code& ec);
 

--- a/cpp/libs/include/asiopal/SerialTypes.h
+++ b/cpp/libs/include/asiopal/SerialTypes.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/SocketChannel.h
+++ b/cpp/libs/include/asiopal/SocketChannel.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -34,10 +34,10 @@ public:
         return std::make_shared<SocketChannel>(executor, std::move(socket));
     }
 
-    SocketChannel(std::shared_ptr<Executor> executor, asio::ip::tcp::socket socket);
+    SocketChannel(const std::shared_ptr<Executor>& executor, asio::ip::tcp::socket socket);
 
 protected:
-    virtual void BeginReadImpl(openpal::WSlice buffer) override;
+    virtual void BeginReadImpl(openpal::WSlice dest) override;
     virtual void BeginWriteImpl(const openpal::RSlice& buffer) override;
     virtual void ShutdownImpl() override;
 

--- a/cpp/libs/include/asiopal/SocketHelpers.h
+++ b/cpp/libs/include/asiopal/SocketHelpers.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/SteadyClock.h
+++ b/cpp/libs/include/asiopal/SteadyClock.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/Synchronized.h
+++ b/cpp/libs/include/asiopal/Synchronized.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/TCPClient.h
+++ b/cpp/libs/include/asiopal/TCPClient.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -42,7 +42,7 @@ public:
         return std::make_shared<TCPClient>(logger, executor, adapter);
     }
 
-    TCPClient(const openpal::Logger& logger, const std::shared_ptr<Executor>& executor, const std::string& adapter);
+    TCPClient(const openpal::Logger& logger, const std::shared_ptr<Executor>& executor, std::string adapter);
 
     bool Cancel();
 

--- a/cpp/libs/include/asiopal/TCPServer.h
+++ b/cpp/libs/include/asiopal/TCPServer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/TLSConfig.h
+++ b/cpp/libs/include/asiopal/TLSConfig.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/ThreadPool.h
+++ b/cpp/libs/include/asiopal/ThreadPool.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/TimeConversions.h
+++ b/cpp/libs/include/asiopal/TimeConversions.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/Timer.h
+++ b/cpp/libs/include/asiopal/Timer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/asiopal/UTCTimeSource.h
+++ b/cpp/libs/include/asiopal/UTCTimeSource.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/dnp3decode/Decoder.h
+++ b/cpp/libs/include/dnp3decode/Decoder.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -33,7 +33,7 @@ class DecoderImpl;
 class Decoder
 {
 public:
-    Decoder(IDecoderCallbacks& callbacks, openpal::Logger logger);
+    Decoder(IDecoderCallbacks& callbacks, const openpal::Logger& logger);
     ~Decoder();
 
     void DecodeLPDU(const openpal::RSlice& data);

--- a/cpp/libs/include/dnp3decode/IDecoderCallbacks.h
+++ b/cpp/libs/include/dnp3decode/IDecoderCallbacks.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/LogLevels.h
+++ b/cpp/libs/include/opendnp3/LogLevels.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/StackStatistics.h
+++ b/cpp/libs/include/opendnp3/StackStatistics.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/AnalogCommandEvent.h
+++ b/cpp/libs/include/opendnp3/app/AnalogCommandEvent.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/AnalogOutput.h
+++ b/cpp/libs/include/opendnp3/app/AnalogOutput.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/AppConstants.h
+++ b/cpp/libs/include/opendnp3/app/AppConstants.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/BaseMeasurementTypes.h
+++ b/cpp/libs/include/opendnp3/app/BaseMeasurementTypes.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/BinaryCommandEvent.h
+++ b/cpp/libs/include/opendnp3/app/BinaryCommandEvent.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/ClassField.h
+++ b/cpp/libs/include/opendnp3/app/ClassField.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/ControlRelayOutputBlock.h
+++ b/cpp/libs/include/opendnp3/app/ControlRelayOutputBlock.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/DNPTime.h
+++ b/cpp/libs/include/opendnp3/app/DNPTime.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/EventCells.h
+++ b/cpp/libs/include/opendnp3/app/EventCells.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/EventTriggers.h
+++ b/cpp/libs/include/opendnp3/app/EventTriggers.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/EventType.h
+++ b/cpp/libs/include/opendnp3/app/EventType.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/Flags.h
+++ b/cpp/libs/include/opendnp3/app/Flags.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/GroupVariationID.h
+++ b/cpp/libs/include/opendnp3/app/GroupVariationID.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/IINField.h
+++ b/cpp/libs/include/opendnp3/app/IINField.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -105,7 +105,7 @@ public:
 
     void SetBitToValue(IINBit bit, bool value);
 
-    bool operator==(const IINField& arRHS) const;
+    bool operator==(const IINField& aRHS) const;
 
     bool Any() const
     {

--- a/cpp/libs/include/opendnp3/app/ITransactable.h
+++ b/cpp/libs/include/opendnp3/app/ITransactable.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/Indexed.h
+++ b/cpp/libs/include/opendnp3/app/Indexed.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/MeasurementInfo.h
+++ b/cpp/libs/include/opendnp3/app/MeasurementInfo.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/MeasurementTypeSpecs.h
+++ b/cpp/libs/include/opendnp3/app/MeasurementTypeSpecs.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/MeasurementTypes.h
+++ b/cpp/libs/include/opendnp3/app/MeasurementTypes.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/OctetData.h
+++ b/cpp/libs/include/opendnp3/app/OctetData.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/OctetString.h
+++ b/cpp/libs/include/opendnp3/app/OctetString.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/QualityMasks.h
+++ b/cpp/libs/include/opendnp3/app/QualityMasks.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/SecurityStat.h
+++ b/cpp/libs/include/opendnp3/app/SecurityStat.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/app/parsing/ICollection.h
+++ b/cpp/libs/include/opendnp3/app/parsing/ICollection.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/link/Addresses.h
+++ b/cpp/libs/include/opendnp3/link/Addresses.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/link/ILinkListener.h
+++ b/cpp/libs/include/opendnp3/link/ILinkListener.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/link/LinkConfig.h
+++ b/cpp/libs/include/opendnp3/link/LinkConfig.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/link/LinkHeaderFields.h
+++ b/cpp/libs/include/opendnp3/link/LinkHeaderFields.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -30,7 +30,7 @@ struct LinkHeaderFields
 {
     LinkHeaderFields();
 
-    LinkHeaderFields(LinkFunction func, bool isMaster, bool fcb, bool fcvdfc, uint16_t dest, uint16_t source);
+    LinkHeaderFields(LinkFunction func, bool isMaster, bool fcb, bool fcvdfc, uint16_t dest, uint16_t src_);
 
     Addresses ToAddresses() const
     {

--- a/cpp/libs/include/opendnp3/link/LinkStatistics.h
+++ b/cpp/libs/include/opendnp3/link/LinkStatistics.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/CommandCallbackT.h
+++ b/cpp/libs/include/opendnp3/master/CommandCallbackT.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/CommandPointResult.h
+++ b/cpp/libs/include/opendnp3/master/CommandPointResult.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/CommandSet.h
+++ b/cpp/libs/include/opendnp3/master/CommandSet.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -73,7 +73,7 @@ public:
     /// Convenience functions that can build an entire header in one call
     template<class T> void Add(std::initializer_list<Indexed<T>> items)
     {
-        if (!items.size() == 0)
+        if ((((!(((items.size()))) == 0))))
         {
             auto& header = this->StartHeader<T>();
             for (auto& command : items)

--- a/cpp/libs/include/opendnp3/master/HeaderInfo.h
+++ b/cpp/libs/include/opendnp3/master/HeaderInfo.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/HeaderTypes.h
+++ b/cpp/libs/include/opendnp3/master/HeaderTypes.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/ICommandCollection.h
+++ b/cpp/libs/include/opendnp3/master/ICommandCollection.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/ICommandProcessor.h
+++ b/cpp/libs/include/opendnp3/master/ICommandProcessor.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/ICommandTaskResult.h
+++ b/cpp/libs/include/opendnp3/master/ICommandTaskResult.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/IMasterApplication.h
+++ b/cpp/libs/include/opendnp3/master/IMasterApplication.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/ISOEHandler.h
+++ b/cpp/libs/include/opendnp3/master/ISOEHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/ITaskCallback.h
+++ b/cpp/libs/include/opendnp3/master/ITaskCallback.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/MasterParams.h
+++ b/cpp/libs/include/opendnp3/master/MasterParams.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/RestartOperationResult.h
+++ b/cpp/libs/include/opendnp3/master/RestartOperationResult.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/TaskConfig.h
+++ b/cpp/libs/include/opendnp3/master/TaskConfig.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/TaskId.h
+++ b/cpp/libs/include/opendnp3/master/TaskId.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/master/TaskInfo.h
+++ b/cpp/libs/include/opendnp3/master/TaskInfo.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/outstation/ApplicationIIN.h
+++ b/cpp/libs/include/opendnp3/outstation/ApplicationIIN.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/outstation/Cell.h
+++ b/cpp/libs/include/opendnp3/outstation/Cell.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/outstation/DatabaseSizes.h
+++ b/cpp/libs/include/opendnp3/outstation/DatabaseSizes.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/outstation/EventBufferConfig.h
+++ b/cpp/libs/include/opendnp3/outstation/EventBufferConfig.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/outstation/ICommandHandler.h
+++ b/cpp/libs/include/opendnp3/outstation/ICommandHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/outstation/IOutstationApplication.h
+++ b/cpp/libs/include/opendnp3/outstation/IOutstationApplication.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/outstation/IUpdateHandler.h
+++ b/cpp/libs/include/opendnp3/outstation/IUpdateHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/outstation/MeasurementConfig.h
+++ b/cpp/libs/include/opendnp3/outstation/MeasurementConfig.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/outstation/OutstationConfig.h
+++ b/cpp/libs/include/opendnp3/outstation/OutstationConfig.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/outstation/OutstationParams.h
+++ b/cpp/libs/include/opendnp3/outstation/OutstationParams.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/outstation/SimpleCommandHandler.h
+++ b/cpp/libs/include/opendnp3/outstation/SimpleCommandHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/opendnp3/outstation/StaticTypeBitfield.h
+++ b/cpp/libs/include/opendnp3/outstation/StaticTypeBitfield.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/Configure.h
+++ b/cpp/libs/include/openpal/Configure.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/channel/IPhysicalLayer.h
+++ b/cpp/libs/include/openpal/channel/IPhysicalLayer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/channel/IPhysicalLayerCallbacks.h
+++ b/cpp/libs/include/openpal/channel/IPhysicalLayerCallbacks.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/container/Array.h
+++ b/cpp/libs/include/openpal/container/Array.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/container/ArrayView.h
+++ b/cpp/libs/include/openpal/container/ArrayView.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/container/Buffer.h
+++ b/cpp/libs/include/openpal/container/Buffer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/container/HasSize.h
+++ b/cpp/libs/include/openpal/container/HasSize.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/container/Pair.h
+++ b/cpp/libs/include/openpal/container/Pair.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/container/RSlice.h
+++ b/cpp/libs/include/openpal/container/RSlice.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/container/Settable.h
+++ b/cpp/libs/include/openpal/container/Settable.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/container/StaticBuffer.h
+++ b/cpp/libs/include/openpal/container/StaticBuffer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/container/WSlice.h
+++ b/cpp/libs/include/openpal/container/WSlice.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/executor/IExecutor.h
+++ b/cpp/libs/include/openpal/executor/IExecutor.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/executor/IMonotonicTimeSource.h
+++ b/cpp/libs/include/openpal/executor/IMonotonicTimeSource.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/executor/ITimer.h
+++ b/cpp/libs/include/openpal/executor/ITimer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/executor/IUTCTimeSource.h
+++ b/cpp/libs/include/openpal/executor/IUTCTimeSource.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/executor/MonotonicTimestamp.h
+++ b/cpp/libs/include/openpal/executor/MonotonicTimestamp.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/executor/TimeDuration.h
+++ b/cpp/libs/include/openpal/executor/TimeDuration.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/executor/TimerRef.h
+++ b/cpp/libs/include/openpal/executor/TimerRef.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -68,7 +68,7 @@ private:
     bool StartAction(const MonotonicTimestamp& expiration, const action_t& action);
 
     // Start a new timer, canceling any existing timer
-    void RestartAction(const TimeDuration& expiration, const action_t& action);
+    void RestartAction(const TimeDuration& timeout, const action_t& action);
     void RestartAction(const MonotonicTimestamp& expiration, const action_t& action);
 
     IExecutor* pExecutor;

--- a/cpp/libs/include/openpal/executor/UTCTimestamp.h
+++ b/cpp/libs/include/openpal/executor/UTCTimestamp.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/logging/ILogHandler.h
+++ b/cpp/libs/include/openpal/logging/ILogHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/logging/Location.h
+++ b/cpp/libs/include/openpal/logging/Location.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/logging/LogEntry.h
+++ b/cpp/libs/include/openpal/logging/LogEntry.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/logging/LogFilters.h
+++ b/cpp/libs/include/openpal/logging/LogFilters.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/logging/LogLevels.h
+++ b/cpp/libs/include/openpal/logging/LogLevels.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/logging/LogMacros.h
+++ b/cpp/libs/include/openpal/logging/LogMacros.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/logging/Logger.h
+++ b/cpp/libs/include/openpal/logging/Logger.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -43,7 +43,7 @@ public:
         openpal::LogFilters levels;
     };
 
-    Logger(const std::shared_ptr<ILogHandler>& backend, const std::string& id, openpal::LogFilters levels);
+    Logger(std::shared_ptr<ILogHandler> backend, const std::string& id, openpal::LogFilters levels);
 
     static Logger Empty()
     {

--- a/cpp/libs/include/openpal/logging/StringFormatting.h
+++ b/cpp/libs/include/openpal/logging/StringFormatting.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -38,7 +38,7 @@ void LogHex(Logger& logger,
             uint32_t otherRowSize);
 
 // Portable allocation of a copy of a cstring
-char* AllocateCopy(char const* alias);
+char* AllocateCopy(char const* src);
 
 } // namespace openpal
 

--- a/cpp/libs/include/openpal/serialization/ByteSerialization.h
+++ b/cpp/libs/include/openpal/serialization/ByteSerialization.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/serialization/DoubleFloat.h
+++ b/cpp/libs/include/openpal/serialization/DoubleFloat.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -40,7 +40,7 @@ public:
     static void WriteBuffer(WSlice& buffer, double value);
 
     static double Read(const uint8_t* data);
-    static void Write(uint8_t* data, double value);
+    static void Write(uint8_t* dest, double value);
 
     const static std::size_t SIZE = sizeof(double);
     const static double Max;

--- a/cpp/libs/include/openpal/serialization/FloatByteOrder.h
+++ b/cpp/libs/include/openpal/serialization/FloatByteOrder.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/serialization/Format.h
+++ b/cpp/libs/include/openpal/serialization/Format.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/serialization/Parse.h
+++ b/cpp/libs/include/openpal/serialization/Parse.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/serialization/Serialization.h
+++ b/cpp/libs/include/openpal/serialization/Serialization.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/serialization/SerializationTemplatesLE.h
+++ b/cpp/libs/include/openpal/serialization/SerializationTemplatesLE.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/serialization/Serializer.h
+++ b/cpp/libs/include/openpal/serialization/Serializer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/serialization/SingleFloat.h
+++ b/cpp/libs/include/openpal/serialization/SingleFloat.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -40,7 +40,7 @@ public:
     static void WriteBuffer(WSlice& buffer, float value);
 
     static float Read(const uint8_t* data);
-    static void Write(uint8_t* data, float value);
+    static void Write(uint8_t* dest, float value);
 
     const static std::size_t SIZE = sizeof(float);
     const static float Max;

--- a/cpp/libs/include/openpal/serialization/UInt48LE.h
+++ b/cpp/libs/include/openpal/serialization/UInt48LE.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/serialization/UInt48Type.h
+++ b/cpp/libs/include/openpal/serialization/UInt48Type.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/util/Comparisons.h
+++ b/cpp/libs/include/openpal/util/Comparisons.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/util/Finally.h
+++ b/cpp/libs/include/openpal/util/Finally.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/util/Limits.h
+++ b/cpp/libs/include/openpal/util/Limits.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/util/SequenceNum.h
+++ b/cpp/libs/include/openpal/util/SequenceNum.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/util/ToHex.h
+++ b/cpp/libs/include/openpal/util/ToHex.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/include/openpal/util/Uncopyable.h
+++ b/cpp/libs/include/openpal/util/Uncopyable.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiodnp3/ConsoleLogger.cpp
+++ b/cpp/libs/src/asiodnp3/ConsoleLogger.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -21,8 +21,7 @@
 
 #include <opendnp3/LogLevels.h>
 
-#include <assert.h>
-
+#include <cassert>
 #include <chrono>
 #include <iostream>
 #include <sstream>

--- a/cpp/libs/src/asiodnp3/Conversions.cpp
+++ b/cpp/libs/src/asiodnp3/Conversions.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiodnp3/Conversions.h
+++ b/cpp/libs/src/asiodnp3/Conversions.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiodnp3/DNP3Channel.cpp
+++ b/cpp/libs/src/asiodnp3/DNP3Channel.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -27,6 +27,8 @@
 #include "opendnp3/LogLevels.h"
 #include "opendnp3/master/MasterSchedulerBackend.h"
 
+#include <utility>
+
 using namespace openpal;
 using namespace asiopal;
 using namespace opendnp3;
@@ -36,15 +38,15 @@ namespace asiodnp3
 
 DNP3Channel::DNP3Channel(const Logger& logger,
                          const std::shared_ptr<asiopal::Executor>& executor,
-                         const std::shared_ptr<IOHandler>& iohandler,
-                         const std::shared_ptr<asiopal::IResourceManager>& manager)
+                         std::shared_ptr<IOHandler> iohandler,
+                         std::shared_ptr<asiopal::IResourceManager> manager)
     :
 
       logger(logger),
       executor(executor),
       scheduler(std::make_shared<MasterSchedulerBackend>(executor)),
-      iohandler(iohandler),
-      manager(manager),
+      iohandler(std::move(iohandler)),
+      manager(std::move(manager)),
       resources(ResourceManager::Create())
 {
 }

--- a/cpp/libs/src/asiodnp3/DNP3Channel.h
+++ b/cpp/libs/src/asiodnp3/DNP3Channel.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -36,8 +36,8 @@ class DNP3Channel final : public IChannel, public std::enable_shared_from_this<D
 public:
     DNP3Channel(const openpal::Logger& logger,
                 const std::shared_ptr<asiopal::Executor>& executor,
-                const std::shared_ptr<IOHandler>& iohandler,
-                const std::shared_ptr<asiopal::IResourceManager>& manager);
+                std::shared_ptr<IOHandler> iohandler,
+                std::shared_ptr<asiopal::IResourceManager> manager);
 
     static std::shared_ptr<DNP3Channel> Create(const openpal::Logger& logger,
                                                const std::shared_ptr<asiopal::Executor>& executor,

--- a/cpp/libs/src/asiodnp3/DNP3Manager.cpp
+++ b/cpp/libs/src/asiodnp3/DNP3Manager.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -21,6 +21,8 @@
 
 #include "asiodnp3/DNP3ManagerImpl.h"
 
+#include <utility>
+
 namespace asiodnp3
 {
 
@@ -32,7 +34,7 @@ DNP3Manager::DNP3Manager(uint32_t concurrencyHint,
 {
 }
 
-DNP3Manager::~DNP3Manager() {}
+DNP3Manager::~DNP3Manager() = default;
 
 void DNP3Manager::Shutdown()
 {
@@ -47,7 +49,7 @@ std::shared_ptr<IChannel> DNP3Manager::AddTCPClient(const std::string& id,
                                                     uint16_t port,
                                                     std::shared_ptr<IChannelListener> listener)
 {
-    return this->impl->AddTCPClient(id, levels, retry, {asiopal::IPEndpoint(host, port)}, local, listener);
+    return this->impl->AddTCPClient(id, levels, retry, {asiopal::IPEndpoint(host, port)}, local, std::move(listener));
 }
 
 std::shared_ptr<IChannel> DNP3Manager::AddTCPClient(const std::string& id,
@@ -57,7 +59,7 @@ std::shared_ptr<IChannel> DNP3Manager::AddTCPClient(const std::string& id,
                                                     const std::string& local,
                                                     std::shared_ptr<IChannelListener> listener)
 {
-    return this->impl->AddTCPClient(id, levels, retry, hosts, local, listener);
+    return this->impl->AddTCPClient(id, levels, retry, hosts, local, std::move(listener));
 }
 
 std::shared_ptr<IChannel> DNP3Manager::AddTCPServer(const std::string& id,
@@ -67,7 +69,7 @@ std::shared_ptr<IChannel> DNP3Manager::AddTCPServer(const std::string& id,
                                                     uint16_t port,
                                                     std::shared_ptr<IChannelListener> listener)
 {
-    return this->impl->AddTCPServer(id, levels, mode, endpoint, port, listener);
+    return this->impl->AddTCPServer(id, levels, mode, endpoint, port, std::move(listener));
 }
 
 std::shared_ptr<IChannel> DNP3Manager::AddSerial(const std::string& id,
@@ -76,7 +78,7 @@ std::shared_ptr<IChannel> DNP3Manager::AddSerial(const std::string& id,
                                                  asiopal::SerialSettings settings,
                                                  std::shared_ptr<IChannelListener> listener)
 {
-    return this->impl->AddSerial(id, levels, retry, settings, listener);
+    return this->impl->AddSerial(id, levels, retry, std::move(settings), std::move(listener));
 }
 
 std::shared_ptr<IChannel> DNP3Manager::AddTLSClient(const std::string& id,
@@ -89,7 +91,8 @@ std::shared_ptr<IChannel> DNP3Manager::AddTLSClient(const std::string& id,
                                                     std::shared_ptr<IChannelListener> listener,
                                                     std::error_code& ec)
 {
-    return this->impl->AddTLSClient(id, levels, retry, {asiopal::IPEndpoint(host, port)}, local, config, listener, ec);
+    return this->impl->AddTLSClient(id, levels, retry, {asiopal::IPEndpoint(host, port)}, local, config,
+                                    std::move(listener), ec);
 }
 
 std::shared_ptr<IChannel> DNP3Manager::AddTLSClient(const std::string& id,
@@ -101,7 +104,7 @@ std::shared_ptr<IChannel> DNP3Manager::AddTLSClient(const std::string& id,
                                                     std::shared_ptr<IChannelListener> listener,
                                                     std::error_code& ec)
 {
-    return this->impl->AddTLSClient(id, levels, retry, hosts, local, config, listener, ec);
+    return this->impl->AddTLSClient(id, levels, retry, hosts, local, config, std::move(listener), ec);
 }
 
 std::shared_ptr<IChannel> DNP3Manager::AddTLSServer(const std::string& id,
@@ -113,26 +116,26 @@ std::shared_ptr<IChannel> DNP3Manager::AddTLSServer(const std::string& id,
                                                     std::shared_ptr<IChannelListener> listener,
                                                     std::error_code& ec)
 {
-    return this->impl->AddTLSServer(id, levels, mode, endpoint, port, config, listener, ec);
+    return this->impl->AddTLSServer(id, levels, mode, endpoint, port, config, std::move(listener), ec);
 }
 
 std::shared_ptr<asiopal::IListener> DNP3Manager::CreateListener(std::string loggerid,
                                                                 openpal::LogFilters loglevel,
                                                                 asiopal::IPEndpoint endpoint,
-                                                                std::shared_ptr<IListenCallbacks> callbacks,
+                                                                const std::shared_ptr<IListenCallbacks>& callbacks,
                                                                 std::error_code& ec)
 {
-    return impl->CreateListener(loggerid, loglevel, endpoint, callbacks, ec);
+    return impl->CreateListener(std::move(loggerid), loglevel, std::move(endpoint), callbacks, ec);
 }
 
 std::shared_ptr<asiopal::IListener> DNP3Manager::CreateListener(std::string loggerid,
                                                                 openpal::LogFilters loglevel,
                                                                 asiopal::IPEndpoint endpoint,
                                                                 const asiopal::TLSConfig& config,
-                                                                std::shared_ptr<IListenCallbacks> callbacks,
+                                                                const std::shared_ptr<IListenCallbacks>& callbacks,
                                                                 std::error_code& ec)
 {
-    return impl->CreateListener(loggerid, loglevel, endpoint, config, callbacks, ec);
+    return impl->CreateListener(std::move(loggerid), loglevel, std::move(endpoint), config, callbacks, ec);
 }
 
 } // namespace asiodnp3

--- a/cpp/libs/src/asiodnp3/DNP3ManagerImpl.cpp
+++ b/cpp/libs/src/asiodnp3/DNP3ManagerImpl.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -21,6 +21,8 @@
 #include "DNP3ManagerImpl.h"
 
 #include <opendnp3/LogLevels.h>
+
+#include <utility>
 
 #ifdef OPENDNP3_USE_TLS
 #include "asiodnp3/tls/MasterTLSServer.h"
@@ -46,9 +48,9 @@ DNP3ManagerImpl::DNP3ManagerImpl(uint32_t concurrencyHint,
                                  std::shared_ptr<openpal::ILogHandler> handler,
                                  std::function<void()> onThreadStart,
                                  std::function<void()> onThreadExit)
-    : logger(handler, "manager", opendnp3::levels::ALL),
+    : logger(std::move(handler), "manager", opendnp3::levels::ALL),
       io(std::make_shared<asiopal::IO>()),
-      threadpool(logger, io, concurrencyHint, onThreadStart, onThreadExit),
+      threadpool(logger, io, concurrencyHint, std::move(onThreadStart), std::move(onThreadExit)),
       resources(ResourceManager::Create())
 {
 }

--- a/cpp/libs/src/asiodnp3/DNP3ManagerImpl.h
+++ b/cpp/libs/src/asiodnp3/DNP3ManagerImpl.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -94,13 +94,13 @@ public:
                                            std::error_code& ec);
 
     std::shared_ptr<asiopal::IListener> CreateListener(std::string loggerid,
-                                                       openpal::LogFilters loglevel,
+                                                       openpal::LogFilters levels,
                                                        asiopal::IPEndpoint endpoint,
                                                        const std::shared_ptr<IListenCallbacks>& callbacks,
                                                        std::error_code& ec);
 
     std::shared_ptr<asiopal::IListener> CreateListener(std::string loggerid,
-                                                       openpal::LogFilters loglevel,
+                                                       openpal::LogFilters levels,
                                                        asiopal::IPEndpoint endpoint,
                                                        const asiopal::TLSConfig& config,
                                                        const std::shared_ptr<IListenCallbacks>& callbacks,

--- a/cpp/libs/src/asiodnp3/DefaultListenCallbacks.cpp
+++ b/cpp/libs/src/asiodnp3/DefaultListenCallbacks.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -23,14 +23,14 @@
 namespace asiodnp3
 {
 
-DefaultListenCallbacks::DefaultListenCallbacks() {}
+DefaultListenCallbacks::DefaultListenCallbacks() = default;
 
-bool DefaultListenCallbacks::AcceptConnection(uint64_t sessionid, const std::string& ipaddress)
+bool DefaultListenCallbacks::AcceptConnection(uint64_t /*sessionid*/, const std::string& /*ipaddress*/)
 {
     return true;
 }
 
-bool DefaultListenCallbacks::AcceptCertificate(uint64_t sessionid, const X509Info& info)
+bool DefaultListenCallbacks::AcceptCertificate(uint64_t /*sessionid*/, const X509Info& /*info*/)
 {
     return true;
 }

--- a/cpp/libs/src/asiodnp3/DefaultMasterApplication.cpp
+++ b/cpp/libs/src/asiodnp3/DefaultMasterApplication.cpp
@@ -28,10 +28,10 @@ namespace asiodnp3
 
 openpal::UTCTimestamp DefaultMasterApplication::Now()
 {
-    auto time
+    uint64_t time
         = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
               .count();
-    return openpal::UTCTimestamp(time);
+    return {time};
 }
 
 } // namespace asiodnp3

--- a/cpp/libs/src/asiodnp3/DefaultMasterApplication.cpp
+++ b/cpp/libs/src/asiodnp3/DefaultMasterApplication.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiodnp3/ErrorCodes.cpp
+++ b/cpp/libs/src/asiodnp3/ErrorCodes.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiodnp3/IOHandler.h
+++ b/cpp/libs/src/asiodnp3/IOHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -47,7 +47,7 @@ class IOHandler : private opendnp3::IFrameSink,
 {
 
 public:
-    IOHandler(const openpal::Logger& logger, bool closeExisting, const std::shared_ptr<IChannelListener>& listener);
+    IOHandler(const openpal::Logger& logger, bool close_existing, std::shared_ptr<IChannelListener> listener);
 
     virtual ~IOHandler() {}
 

--- a/cpp/libs/src/asiodnp3/IPEndpointsList.cpp
+++ b/cpp/libs/src/asiodnp3/IPEndpointsList.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiodnp3/IPEndpointsList.h
+++ b/cpp/libs/src/asiodnp3/IPEndpointsList.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiodnp3/LinkSession.cpp
+++ b/cpp/libs/src/asiodnp3/LinkSession.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -25,6 +25,8 @@
 #include "opendnp3/LogLevels.h"
 #include "opendnp3/master/MasterSchedulerBackend.h"
 
+#include <utility>
+
 using namespace openpal;
 using namespace asiopal;
 using namespace opendnp3;
@@ -34,13 +36,13 @@ namespace asiodnp3
 
 LinkSession::LinkSession(const openpal::Logger& logger,
                          uint64_t sessionid,
-                         const std::shared_ptr<IResourceManager>& manager,
-                         const std::shared_ptr<IListenCallbacks>& callbacks,
+                         std::shared_ptr<IResourceManager> manager,
+                         std::shared_ptr<IListenCallbacks> callbacks,
                          const std::shared_ptr<asiopal::IAsyncChannel>& channel)
     : logger(logger),
       session_id(sessionid),
-      manager(manager),
-      callbacks(callbacks),
+      manager(std::move(manager)),
+      callbacks(std::move(callbacks)),
       channel(channel),
       parser(logger),
       first_frame_timer(*channel->executor)
@@ -97,7 +99,7 @@ void LinkSession::OnReadComplete(const std::error_code& ec, size_t num)
     }
 }
 
-void LinkSession::OnWriteComplete(const std::error_code& ec, size_t num)
+void LinkSession::OnWriteComplete(const std::error_code& ec, size_t /*num*/)
 {
     if (ec)
     {
@@ -110,7 +112,7 @@ void LinkSession::OnWriteComplete(const std::error_code& ec, size_t num)
     }
 }
 
-void LinkSession::BeginTransmit(const openpal::RSlice& buffer, opendnp3::ILinkSession& session)
+void LinkSession::BeginTransmit(const openpal::RSlice& buffer, opendnp3::ILinkSession& /*session*/)
 {
     this->channel->BeginWrite(buffer);
 }

--- a/cpp/libs/src/asiodnp3/LinkSession.h
+++ b/cpp/libs/src/asiodnp3/LinkSession.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -62,8 +62,8 @@ public:
 
     LinkSession(const openpal::Logger& logger,
                 uint64_t sessionid,
-                const std::shared_ptr<asiopal::IResourceManager>& manager,
-                const std::shared_ptr<IListenCallbacks>& callbacks,
+                std::shared_ptr<asiopal::IResourceManager> manager,
+                std::shared_ptr<IListenCallbacks> callbacks,
                 const std::shared_ptr<asiopal::IAsyncChannel>& channel);
 
     // override IResource

--- a/cpp/libs/src/asiodnp3/MasterScan.cpp
+++ b/cpp/libs/src/asiodnp3/MasterScan.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -24,15 +24,16 @@
 #include "opendnp3/master/IMasterTask.h"
 #include "opendnp3/master/MasterContext.h"
 
+#include <utility>
+
 using namespace openpal;
 using namespace opendnp3;
 
 namespace asiodnp3
 {
 
-MasterScan::MasterScan(const std::shared_ptr<opendnp3::IMasterTask>& task,
-                       const std::shared_ptr<IMasterScheduler>& scheduler)
-    : task(task), scheduler(scheduler)
+MasterScan::MasterScan(std::shared_ptr<opendnp3::IMasterTask> task, std::shared_ptr<IMasterScheduler> scheduler)
+    : task(std::move(task)), scheduler(std::move(scheduler))
 {
 }
 

--- a/cpp/libs/src/asiodnp3/MasterScan.h
+++ b/cpp/libs/src/asiodnp3/MasterScan.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -40,8 +40,7 @@ class MasterScan final : public IMasterScan
 public:
     MasterScan() = default;
 
-    MasterScan(const std::shared_ptr<opendnp3::IMasterTask>& task,
-               const std::shared_ptr<opendnp3::IMasterScheduler>& scheduler);
+    MasterScan(std::shared_ptr<opendnp3::IMasterTask> task, std::shared_ptr<opendnp3::IMasterScheduler> scheduler);
 
     static std::shared_ptr<MasterScan> Create(const std::shared_ptr<opendnp3::IMasterTask>& task,
                                               const std::shared_ptr<opendnp3::IMasterScheduler>& scheduler)

--- a/cpp/libs/src/asiodnp3/MasterSessionStack.cpp
+++ b/cpp/libs/src/asiodnp3/MasterSessionStack.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -24,6 +24,8 @@
 
 #include "asiodnp3/Conversions.h"
 #include "asiodnp3/LinkSession.h"
+
+#include <utility>
 
 using namespace opendnp3;
 
@@ -48,12 +50,12 @@ MasterSessionStack::MasterSessionStack(const openpal::Logger& logger,
                                        const std::shared_ptr<opendnp3::ISOEHandler>& SOEHandler,
                                        const std::shared_ptr<opendnp3::IMasterApplication>& application,
                                        const std::shared_ptr<opendnp3::IMasterScheduler>& scheduler,
-                                       const std::shared_ptr<LinkSession>& session,
+                                       std::shared_ptr<LinkSession> session,
                                        opendnp3::ILinkTx& linktx,
                                        const MasterStackConfig& config)
     : executor(executor),
       scheduler(scheduler),
-      session(session),
+      session(std::move(session)),
       stack(logger, executor, application, config.master.maxRxFragSize, LinkLayerConfig(config.link, false)),
       context(Addresses(config.link.LocalAddr, config.link.RemoteAddr),
               logger,

--- a/cpp/libs/src/asiodnp3/MasterSessionStack.h
+++ b/cpp/libs/src/asiodnp3/MasterSessionStack.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -115,7 +115,7 @@ public:
                        const std::shared_ptr<opendnp3::ISOEHandler>& SOEHandler,
                        const std::shared_ptr<opendnp3::IMasterApplication>& application,
                        const std::shared_ptr<opendnp3::IMasterScheduler>& scheduler,
-                       const std::shared_ptr<LinkSession>& session,
+                       std::shared_ptr<LinkSession> session,
                        opendnp3::ILinkTx& linktx,
                        const MasterStackConfig& config);
 

--- a/cpp/libs/src/asiodnp3/MasterStack.cpp
+++ b/cpp/libs/src/asiodnp3/MasterStack.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiodnp3/MasterStack.h
+++ b/cpp/libs/src/asiodnp3/MasterStack.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiodnp3/MasterTCPServer.cpp
+++ b/cpp/libs/src/asiodnp3/MasterTCPServer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -29,6 +29,7 @@
 #include "asiodnp3/LinkSession.h"
 
 #include <sstream>
+#include <utility>
 
 using namespace opendnp3;
 using namespace openpal;
@@ -40,10 +41,10 @@ namespace asiodnp3
 MasterTCPServer::MasterTCPServer(const openpal::Logger& logger,
                                  const std::shared_ptr<asiopal::Executor>& executor,
                                  const asiopal::IPEndpoint& endpoint,
-                                 const std::shared_ptr<IListenCallbacks>& callbacks,
-                                 const std::shared_ptr<asiopal::ResourceManager>& manager,
+                                 std::shared_ptr<IListenCallbacks> callbacks,
+                                 std::shared_ptr<asiopal::ResourceManager> manager,
                                  std::error_code& ec)
-    : TCPServer(logger, executor, endpoint, ec), callbacks(callbacks), manager(manager)
+    : TCPServer(logger, executor, endpoint, ec), callbacks(std::move(callbacks)), manager(std::move(manager))
 {
 }
 

--- a/cpp/libs/src/asiodnp3/OutstationStack.cpp
+++ b/cpp/libs/src/asiodnp3/OutstationStack.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiodnp3/OutstationStack.h
+++ b/cpp/libs/src/asiodnp3/OutstationStack.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiodnp3/PrintingCommandCallback.cpp
+++ b/cpp/libs/src/asiodnp3/PrintingCommandCallback.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiodnp3/PrintingSOEHandler.cpp
+++ b/cpp/libs/src/asiodnp3/PrintingSOEHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -60,7 +60,7 @@ void PrintingSOEHandler::Process(const HeaderInfo& info, const ICollection<Index
     return PrintAll(info, values);
 }
 
-void PrintingSOEHandler::Process(const HeaderInfo& info, const ICollection<Indexed<OctetString>>& values)
+void PrintingSOEHandler::Process(const HeaderInfo& /*info*/, const ICollection<Indexed<OctetString>>& values)
 {
     auto print = [](const Indexed<OctetString>& pair) {
         std::cout << "OctetString "
@@ -70,7 +70,7 @@ void PrintingSOEHandler::Process(const HeaderInfo& info, const ICollection<Index
     values.ForeachItem(print);
 }
 
-void PrintingSOEHandler::Process(const HeaderInfo& info, const ICollection<Indexed<TimeAndInterval>>& values)
+void PrintingSOEHandler::Process(const HeaderInfo& /*info*/, const ICollection<Indexed<TimeAndInterval>>& values)
 {
     auto print = [](const Indexed<TimeAndInterval>& pair) {
         std::cout << "TimeAndInterval: "
@@ -81,7 +81,7 @@ void PrintingSOEHandler::Process(const HeaderInfo& info, const ICollection<Index
     values.ForeachItem(print);
 }
 
-void PrintingSOEHandler::Process(const HeaderInfo& info, const ICollection<Indexed<BinaryCommandEvent>>& values)
+void PrintingSOEHandler::Process(const HeaderInfo& /*info*/, const ICollection<Indexed<BinaryCommandEvent>>& values)
 {
     auto print = [](const Indexed<BinaryCommandEvent>& pair) {
         std::cout << "BinaryCommandEvent: "
@@ -92,7 +92,7 @@ void PrintingSOEHandler::Process(const HeaderInfo& info, const ICollection<Index
     values.ForeachItem(print);
 }
 
-void PrintingSOEHandler::Process(const HeaderInfo& info, const ICollection<Indexed<AnalogCommandEvent>>& values)
+void PrintingSOEHandler::Process(const HeaderInfo& /*info*/, const ICollection<Indexed<AnalogCommandEvent>>& values)
 {
     auto print = [](const Indexed<AnalogCommandEvent>& pair) {
         std::cout << "AnalogCommandEvent: "
@@ -103,7 +103,7 @@ void PrintingSOEHandler::Process(const HeaderInfo& info, const ICollection<Index
     values.ForeachItem(print);
 }
 
-void PrintingSOEHandler::Process(const HeaderInfo& info, const ICollection<Indexed<SecurityStat>>& values)
+void PrintingSOEHandler::Process(const HeaderInfo& /*info*/, const ICollection<Indexed<SecurityStat>>& values)
 {
     auto print = [](const Indexed<SecurityStat>& pair) {
         std::cout << "SecurityStat: "
@@ -114,7 +114,7 @@ void PrintingSOEHandler::Process(const HeaderInfo& info, const ICollection<Index
     values.ForeachItem(print);
 }
 
-void PrintingSOEHandler::Process(const opendnp3::HeaderInfo& info,
+void PrintingSOEHandler::Process(const opendnp3::HeaderInfo& /*info*/,
                                  const opendnp3::ICollection<opendnp3::DNPTime>& values)
 {
     auto print = [](const DNPTime& value) { std::cout << "DNPTime: " << value.value << std::endl; };

--- a/cpp/libs/src/asiodnp3/SerialIOHandler.cpp
+++ b/cpp/libs/src/asiodnp3/SerialIOHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -24,6 +24,8 @@
 
 #include "opendnp3/LogLevels.h"
 
+#include <utility>
+
 namespace asiodnp3
 {
 
@@ -31,8 +33,12 @@ SerialIOHandler::SerialIOHandler(const openpal::Logger& logger,
                                  const std::shared_ptr<IChannelListener>& listener,
                                  const std::shared_ptr<asiopal::Executor>& executor,
                                  const asiopal::ChannelRetry& retry,
-                                 const asiopal::SerialSettings& settings)
-    : IOHandler(logger, false, listener), executor(executor), retry(retry), settings(settings), retrytimer(*executor)
+                                 asiopal::SerialSettings settings)
+    : IOHandler(logger, false, listener),
+      executor(executor),
+      retry(retry),
+      settings(std::move(settings)),
+      retrytimer(*executor)
 {
 }
 

--- a/cpp/libs/src/asiodnp3/SerialIOHandler.h
+++ b/cpp/libs/src/asiodnp3/SerialIOHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -49,7 +49,7 @@ public:
                     const std::shared_ptr<IChannelListener>& listener,
                     const std::shared_ptr<asiopal::Executor>& executor,
                     const asiopal::ChannelRetry& retry,
-                    const asiopal::SerialSettings& settings);
+                    asiopal::SerialSettings settings);
 
 protected:
     virtual void ShutdownImpl() override;
@@ -58,7 +58,7 @@ protected:
     virtual void OnChannelShutdown() override;
 
 private:
-    void TryOpen(const openpal::TimeDuration& retry);
+    void TryOpen(const openpal::TimeDuration& timeout);
 
     void ResetState();
 

--- a/cpp/libs/src/asiodnp3/StackBase.h
+++ b/cpp/libs/src/asiodnp3/StackBase.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiodnp3/TCPClientIOHandler.cpp
+++ b/cpp/libs/src/asiodnp3/TCPClientIOHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -22,6 +22,8 @@
 
 #include "asiopal/SocketChannel.h"
 
+#include <utility>
+
 using namespace asiopal;
 
 namespace asiodnp3
@@ -32,12 +34,12 @@ TCPClientIOHandler::TCPClientIOHandler(const openpal::Logger& logger,
                                        const std::shared_ptr<asiopal::Executor>& executor,
                                        const asiopal::ChannelRetry& retry,
                                        const asiodnp3::IPEndpointsList& remotes,
-                                       const std::string& adapter)
+                                       std::string adapter)
     : IOHandler(logger, false, listener),
       executor(executor),
       retry(retry),
       remotes(remotes),
-      adapter(adapter),
+      adapter(std::move(adapter)),
       retrytimer(*executor)
 {
 }

--- a/cpp/libs/src/asiodnp3/TCPClientIOHandler.h
+++ b/cpp/libs/src/asiodnp3/TCPClientIOHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -51,7 +51,7 @@ public:
                        const std::shared_ptr<asiopal::Executor>& executor,
                        const asiopal::ChannelRetry& retry,
                        const asiodnp3::IPEndpointsList& remotes,
-                       const std::string& adapter);
+                       std::string adapter);
 
 protected:
     virtual void ShutdownImpl() override;

--- a/cpp/libs/src/asiodnp3/TCPServerIOHandler.cpp
+++ b/cpp/libs/src/asiodnp3/TCPServerIOHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -26,13 +26,15 @@
 
 #include "opendnp3/LogLevels.h"
 
+#include <utility>
+
 using namespace asiopal;
 using namespace opendnp3;
 
 namespace asiodnp3
 {
 
-void TCPServerIOHandler::Server::AcceptConnection(uint64_t sessionid,
+void TCPServerIOHandler::Server::AcceptConnection(uint64_t /*sessionid*/,
                                                   const std::shared_ptr<asiopal::Executor>& executor,
                                                   asio::ip::tcp::socket socket)
 {
@@ -42,10 +44,12 @@ void TCPServerIOHandler::Server::AcceptConnection(uint64_t sessionid,
 TCPServerIOHandler::TCPServerIOHandler(const openpal::Logger& logger,
                                        ServerAcceptMode mode,
                                        const std::shared_ptr<IChannelListener>& listener,
-                                       const std::shared_ptr<asiopal::Executor>& executor,
-                                       const asiopal::IPEndpoint& endpoint,
-                                       std::error_code& ec)
-    : IOHandler(logger, mode == ServerAcceptMode::CloseExisting, listener), executor(executor), endpoint(endpoint)
+                                       std::shared_ptr<asiopal::Executor> executor,
+                                       asiopal::IPEndpoint endpoint,
+                                       std::error_code& /*ec*/)
+    : IOHandler(logger, mode == ServerAcceptMode::CloseExisting, listener),
+      executor(std::move(executor)),
+      endpoint(std::move(endpoint))
 {
 }
 

--- a/cpp/libs/src/asiodnp3/TCPServerIOHandler.h
+++ b/cpp/libs/src/asiodnp3/TCPServerIOHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -80,8 +80,8 @@ public:
     TCPServerIOHandler(const openpal::Logger& logger,
                        opendnp3::ServerAcceptMode accept_mode,
                        const std::shared_ptr<IChannelListener>& listener,
-                       const std::shared_ptr<asiopal::Executor>& executor,
-                       const asiopal::IPEndpoint& endpoint,
+                       std::shared_ptr<asiopal::Executor> executor,
+                       asiopal::IPEndpoint endpoint,
                        std::error_code& ec);
 
 protected:

--- a/cpp/libs/src/asiodnp3/UpdateBuilder.cpp
+++ b/cpp/libs/src/asiodnp3/UpdateBuilder.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiodnp3/tls/MasterTLSServer.h
+++ b/cpp/libs/src/asiodnp3/tls/MasterTLSServer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -40,8 +40,8 @@ public:
                     const std::shared_ptr<asiopal::Executor>& executor,
                     const asiopal::IPEndpoint& endpoint,
                     const asiopal::TLSConfig& tlsConfig,
-                    const std::shared_ptr<IListenCallbacks>& callbacks,
-                    const std::shared_ptr<asiopal::ResourceManager>& manager,
+                    std::shared_ptr<IListenCallbacks> callbacks,
+                    std::shared_ptr<asiopal::ResourceManager> manager,
                     std::error_code& ec);
 
     static std::shared_ptr<MasterTLSServer> Create(const openpal::Logger& logger,

--- a/cpp/libs/src/asiodnp3/tls/TLSClientIOHandler.cpp
+++ b/cpp/libs/src/asiodnp3/tls/TLSClientIOHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -24,6 +24,8 @@
 
 #include "opendnp3/LogLevels.h"
 
+#include <utility>
+
 using namespace asiopal;
 
 namespace asiodnp3
@@ -32,16 +34,16 @@ namespace asiodnp3
 TLSClientIOHandler::TLSClientIOHandler(const openpal::Logger& logger,
                                        const std::shared_ptr<IChannelListener>& listener,
                                        const std::shared_ptr<asiopal::Executor>& executor,
-                                       const asiopal::TLSConfig& config,
+                                       asiopal::TLSConfig config,
                                        const asiopal::ChannelRetry& retry,
                                        const asiodnp3::IPEndpointsList& remotes,
-                                       const std::string& adapter)
+                                       std::string adapter)
     : IOHandler(logger, false, listener),
       executor(executor),
-      config(config),
+      config(std::move(config)),
       retry(retry),
       remotes(remotes),
-      adapter(adapter),
+      adapter(std::move(adapter)),
       retrytimer(*executor)
 {
 }

--- a/cpp/libs/src/asiodnp3/tls/TLSClientIOHandler.h
+++ b/cpp/libs/src/asiodnp3/tls/TLSClientIOHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -52,10 +52,10 @@ public:
     TLSClientIOHandler(const openpal::Logger& logger,
                        const std::shared_ptr<IChannelListener>& listener,
                        const std::shared_ptr<asiopal::Executor>& executor,
-                       const asiopal::TLSConfig& config,
+                       asiopal::TLSConfig config,
                        const asiopal::ChannelRetry& retry,
                        const asiodnp3::IPEndpointsList& remotes,
-                       const std::string& adapter);
+                       std::string adapter);
 
 protected:
     virtual void ShutdownImpl() override;

--- a/cpp/libs/src/asiodnp3/tls/TLSServerIOHandler.cpp
+++ b/cpp/libs/src/asiodnp3/tls/TLSServerIOHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -26,13 +26,15 @@
 
 #include "opendnp3/LogLevels.h"
 
+#include <utility>
+
 using namespace opendnp3;
 using namespace asiopal;
 
 namespace asiodnp3
 {
 
-void TLSServerIOHandler::Server::AcceptStream(uint64_t sessionid,
+void TLSServerIOHandler::Server::AcceptStream(uint64_t /*sessionid*/,
                                               const std::shared_ptr<asiopal::Executor>& executor,
                                               std::shared_ptr<asio::ssl::stream<asio::ip::tcp::socket>> stream)
 {
@@ -42,14 +44,14 @@ void TLSServerIOHandler::Server::AcceptStream(uint64_t sessionid,
 TLSServerIOHandler::TLSServerIOHandler(const openpal::Logger& logger,
                                        ServerAcceptMode mode,
                                        const std::shared_ptr<IChannelListener>& listener,
-                                       const std::shared_ptr<asiopal::Executor>& executor,
-                                       const asiopal::IPEndpoint& endpoint,
-                                       const asiopal::TLSConfig& config,
-                                       std::error_code& ec)
+                                       std::shared_ptr<asiopal::Executor> executor,
+                                       asiopal::IPEndpoint endpoint,
+                                       asiopal::TLSConfig config,
+                                       std::error_code& /*ec*/)
     : IOHandler(logger, mode == ServerAcceptMode::CloseExisting, listener),
-      executor(executor),
-      endpoint(endpoint),
-      config(config)
+      executor(std::move(executor)),
+      endpoint(std::move(endpoint)),
+      config(std::move(config))
 {
 }
 

--- a/cpp/libs/src/asiodnp3/tls/TLSServerIOHandler.h
+++ b/cpp/libs/src/asiodnp3/tls/TLSServerIOHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -89,9 +89,9 @@ public:
     TLSServerIOHandler(const openpal::Logger& logger,
                        opendnp3::ServerAcceptMode mode,
                        const std::shared_ptr<IChannelListener>& listener,
-                       const std::shared_ptr<asiopal::Executor>& executor,
-                       const asiopal::IPEndpoint& endpoint,
-                       const asiopal::TLSConfig& config,
+                       std::shared_ptr<asiopal::Executor> executor,
+                       asiopal::IPEndpoint endpoint,
+                       asiopal::TLSConfig config,
                        std::error_code& ec);
 
 protected:

--- a/cpp/libs/src/asiopal/ASIOSerialHelpers.cpp
+++ b/cpp/libs/src/asiopal/ASIOSerialHelpers.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -124,10 +124,7 @@ bool Configure(const SerialSettings& settings, asio::serial_port& port, error_co
         return false;
 
     port.set_option(ConvertStopBits(settings.stopBits), ec);
-    if (ec)
-        return false;
-
-    return true;
+    return !static_cast<bool>(ec);
 }
 
 } // namespace asiopal

--- a/cpp/libs/src/asiopal/ChannelRetry.cpp
+++ b/cpp/libs/src/asiopal/ChannelRetry.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiopal/Executor.cpp
+++ b/cpp/libs/src/asiopal/Executor.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiopal/IOpenDelayStrategy.cpp
+++ b/cpp/libs/src/asiopal/IOpenDelayStrategy.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiopal/ResourceManager.cpp
+++ b/cpp/libs/src/asiopal/ResourceManager.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiopal/SerialChannel.cpp
+++ b/cpp/libs/src/asiopal/SerialChannel.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -24,13 +24,14 @@
 
 #ifdef USE_FLOCK
 #include <sys/file.h>
+
 #include <cerrno>
 #endif
 
 namespace asiopal
 {
 
-SerialChannel::SerialChannel(std::shared_ptr<Executor> executor)
+SerialChannel::SerialChannel(const std::shared_ptr<Executor>& executor)
     : IAsyncChannel(executor), port(executor->strand.get_io_context())
 {
 }

--- a/cpp/libs/src/asiopal/SocketChannel.cpp
+++ b/cpp/libs/src/asiopal/SocketChannel.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -23,7 +23,7 @@
 namespace asiopal
 {
 
-SocketChannel::SocketChannel(std::shared_ptr<Executor> executor, asio::ip::tcp::socket socket)
+SocketChannel::SocketChannel(const std::shared_ptr<Executor>& executor, asio::ip::tcp::socket socket)
     : IAsyncChannel(executor), socket(std::move(socket))
 {
 }

--- a/cpp/libs/src/asiopal/TCPServer.cpp
+++ b/cpp/libs/src/asiopal/TCPServer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiopal/ThreadPool.cpp
+++ b/cpp/libs/src/asiopal/ThreadPool.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -24,6 +24,8 @@
 
 #include <asiopal/SteadyClock.h>
 
+#include <utility>
+
 using namespace std;
 using namespace std::chrono;
 using namespace openpal;
@@ -38,8 +40,8 @@ ThreadPool::ThreadPool(const openpal::Logger& logger,
                        std::function<void()> onThreadExit)
     : logger(logger),
       io(io),
-      onThreadStart(onThreadStart),
-      onThreadExit(onThreadExit),
+      onThreadStart(std::move(std::move(onThreadStart))),
+      onThreadExit(std::move(std::move(onThreadExit))),
       isShutdown(false),
       infiniteTimer(io->service)
 {

--- a/cpp/libs/src/asiopal/TimeConversions.cpp
+++ b/cpp/libs/src/asiopal/TimeConversions.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiopal/Timer.cpp
+++ b/cpp/libs/src/asiopal/Timer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiopal/UTCTimeSource.cpp
+++ b/cpp/libs/src/asiopal/UTCTimeSource.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiopal/tls/SSLContext.cpp
+++ b/cpp/libs/src/asiopal/tls/SSLContext.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiopal/tls/SSLContext.h
+++ b/cpp/libs/src/asiopal/tls/SSLContext.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -36,7 +36,7 @@ class SSLContext : private openpal::Uncopyable
 {
 
 public:
-    SSLContext(const openpal::Logger& logger, bool server, const TLSConfig& cfg, std::error_code&);
+    SSLContext(const openpal::Logger& logger, bool server, const TLSConfig& config, std::error_code&);
 
     asio::ssl::context value;
 

--- a/cpp/libs/src/asiopal/tls/TLSClient.cpp
+++ b/cpp/libs/src/asiopal/tls/TLSClient.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -24,6 +24,8 @@
 
 #include "opendnp3/LogLevels.h"
 
+#include <utility>
+
 using namespace openpal;
 using namespace opendnp3;
 
@@ -32,15 +34,15 @@ namespace asiopal
 
 TLSClient::TLSClient(const Logger& logger,
                      const std::shared_ptr<Executor>& executor,
-                     const std::string& adapter,
+                     std::string adapter,
                      const TLSConfig& config,
                      std::error_code& ec)
     : logger(logger),
       condition(logger),
       executor(executor),
-      adapter(adapter),
+      adapter(std::move(adapter)),
       ctx(logger, false, config, ec),
-      localEndpoint(),
+
       resolver(executor->strand.get_io_service())
 {
 }
@@ -119,15 +121,12 @@ bool TLSClient::BeginConnect(const IPEndpoint& remote, const connect_callback_t&
 
         return true;
     }
-    else
-    {
-        asio::ip::tcp::endpoint remoteEndpoint(address, remote.port);
-        auto cb
-            = [self, stream, callback](const std::error_code& ec) { self->HandleConnectResult(callback, stream, ec); };
 
-        stream->lowest_layer().async_connect(remoteEndpoint, executor->strand.wrap(cb));
-        return true;
-    }
+    asio::ip::tcp::endpoint remoteEndpoint(address, remote.port);
+    auto cb = [self, stream, callback](const std::error_code& ec) { self->HandleConnectResult(callback, stream, ec); };
+
+    stream->lowest_layer().async_connect(remoteEndpoint, executor->strand.wrap(cb));
+    return true;
 }
 
 void TLSClient::LogVerifyCallback(bool preverified, asio::ssl::verify_context& ctx)

--- a/cpp/libs/src/asiopal/tls/TLSClient.h
+++ b/cpp/libs/src/asiopal/tls/TLSClient.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -52,7 +52,7 @@ public:
 
     TLSClient(const openpal::Logger& logger,
               const std::shared_ptr<Executor>& executor,
-              const std::string& adapter,
+              std::string adapter,
               const TLSConfig& config,
               std::error_code& ec);
 

--- a/cpp/libs/src/asiopal/tls/TLSContext.h
+++ b/cpp/libs/src/asiopal/tls/TLSContext.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiopal/tls/TLSServer.cpp
+++ b/cpp/libs/src/asiopal/tls/TLSServer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiopal/tls/TLSServer.h
+++ b/cpp/libs/src/asiopal/tls/TLSServer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/asiopal/tls/TLSStreamChannel.cpp
+++ b/cpp/libs/src/asiopal/tls/TLSStreamChannel.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -20,12 +20,14 @@
 
 #include "asiopal/tls/TLSStreamChannel.h"
 
+#include <utility>
+
 namespace asiopal
 {
 
 TLSStreamChannel::TLSStreamChannel(const std::shared_ptr<Executor>& executor,
-                                   const std::shared_ptr<asio::ssl::stream<asio::ip::tcp::socket>>& stream)
-    : IAsyncChannel(executor), stream(stream)
+                                   std::shared_ptr<asio::ssl::stream<asio::ip::tcp::socket>> stream)
+    : IAsyncChannel(executor), stream(std::move(stream))
 {
 }
 

--- a/cpp/libs/src/asiopal/tls/TLSStreamChannel.h
+++ b/cpp/libs/src/asiopal/tls/TLSStreamChannel.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -39,11 +39,11 @@ public:
     }
 
     TLSStreamChannel(const std::shared_ptr<Executor>& executor,
-                     const std::shared_ptr<asio::ssl::stream<asio::ip::tcp::socket>>& stream);
+                     std::shared_ptr<asio::ssl::stream<asio::ip::tcp::socket>> stream);
 
 private:
-    virtual void BeginReadImpl(openpal::WSlice buffer) override;
-    virtual void BeginWriteImpl(const openpal::RSlice& buffer) override;
+    virtual void BeginReadImpl(openpal::WSlice dest) override;
+    virtual void BeginWriteImpl(const openpal::RSlice& data) override;
     virtual void ShutdownImpl() override;
 
     const std::shared_ptr<asio::ssl::stream<asio::ip::tcp::socket>> stream;

--- a/cpp/libs/src/dnp3decode/Decoder.cpp
+++ b/cpp/libs/src/dnp3decode/Decoder.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -24,7 +24,9 @@
 
 namespace opendnp3
 {
-Decoder::Decoder(IDecoderCallbacks& callbacks, openpal::Logger logger) : impl(new DecoderImpl(callbacks, logger)) {}
+Decoder::Decoder(IDecoderCallbacks& callbacks, const openpal::Logger& logger) : impl(new DecoderImpl(callbacks, logger))
+{
+}
 
 void Decoder::DecodeLPDU(const openpal::RSlice& data)
 {

--- a/cpp/libs/src/dnp3decode/DecoderImpl.cpp
+++ b/cpp/libs/src/dnp3decode/DecoderImpl.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -83,37 +83,37 @@ void DecoderImpl::DecodeAPDU(const openpal::RSlice& data)
         {
             logging::LogHeader(this->logger, flags::APP_HEADER_RX, result.header);
 
-            if (result.header.IIN.LSB & 0x01)
+            if ((result.header.IIN.LSB & 0x01) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN1.0 - All stations");
-            if (result.header.IIN.LSB & 0x02)
+            if ((result.header.IIN.LSB & 0x02) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN1.1 - Class 1 events");
-            if (result.header.IIN.LSB & 0x04)
+            if ((result.header.IIN.LSB & 0x04) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN1.2 - Class 2 events");
-            if (result.header.IIN.LSB & 0x08)
+            if ((result.header.IIN.LSB & 0x08) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN1.3 - Class 3 events");
-            if (result.header.IIN.LSB & 0x10)
+            if ((result.header.IIN.LSB & 0x10) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN1.4 - Need time");
-            if (result.header.IIN.LSB & 0x20)
+            if ((result.header.IIN.LSB & 0x20) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN1.5 - Local control");
-            if (result.header.IIN.LSB & 0x40)
+            if ((result.header.IIN.LSB & 0x40) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN1.6 - Device trouble");
-            if (result.header.IIN.LSB & 0x80)
+            if ((result.header.IIN.LSB & 0x80) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN1.7 - Device restart");
-            if (result.header.IIN.MSB & 0x01)
+            if ((result.header.IIN.MSB & 0x01) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN2.0 - Function code not supported");
-            if (result.header.IIN.MSB & 0x02)
+            if ((result.header.IIN.MSB & 0x02) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN2.1 - Object unknown");
-            if (result.header.IIN.MSB & 0x04)
+            if ((result.header.IIN.MSB & 0x04) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN2.2 - Parameter error");
-            if (result.header.IIN.MSB & 0x08)
+            if ((result.header.IIN.MSB & 0x08) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN2.3 - Event buffer overflow");
-            if (result.header.IIN.MSB & 0x10)
+            if ((result.header.IIN.MSB & 0x10) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN2.4 - Already executing");
-            if (result.header.IIN.MSB & 0x20)
+            if ((result.header.IIN.MSB & 0x20) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN2.5 - Configuration corrupt");
-            if (result.header.IIN.MSB & 0x40)
+            if ((result.header.IIN.MSB & 0x40) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN2.6 - Reserved 1");
-            if (result.header.IIN.MSB & 0x80)
+            if ((result.header.IIN.MSB & 0x80) != 0)
                 SIMPLE_LOG_BLOCK(this->logger, flags::APP_HEADER_RX, "IIN2.7 - Reserved 2");
 
             Indent i(*callbacks);

--- a/cpp/libs/src/dnp3decode/DecoderImpl.h
+++ b/cpp/libs/src/dnp3decode/DecoderImpl.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/dnp3decode/Indent.h
+++ b/cpp/libs/src/dnp3decode/Indent.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/dnp3decode/LoggingHandler.cpp
+++ b/cpp/libs/src/dnp3decode/LoggingHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -28,12 +28,12 @@ using namespace openpal;
 namespace opendnp3
 {
 
-LoggingHandler::LoggingHandler(openpal::Logger logger_, IDecoderCallbacks& callbacks_)
+LoggingHandler::LoggingHandler(const openpal::Logger& logger_, IDecoderCallbacks& callbacks_)
     : logger(logger_), callbacks(&callbacks_)
 {
 }
 
-void LoggingHandler::OnHeaderResult(const HeaderRecord& record, const IINField& result)
+void LoggingHandler::OnHeaderResult(const HeaderRecord& /*record*/, const IINField& result)
 {
     if (result.Any())
     {
@@ -44,12 +44,12 @@ void LoggingHandler::OnHeaderResult(const HeaderRecord& record, const IINField& 
 
 std::string LoggingHandler::ToUTCString(const DNPTime& dnptime)
 {
-    time_t seconds = static_cast<time_t>(dnptime / 1000);
-    uint16_t milliseconds = static_cast<uint16_t>(dnptime % 1000);
+    auto seconds = static_cast<time_t>(dnptime / 1000);
+    auto milliseconds = static_cast<uint16_t>(dnptime % 1000);
 
 #ifdef WIN32
     tm t;
-    if (gmtime_s(&t, &seconds))
+    if (gmtime_s(&t, &seconds) != 0)
     {
         return "BAD TIME";
     }
@@ -122,9 +122,9 @@ IINField LoggingHandler::PrintTimeAndInterval(const ICollection<Indexed<TimeAndI
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
+IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
                                        const Group120Var1& value,
-                                       const openpal::RSlice& object)
+                                       const openpal::RSlice& /*object*/)
 {
     Indent i(*callbacks);
 
@@ -141,9 +141,9 @@ IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
+IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
                                        const Group120Var2& value,
-                                       const openpal::RSlice& object)
+                                       const openpal::RSlice& /*object*/)
 {
     Indent i(*callbacks);
 
@@ -158,9 +158,9 @@ IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
+IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
                                        const Group120Var5& value,
-                                       const openpal::RSlice& object)
+                                       const openpal::RSlice& /*object*/)
 {
     Indent i(*callbacks);
 
@@ -181,9 +181,9 @@ IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
+IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
                                        const Group120Var6& value,
-                                       const openpal::RSlice& object)
+                                       const openpal::RSlice& /*object*/)
 {
     Indent i(*callbacks);
 
@@ -198,9 +198,9 @@ IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
+IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
                                        const Group120Var7& value,
-                                       const openpal::RSlice& object)
+                                       const openpal::RSlice& /*object*/)
 {
     Indent i(*callbacks);
 
@@ -225,9 +225,9 @@ IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
+IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
                                        const Group120Var8& value,
-                                       const openpal::RSlice& object)
+                                       const openpal::RSlice& /*object*/)
 {
     Indent i(*callbacks);
 
@@ -242,9 +242,9 @@ IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
+IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
                                        const Group120Var9& value,
-                                       const openpal::RSlice& object)
+                                       const openpal::RSlice& /*object*/)
 {
     Indent i(*callbacks);
 
@@ -254,9 +254,9 @@ IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
+IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
                                        const Group120Var10& value,
-                                       const openpal::RSlice& object)
+                                       const openpal::RSlice& /*object*/)
 {
     Indent i(*callbacks);
 
@@ -282,9 +282,9 @@ IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
+IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
                                        const Group120Var11& value,
-                                       const openpal::RSlice& object)
+                                       const openpal::RSlice& /*object*/)
 {
     Indent i(*callbacks);
 
@@ -303,9 +303,9 @@ IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
+IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
                                        const Group120Var12& value,
-                                       const openpal::RSlice& object)
+                                       const openpal::RSlice& /*object*/)
 {
     Indent i(*callbacks);
 
@@ -322,9 +322,9 @@ IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
+IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
                                        const Group120Var13& value,
-                                       const openpal::RSlice& object)
+                                       const openpal::RSlice& /*object*/)
 {
     Indent i(*callbacks);
 
@@ -341,9 +341,9 @@ IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
+IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
                                        const Group120Var14& value,
-                                       const openpal::RSlice& object)
+                                       const openpal::RSlice& /*object*/)
 {
     Indent i(*callbacks);
 
@@ -353,9 +353,9 @@ IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
+IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
                                        const Group120Var15& value,
-                                       const openpal::RSlice& object)
+                                       const openpal::RSlice& /*object*/)
 {
     Indent i(*callbacks);
 
@@ -365,32 +365,32 @@ IINField LoggingHandler::ProcessHeader(const FreeFormatHeader& header,
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const CountHeader& header, const ICollection<Group50Var1>& values)
+IINField LoggingHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group50Var1>& values)
 {
     return this->PrintTime(values);
 }
 
-IINField LoggingHandler::ProcessHeader(const CountHeader& header, const ICollection<Group51Var1>& values)
+IINField LoggingHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group51Var1>& values)
 {
     return this->PrintTime(values);
 }
 
-IINField LoggingHandler::ProcessHeader(const CountHeader& header, const ICollection<Group51Var2>& values)
+IINField LoggingHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group51Var2>& values)
 {
     return this->PrintTime(values);
 }
 
-IINField LoggingHandler::ProcessHeader(const CountHeader& header, const ICollection<Group52Var1>& values)
+IINField LoggingHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group52Var1>& values)
 {
     return this->PrintTime16(values);
 }
 
-IINField LoggingHandler::ProcessHeader(const CountHeader& header, const ICollection<Group52Var2>& values)
+IINField LoggingHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group52Var2>& values)
 {
     return this->PrintTime16(values);
 }
 
-IINField LoggingHandler::ProcessHeader(const CountHeader& header, const ICollection<Group120Var3>& values)
+IINField LoggingHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group120Var3>& values)
 {
     Indent i(*callbacks);
 
@@ -406,7 +406,7 @@ IINField LoggingHandler::ProcessHeader(const CountHeader& header, const ICollect
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const CountHeader& header, const ICollection<Group120Var4>& values)
+IINField LoggingHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group120Var4>& values)
 {
     Indent i(*callbacks);
 
@@ -421,7 +421,7 @@ IINField LoggingHandler::ProcessHeader(const CountHeader& header, const ICollect
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<IINValue>>& values)
+IINField LoggingHandler::ProcessHeader(const RangeHeader& /*header*/, const ICollection<Indexed<IINValue>>& values)
 {
     return this->PrintV(values);
 }
@@ -465,17 +465,18 @@ IINField LoggingHandler::ProcessHeader(const RangeHeader& header,
     return this->PrintVQT(header.enumeration, values);
 }
 
-IINField LoggingHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<OctetString>>& values)
+IINField LoggingHandler::ProcessHeader(const RangeHeader& /*header*/, const ICollection<Indexed<OctetString>>& values)
 {
     return this->PrintOctets(values);
 }
 
-IINField LoggingHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<TimeAndInterval>>& values)
+IINField LoggingHandler::ProcessHeader(const RangeHeader& /*header*/,
+                                       const ICollection<Indexed<TimeAndInterval>>& values)
 {
     return this->PrintTimeAndInterval(values);
 }
 
-IINField LoggingHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<Group121Var1>>& values)
+IINField LoggingHandler::ProcessHeader(const RangeHeader& /*header*/, const ICollection<Indexed<Group121Var1>>& values)
 {
     return this->PrintSecStat(values);
 }
@@ -518,12 +519,13 @@ IINField LoggingHandler::ProcessHeader(const PrefixHeader& header,
     return this->PrintVQT(header.enumeration, values);
 }
 
-IINField LoggingHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<OctetString>>& values)
+IINField LoggingHandler::ProcessHeader(const PrefixHeader& /*header*/, const ICollection<Indexed<OctetString>>& values)
 {
     return this->PrintOctets(values);
 }
 
-IINField LoggingHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<TimeAndInterval>>& values)
+IINField LoggingHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                       const ICollection<Indexed<TimeAndInterval>>& values)
 {
     return this->PrintTimeAndInterval(values);
 }
@@ -570,12 +572,12 @@ IINField LoggingHandler::ProcessHeader(const PrefixHeader& header,
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<Group122Var1>>& values)
+IINField LoggingHandler::ProcessHeader(const PrefixHeader& /*header*/, const ICollection<Indexed<Group122Var1>>& values)
 {
     return this->PrintSecStat(values);
 }
 
-IINField LoggingHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<Group122Var2>>& values)
+IINField LoggingHandler::ProcessHeader(const PrefixHeader& /*header*/, const ICollection<Indexed<Group122Var2>>& values)
 {
     Indent i(*callbacks);
     auto logItem = [this](const Indexed<Group122Var2>& item) {
@@ -592,31 +594,31 @@ IINField LoggingHandler::ProcessHeader(const PrefixHeader& header, const ICollec
     return IINField::Empty();
 }
 
-IINField LoggingHandler::ProcessHeader(const PrefixHeader& header,
+IINField LoggingHandler::ProcessHeader(const PrefixHeader& /*header*/,
                                        const ICollection<Indexed<ControlRelayOutputBlock>>& values)
 {
     return PrintCrob(values);
 }
 
-IINField LoggingHandler::ProcessHeader(const PrefixHeader& header,
+IINField LoggingHandler::ProcessHeader(const PrefixHeader& /*header*/,
                                        const ICollection<Indexed<AnalogOutputInt16>>& values)
 {
     return PrintAO(values);
 }
 
-IINField LoggingHandler::ProcessHeader(const PrefixHeader& header,
+IINField LoggingHandler::ProcessHeader(const PrefixHeader& /*header*/,
                                        const ICollection<Indexed<AnalogOutputInt32>>& values)
 {
     return PrintAO(values);
 }
 
-IINField LoggingHandler::ProcessHeader(const PrefixHeader& header,
+IINField LoggingHandler::ProcessHeader(const PrefixHeader& /*header*/,
                                        const ICollection<Indexed<AnalogOutputFloat32>>& values)
 {
     return PrintAO(values);
 }
 
-IINField LoggingHandler::ProcessHeader(const PrefixHeader& header,
+IINField LoggingHandler::ProcessHeader(const PrefixHeader& /*header*/,
                                        const ICollection<Indexed<AnalogOutputDouble64>>& values)
 {
     return PrintAO(values);

--- a/cpp/libs/src/dnp3decode/LoggingHandler.h
+++ b/cpp/libs/src/dnp3decode/LoggingHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -40,7 +40,7 @@ namespace opendnp3
 class LoggingHandler final : public IAPDUHandler
 {
 public:
-    LoggingHandler(openpal::Logger logger, IDecoderCallbacks& callbacks);
+    LoggingHandler(const openpal::Logger& logger, IDecoderCallbacks& callbacks);
 
 private:
     virtual void OnHeaderResult(const HeaderRecord& record, const IINField& result) override;
@@ -73,7 +73,7 @@ private:
     template<class T> IINField PrintAO(const ICollection<Indexed<T>>& items);
 
     IINField PrintCrob(const ICollection<Indexed<ControlRelayOutputBlock>>& items);
-    IINField PrintOctets(const ICollection<Indexed<OctetString>>& values);
+    IINField PrintOctets(const ICollection<Indexed<OctetString>>& items);
     IINField PrintTimeAndInterval(const ICollection<Indexed<TimeAndInterval>>& values);
 
     template<class T> IINField PrintVQT(GroupVariation gv, const ICollection<Indexed<T>>& items);

--- a/cpp/libs/src/opendnp3/LayerInterfaces.h
+++ b/cpp/libs/src/opendnp3/LayerInterfaces.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/LogLevels.cpp
+++ b/cpp/libs/src/opendnp3/LogLevels.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/Route.h
+++ b/cpp/libs/src/opendnp3/Route.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/APDUBuilders.cpp
+++ b/cpp/libs/src/opendnp3/app/APDUBuilders.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/APDUBuilders.h
+++ b/cpp/libs/src/opendnp3/app/APDUBuilders.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -30,7 +30,7 @@ namespace build
 {
     // -------- requests -------------
 
-    void ClassRequest(APDURequest& request, FunctionCode code, const ClassField& classes, uint8_t seq);
+    void ClassRequest(APDURequest& request, FunctionCode fc, const ClassField& classes, uint8_t seq);
 
     bool WriteClassHeaders(HeaderWriter& writer, const ClassField& classes);
 

--- a/cpp/libs/src/opendnp3/app/APDUHeader.cpp
+++ b/cpp/libs/src/opendnp3/app/APDUHeader.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/APDUHeader.h
+++ b/cpp/libs/src/opendnp3/app/APDUHeader.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/APDULogging.cpp
+++ b/cpp/libs/src/opendnp3/app/APDULogging.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/APDULogging.h
+++ b/cpp/libs/src/opendnp3/app/APDULogging.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/APDURequest.cpp
+++ b/cpp/libs/src/opendnp3/app/APDURequest.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -26,7 +26,7 @@ namespace opendnp3
 
 APDURequest::APDURequest(const openpal::WSlice& aBuffer) : APDUWrapper(aBuffer) {}
 
-void APDURequest::ConfigureHeader(FunctionCode code, uint8_t seq)
+void APDURequest::ConfigureHeader(FunctionCode /*code*/, uint8_t seq)
 {
     this->SetFunction(FunctionCode::AUTH_REQUEST);
     this->SetControl(AppControlField::Request(seq));

--- a/cpp/libs/src/opendnp3/app/APDURequest.h
+++ b/cpp/libs/src/opendnp3/app/APDURequest.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/APDUResponse.cpp
+++ b/cpp/libs/src/opendnp3/app/APDUResponse.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -21,7 +21,7 @@
 
 #include <openpal/Configure.h>
 
-#include <assert.h>
+#include <cassert>
 
 using namespace openpal;
 

--- a/cpp/libs/src/opendnp3/app/APDUResponse.h
+++ b/cpp/libs/src/opendnp3/app/APDUResponse.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/APDUWrapper.cpp
+++ b/cpp/libs/src/opendnp3/app/APDUWrapper.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -23,7 +23,7 @@
 
 #include <openpal/Configure.h>
 
-#include <assert.h>
+#include <cassert>
 
 using namespace openpal;
 

--- a/cpp/libs/src/opendnp3/app/APDUWrapper.h
+++ b/cpp/libs/src/opendnp3/app/APDUWrapper.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -43,7 +43,7 @@ class APDUWrapper
 public:
     APDUWrapper();
 
-    explicit APDUWrapper(const openpal::WSlice& aBuffer);
+    explicit APDUWrapper(const openpal::WSlice& buffer_);
 
     bool IsValid() const;
 

--- a/cpp/libs/src/opendnp3/app/AnalogCommandEvent.cpp
+++ b/cpp/libs/src/opendnp3/app/AnalogCommandEvent.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/AnalogOutput.cpp
+++ b/cpp/libs/src/opendnp3/app/AnalogOutput.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/AppControlField.cpp
+++ b/cpp/libs/src/opendnp3/app/AppControlField.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/AppControlField.h
+++ b/cpp/libs/src/opendnp3/app/AppControlField.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/AppSeqNum.h
+++ b/cpp/libs/src/opendnp3/app/AppSeqNum.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/BinaryCommandEvent.cpp
+++ b/cpp/libs/src/opendnp3/app/BinaryCommandEvent.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/BitfieldRangeWriteIterator.h
+++ b/cpp/libs/src/opendnp3/app/BitfieldRangeWriteIterator.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/ClassField.cpp
+++ b/cpp/libs/src/opendnp3/app/ClassField.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/ControlRelayOutputBlock.cpp
+++ b/cpp/libs/src/opendnp3/app/ControlRelayOutputBlock.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/CountWriteIterator.h
+++ b/cpp/libs/src/opendnp3/app/CountWriteIterator.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/DNP3Serializer.h
+++ b/cpp/libs/src/opendnp3/app/DNP3Serializer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/DownSampling.h
+++ b/cpp/libs/src/opendnp3/app/DownSampling.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/EventTriggers.cpp
+++ b/cpp/libs/src/opendnp3/app/EventTriggers.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -31,18 +31,14 @@ namespace measurements
         {
             return true;
         }
-        else
+
+        double diff = fabs(newMeas.value - oldMeas.value);
+        if (diff == INFINITY)
         {
-            double diff = fabs(newMeas.value - oldMeas.value);
-            if (diff == INFINITY)
-            {
-                return true;
-            }
-            else
-            {
-                return diff > deadband;
-            }
+            return true;
         }
+
+        return diff > deadband;
     }
 } // namespace measurements
 

--- a/cpp/libs/src/opendnp3/app/Functions.cpp
+++ b/cpp/libs/src/opendnp3/app/Functions.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -16,26 +16,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-/**
- * Licensed to Green Energy Corp (www.greenenergycorp.com) under one or
- * more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Green Energy Corp licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except in
- * compliance with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * This project was forked on 01/01/2013 by Automatak, LLC and modifications
- * may have been made to this file. Automatak, LLC licenses these modifications
- * to you under the terms of the License.
  */
 
 #include "Functions.h"

--- a/cpp/libs/src/opendnp3/app/Functions.h
+++ b/cpp/libs/src/opendnp3/app/Functions.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -17,26 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Licensed to Green Energy Corp (www.greenenergycorp.com) under one or
- * more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Green Energy Corp licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except in
- * compliance with the License.  You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * This project was forked on 01/01/2013 by Automatak, LLC and modifications
- * may have been made to this file. Automatak, LLC licenses these modifications
- * to you under the terms of the License.
- */
+
 #ifndef OPENDNP3_FUNCTIONS_H
 #define OPENDNP3_FUNCTIONS_H
 

--- a/cpp/libs/src/opendnp3/app/GroupVariationRecord.cpp
+++ b/cpp/libs/src/opendnp3/app/GroupVariationRecord.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/GroupVariationRecord.h
+++ b/cpp/libs/src/opendnp3/app/GroupVariationRecord.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/HeaderWriter.cpp
+++ b/cpp/libs/src/opendnp3/app/HeaderWriter.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -21,7 +21,7 @@
 
 #include <openpal/serialization/Serialization.h>
 
-#include <assert.h>
+#include <cassert>
 
 using namespace openpal;
 
@@ -48,10 +48,8 @@ bool HeaderWriter::Rollback()
         mark.Clear();
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 bool HeaderWriter::WriteHeader(GroupVariationID id, QualifierCode qc)
@@ -60,13 +58,11 @@ bool HeaderWriter::WriteHeader(GroupVariationID id, QualifierCode qc)
     {
         return false;
     }
-    else
-    {
-        UInt8::WriteBuffer(*position, id.group);
-        UInt8::WriteBuffer(*position, id.variation);
-        UInt8::WriteBuffer(*position, QualifierCodeToType(qc));
-        return true;
-    }
+
+    UInt8::WriteBuffer(*position, id.group);
+    UInt8::WriteBuffer(*position, id.variation);
+    UInt8::WriteBuffer(*position, QualifierCodeToType(qc));
+    return true;
 }
 
 bool HeaderWriter::WriteHeaderWithReserve(GroupVariationID id, QualifierCode qc, uint32_t reserve)
@@ -83,10 +79,8 @@ bool HeaderWriter::WriteFreeFormat(const IVariableLength& value)
         openpal::UInt16::WriteBuffer(*position, value.Size());
         return value.Write(*position);
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 } // namespace opendnp3

--- a/cpp/libs/src/opendnp3/app/HeaderWriter.h
+++ b/cpp/libs/src/opendnp3/app/HeaderWriter.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/IINField.cpp
+++ b/cpp/libs/src/opendnp3/app/IINField.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/IINValue.h
+++ b/cpp/libs/src/opendnp3/app/IINValue.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/IVariableLength.h
+++ b/cpp/libs/src/opendnp3/app/IVariableLength.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/MeasurementFactory.h
+++ b/cpp/libs/src/opendnp3/app/MeasurementFactory.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/MeasurementTypes.cpp
+++ b/cpp/libs/src/opendnp3/app/MeasurementTypes.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/Message.h
+++ b/cpp/libs/src/opendnp3/app/Message.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/OctetData.cpp
+++ b/cpp/libs/src/opendnp3/app/OctetData.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/PrefixedWriteIterator.h
+++ b/cpp/libs/src/opendnp3/app/PrefixedWriteIterator.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/QualityFlags.cpp
+++ b/cpp/libs/src/opendnp3/app/QualityFlags.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/QualityFlags.h
+++ b/cpp/libs/src/opendnp3/app/QualityFlags.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/Range.h
+++ b/cpp/libs/src/opendnp3/app/Range.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/RangeWriteIterator.h
+++ b/cpp/libs/src/opendnp3/app/RangeWriteIterator.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/SecurityStat.cpp
+++ b/cpp/libs/src/opendnp3/app/SecurityStat.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/SequenceInfo.h
+++ b/cpp/libs/src/opendnp3/app/SequenceInfo.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/TxBuffer.h
+++ b/cpp/libs/src/opendnp3/app/TxBuffer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/WriteConversionTemplates.h
+++ b/cpp/libs/src/opendnp3/app/WriteConversionTemplates.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/WriteConversions.h
+++ b/cpp/libs/src/opendnp3/app/WriteConversions.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/APDUHeaderParser.cpp
+++ b/cpp/libs/src/opendnp3/app/parsing/APDUHeaderParser.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -37,11 +37,9 @@ APDUHeaderParser::Result<APDUHeader> APDUHeaderParser::ParseRequest(const openpa
         FORMAT_LOGGER_BLOCK(logger, flags::WARN, "Request fragment  with insufficient size of %u bytes", apdu.Size());
         return Result<APDUHeader>::Error();
     }
-    else
-    {
-        return Result<APDUHeader>::Ok(APDUHeader(AppControlField(apdu[0]), FunctionCodeFromType(apdu[1])),
-                                      apdu.Skip(APDUHeader::REQUEST_SIZE));
-    }
+
+    return Result<APDUHeader>::Ok(APDUHeader(AppControlField(apdu[0]), FunctionCodeFromType(apdu[1])),
+                                  apdu.Skip(APDUHeader::REQUEST_SIZE));
 }
 
 APDUHeaderParser::Result<APDUResponseHeader> APDUHeaderParser::ParseResponse(const openpal::RSlice& apdu,
@@ -52,12 +50,10 @@ APDUHeaderParser::Result<APDUResponseHeader> APDUHeaderParser::ParseResponse(con
         FORMAT_LOGGER_BLOCK(logger, flags::WARN, "Response fragment  with insufficient size of %u bytes", apdu.Size());
         return Result<APDUResponseHeader>::Error();
     }
-    else
-    {
-        return Result<APDUResponseHeader>::Ok(
-            APDUResponseHeader(AppControlField(apdu[0]), FunctionCodeFromType(apdu[1]), IINField(apdu[2], apdu[3])),
-            apdu.Skip(APDUHeader::RESPONSE_SIZE));
-    }
+
+    return Result<APDUResponseHeader>::Ok(
+        APDUResponseHeader(AppControlField(apdu[0]), FunctionCodeFromType(apdu[1]), IINField(apdu[2], apdu[3])),
+        apdu.Skip(APDUHeader::RESPONSE_SIZE));
 }
 
 } // namespace opendnp3

--- a/cpp/libs/src/opendnp3/app/parsing/APDUHeaderParser.h
+++ b/cpp/libs/src/opendnp3/app/parsing/APDUHeaderParser.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/APDUParser.cpp
+++ b/cpp/libs/src/opendnp3/app/parsing/APDUParser.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -103,7 +103,8 @@ ParseResult APDUParser::ParseHeader(RSlice& buffer,
     }
 
     // if a white-list is defined and it doesn't validate, exit early
-    if (pWhiteList && !pWhiteList->IsAllowed(count, GV.enumeration, QualifierCodeFromType(header.qualifier)))
+    if ((pWhiteList != nullptr)
+        && !pWhiteList->IsAllowed(count, GV.enumeration, QualifierCodeFromType(header.qualifier)))
     {
         FORMAT_LOGGER_BLOCK(pLogger, flags::WARN, "Header (%i) w/ Object (%i,%i) and qualifier (%i) failed whitelist",
                             count, header.group, header.variation, header.qualifier);
@@ -160,7 +161,7 @@ ParseResult APDUParser::HandleAllObjectsHeader(openpal::Logger* pLogger,
     FORMAT_LOGGER_BLOCK(pLogger, settings.Filters(), "%03u,%03u - %s - %s", record.group, record.variation,
                         GroupVariationToString(record.enumeration), QualifierCodeToString(QualifierCode::ALL_OBJECTS));
 
-    if (pHandler)
+    if (pHandler != nullptr)
     {
         pHandler->OnHeader(AllObjectsHeader(record));
     }

--- a/cpp/libs/src/opendnp3/app/parsing/APDUParser.h
+++ b/cpp/libs/src/opendnp3/app/parsing/APDUParser.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/BitReader.cpp
+++ b/cpp/libs/src/opendnp3/app/parsing/BitReader.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -21,7 +21,7 @@
 
 #include <openpal/Configure.h>
 
-#include <assert.h>
+#include <cassert>
 
 namespace opendnp3
 {

--- a/cpp/libs/src/opendnp3/app/parsing/BitReader.h
+++ b/cpp/libs/src/opendnp3/app/parsing/BitReader.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -31,7 +31,7 @@ uint32_t NumBytesInBits(uint32_t numBits);
 bool GetBit(const openpal::RSlice& buffer, uint32_t position);
 
 uint32_t NumBytesInDoubleBits(uint32_t numBits);
-DoubleBit GetDoubleBit(const openpal::RSlice& buffer, uint32_t position);
+DoubleBit GetDoubleBit(const openpal::RSlice& buffer, uint32_t index);
 
 } // namespace opendnp3
 

--- a/cpp/libs/src/opendnp3/app/parsing/BufferedCollection.h
+++ b/cpp/libs/src/opendnp3/app/parsing/BufferedCollection.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/Collections.h
+++ b/cpp/libs/src/opendnp3/app/parsing/Collections.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/CountIndexParser.cpp
+++ b/cpp/libs/src/opendnp3/app/parsing/CountIndexParser.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -64,10 +64,8 @@ ParseResult CountIndexParser::ParseHeader(openpal::RSlice& buffer,
 
         return ParseCountOfObjects(buffer, record, numparser, count, pLogger, pHandler);
     }
-    else
-    {
-        return res;
-    }
+
+    return res;
 }
 
 ParseResult CountIndexParser::Process(const HeaderRecord& record,
@@ -80,15 +78,13 @@ ParseResult CountIndexParser::Process(const HeaderRecord& record,
         SIMPLE_LOGGER_BLOCK(pLogger, flags::WARN, "Not enough data for specified objects");
         return ParseResult::NOT_ENOUGH_DATA_FOR_OBJECTS;
     }
-    else
+
+    if (pHandler != nullptr)
     {
-        if (pHandler)
-        {
-            handler(record, count, numparser, buffer, *pHandler);
-        }
-        buffer.Advance(requiredSize);
-        return ParseResult::OK;
+        handler(record, count, numparser, buffer, *pHandler);
     }
+    buffer.Advance(requiredSize);
+    return ParseResult::OK;
 }
 
 ParseResult CountIndexParser::ParseCountOfObjects(openpal::RSlice& buffer,
@@ -244,7 +240,7 @@ ParseResult CountIndexParser::ParseIndexPrefixedOctetData(openpal::RSlice& buffe
         return ParseResult::NOT_ENOUGH_DATA_FOR_OBJECTS;
     }
 
-    if (pHandler)
+    if (pHandler != nullptr)
     {
         auto read = [&numparser, record](RSlice& buffer, uint32_t pos) -> Indexed<OctetString> {
             auto index = numparser.ReadNum(buffer);

--- a/cpp/libs/src/opendnp3/app/parsing/CountIndexParser.h
+++ b/cpp/libs/src/opendnp3/app/parsing/CountIndexParser.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/CountParser.cpp
+++ b/cpp/libs/src/opendnp3/app/parsing/CountParser.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -41,15 +41,13 @@ ParseResult CountParser::Process(const HeaderRecord& record,
         SIMPLE_LOGGER_BLOCK(pLogger, flags::WARN, "Not enough data for specified objects");
         return ParseResult::NOT_ENOUGH_DATA_FOR_OBJECTS;
     }
-    else
+
+    if (pHandler != nullptr)
     {
-        if (pHandler)
-        {
-            handler(record, count, buffer, *pHandler);
-        }
-        buffer.Advance(requiredSize);
-        return ParseResult::OK;
+        handler(record, count, buffer, *pHandler);
     }
+    buffer.Advance(requiredSize);
+    return ParseResult::OK;
 }
 
 ParseResult CountParser::ParseHeader(openpal::RSlice& buffer,
@@ -71,15 +69,13 @@ ParseResult CountParser::ParseHeader(openpal::RSlice& buffer,
         {
             return ParseCountOfObjects(buffer, record, count, pLogger, pHandler);
         }
-        else
-        {
-            if (pHandler)
-            {
-                pHandler->OnHeader(CountHeader(record, count));
-            }
 
-            return ParseResult::OK;
+        if (pHandler != nullptr)
+        {
+            pHandler->OnHeader(CountHeader(record, count));
         }
+
+        return ParseResult::OK;
     }
     else
     {

--- a/cpp/libs/src/opendnp3/app/parsing/CountParser.h
+++ b/cpp/libs/src/opendnp3/app/parsing/CountParser.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/FreeFormatParser.cpp
+++ b/cpp/libs/src/opendnp3/app/parsing/FreeFormatParser.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -139,7 +139,7 @@ ParseResult FreeFormatParser::ParseHeader(openpal::RSlice& buffer,
 
 ParseResult FreeFormatParser::ParseFreeFormat(FreeFormatHandler parser,
                                               const FreeFormatHeader& header,
-                                              uint16_t size,
+                                              uint16_t /*size*/,
                                               openpal::RSlice& objects,
                                               IAPDUHandler* pHandler,
                                               openpal::Logger* pLogger)
@@ -148,12 +148,10 @@ ParseResult FreeFormatParser::ParseFreeFormat(FreeFormatHandler parser,
     {
         return ParseResult::OK;
     }
-    else
-    {
-        FORMAT_LOGGER_BLOCK(pLogger, flags::WARN, "Insufficient data for free-format object: (%i, %i)", header.group,
-                            header.variation);
-        return ParseResult::NOT_ENOUGH_DATA_FOR_OBJECTS;
-    }
+
+    FORMAT_LOGGER_BLOCK(pLogger, flags::WARN, "Insufficient data for free-format object: (%i, %i)", header.group,
+                        header.variation);
+    return ParseResult::NOT_ENOUGH_DATA_FOR_OBJECTS;
 }
 
 } // namespace opendnp3

--- a/cpp/libs/src/opendnp3/app/parsing/FreeFormatParser.h
+++ b/cpp/libs/src/opendnp3/app/parsing/FreeFormatParser.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -49,7 +49,7 @@ private:
                                       const openpal::RSlice& objects,
                                       IAPDUHandler* pHandler);
 
-    static ParseResult ParseFreeFormat(FreeFormatHandler handler,
+    static ParseResult ParseFreeFormat(FreeFormatHandler parser,
                                        const FreeFormatHeader& header,
                                        uint16_t size,
                                        openpal::RSlice& objects,

--- a/cpp/libs/src/opendnp3/app/parsing/Functions.h
+++ b/cpp/libs/src/opendnp3/app/parsing/Functions.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/IAPDUHandler.cpp
+++ b/cpp/libs/src/opendnp3/app/parsing/IAPDUHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -307,304 +307,322 @@ void IAPDUHandler::OnHeader(const PrefixHeader& header, const ICollection<Indexe
     Record(header, this->ProcessHeader(header, values));
 }
 
-IINField IAPDUHandler::ProcessHeader(const AllObjectsHeader& record)
+IINField IAPDUHandler::ProcessHeader(const AllObjectsHeader& /*record*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const RangeHeader& header)
+IINField IAPDUHandler::ProcessHeader(const RangeHeader& /*header*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const CountHeader& header)
+IINField IAPDUHandler::ProcessHeader(const CountHeader& /*header*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& header,
-                                     const Group120Var1& value,
-                                     const openpal::RSlice& object)
+IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
+                                     const Group120Var1& /*value*/,
+                                     const openpal::RSlice& /*object*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& header,
-                                     const Group120Var2& value,
-                                     const openpal::RSlice& object)
+IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
+                                     const Group120Var2& /*value*/,
+                                     const openpal::RSlice& /*object*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& header,
-                                     const Group120Var5& value,
-                                     const openpal::RSlice& object)
+IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
+                                     const Group120Var5& /*value*/,
+                                     const openpal::RSlice& /*object*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& header,
-                                     const Group120Var6& value,
-                                     const openpal::RSlice& object)
+IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
+                                     const Group120Var6& /*value*/,
+                                     const openpal::RSlice& /*object*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& header,
-                                     const Group120Var7& value,
-                                     const openpal::RSlice& object)
+IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
+                                     const Group120Var7& /*value*/,
+                                     const openpal::RSlice& /*object*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& header,
-                                     const Group120Var8& value,
-                                     const openpal::RSlice& object)
+IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
+                                     const Group120Var8& /*value*/,
+                                     const openpal::RSlice& /*object*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& header,
-                                     const Group120Var9& value,
-                                     const openpal::RSlice& object)
+IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
+                                     const Group120Var9& /*value*/,
+                                     const openpal::RSlice& /*object*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& header,
-                                     const Group120Var10& value,
-                                     const openpal::RSlice& object)
+IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
+                                     const Group120Var10& /*value*/,
+                                     const openpal::RSlice& /*object*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& header,
-                                     const Group120Var11& value,
-                                     const openpal::RSlice& object)
+IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
+                                     const Group120Var11& /*value*/,
+                                     const openpal::RSlice& /*object*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& header,
-                                     const Group120Var12& value,
-                                     const openpal::RSlice& object)
+IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
+                                     const Group120Var12& /*value*/,
+                                     const openpal::RSlice& /*object*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& header,
-                                     const Group120Var13& value,
-                                     const openpal::RSlice& object)
+IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
+                                     const Group120Var13& /*value*/,
+                                     const openpal::RSlice& /*object*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& header,
-                                     const Group120Var14& value,
-                                     const openpal::RSlice& object)
+IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
+                                     const Group120Var14& /*value*/,
+                                     const openpal::RSlice& /*object*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& header,
-                                     const Group120Var15& value,
-                                     const openpal::RSlice& object)
+IINField IAPDUHandler::ProcessHeader(const FreeFormatHeader& /*header*/,
+                                     const Group120Var15& /*value*/,
+                                     const openpal::RSlice& /*object*/)
 {
     return ProcessUnsupportedHeader();
 }
 
 /// ---- counts -----
 
-IINField IAPDUHandler::ProcessHeader(const CountHeader& header, const ICollection<Group50Var1>&)
+IINField IAPDUHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group50Var1>& /*unused*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const CountHeader& header, const ICollection<Group50Var3>& values)
+IINField IAPDUHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group50Var3>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const CountHeader& header, const ICollection<Group51Var1>&)
+IINField IAPDUHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group51Var1>& /*unused*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const CountHeader& header, const ICollection<Group51Var2>&)
+IINField IAPDUHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group51Var2>& /*unused*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const CountHeader& header, const ICollection<Group52Var1>& values)
+IINField IAPDUHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group52Var1>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const CountHeader& header, const ICollection<Group52Var2>&)
+IINField IAPDUHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group52Var2>& /*unused*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const CountHeader& header, const ICollection<Group120Var3>&)
+IINField IAPDUHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group120Var3>& /*unused*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const CountHeader& header, const ICollection<Group120Var4>&)
+IINField IAPDUHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group120Var4>& /*unused*/)
 {
     return ProcessUnsupportedHeader();
 }
 
 /// ---- ranges -----
 
-IINField IAPDUHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<IINValue>>& values)
+IINField IAPDUHandler::ProcessHeader(const RangeHeader& /*header*/, const ICollection<Indexed<IINValue>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<Binary>>& values)
+IINField IAPDUHandler::ProcessHeader(const RangeHeader& /*header*/, const ICollection<Indexed<Binary>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<DoubleBitBinary>>& values)
+IINField IAPDUHandler::ProcessHeader(const RangeHeader& /*header*/,
+                                     const ICollection<Indexed<DoubleBitBinary>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<BinaryOutputStatus>>& values)
+IINField IAPDUHandler::ProcessHeader(const RangeHeader& /*header*/,
+                                     const ICollection<Indexed<BinaryOutputStatus>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<Counter>>& values)
+IINField IAPDUHandler::ProcessHeader(const RangeHeader& /*header*/, const ICollection<Indexed<Counter>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<FrozenCounter>>& values)
+IINField IAPDUHandler::ProcessHeader(const RangeHeader& /*header*/,
+                                     const ICollection<Indexed<FrozenCounter>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<Analog>>& values)
+IINField IAPDUHandler::ProcessHeader(const RangeHeader& /*header*/, const ICollection<Indexed<Analog>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<AnalogOutputStatus>>& values)
+IINField IAPDUHandler::ProcessHeader(const RangeHeader& /*header*/,
+                                     const ICollection<Indexed<AnalogOutputStatus>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<OctetString>>& values)
+IINField IAPDUHandler::ProcessHeader(const RangeHeader& /*header*/, const ICollection<Indexed<OctetString>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<TimeAndInterval>>& values)
+IINField IAPDUHandler::ProcessHeader(const RangeHeader& /*header*/,
+                                     const ICollection<Indexed<TimeAndInterval>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<Group121Var1>>& values)
+IINField IAPDUHandler::ProcessHeader(const RangeHeader& /*header*/,
+                                     const ICollection<Indexed<Group121Var1>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
 /// ---- index prefixes -----
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<Counter>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/, const ICollection<Indexed<Counter>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<FrozenCounter>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<FrozenCounter>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<Binary>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/, const ICollection<Indexed<Binary>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<BinaryOutputStatus>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<BinaryOutputStatus>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<DoubleBitBinary>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<DoubleBitBinary>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<Analog>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/, const ICollection<Indexed<Analog>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<AnalogOutputStatus>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<AnalogOutputStatus>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<OctetString>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<OctetString>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<TimeAndInterval>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<TimeAndInterval>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<BinaryCommandEvent>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<BinaryCommandEvent>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<AnalogCommandEvent>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<AnalogCommandEvent>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<Group122Var1>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<Group122Var1>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<Group122Var2>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<Group122Var2>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
 //// --- controls ----
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header,
-                                     const ICollection<Indexed<ControlRelayOutputBlock>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<ControlRelayOutputBlock>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<AnalogOutputInt16>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<AnalogOutputInt16>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<AnalogOutputInt32>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<AnalogOutputInt32>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header,
-                                     const ICollection<Indexed<AnalogOutputFloat32>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<AnalogOutputFloat32>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }
 
-IINField IAPDUHandler::ProcessHeader(const PrefixHeader& header,
-                                     const ICollection<Indexed<AnalogOutputDouble64>>& values)
+IINField IAPDUHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<AnalogOutputDouble64>>& /*values*/)
 {
     return ProcessUnsupportedHeader();
 }

--- a/cpp/libs/src/opendnp3/app/parsing/IAPDUHandler.h
+++ b/cpp/libs/src/opendnp3/app/parsing/IAPDUHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/IWhiteList.h
+++ b/cpp/libs/src/opendnp3/app/parsing/IWhiteList.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/NumParser.cpp
+++ b/cpp/libs/src/opendnp3/app/parsing/NumParser.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -45,10 +45,8 @@ ParseResult NumParser::ParseCount(openpal::RSlice& buffer, uint16_t& count, open
             SIMPLE_LOGGER_BLOCK(pLogger, flags::WARN, "count of 0");
             return ParseResult::COUNT_OF_ZERO;
         }
-        else
-        {
-            return ParseResult::OK;
-        }
+
+        return ParseResult::OK;
     }
     else
     {
@@ -64,21 +62,17 @@ ParseResult NumParser::ParseRange(openpal::RSlice& buffer, Range& range, openpal
         SIMPLE_LOGGER_BLOCK(pLogger, flags::WARN, "Not enough data for start / stop");
         return ParseResult::NOT_ENOUGH_DATA_FOR_RANGE;
     }
-    else
-    {
-        range.start = this->ReadNum(buffer);
-        range.stop = this->ReadNum(buffer);
 
-        if (range.IsValid())
-        {
-            return ParseResult::OK;
-        }
-        else
-        {
-            FORMAT_LOGGER_BLOCK(pLogger, flags::WARN, "start (%u) > stop (%u)", range.start, range.stop);
-            return ParseResult::BAD_START_STOP;
-        }
+    range.start = this->ReadNum(buffer);
+    range.stop = this->ReadNum(buffer);
+
+    if (range.IsValid())
+    {
+        return ParseResult::OK;
     }
+
+    FORMAT_LOGGER_BLOCK(pLogger, flags::WARN, "start (%u) > stop (%u)", range.start, range.stop);
+    return ParseResult::BAD_START_STOP;
 }
 
 uint16_t NumParser::ReadNum(openpal::RSlice& buffer) const
@@ -92,11 +86,9 @@ bool NumParser::Read(uint16_t& num, openpal::RSlice& buffer) const
     {
         return false;
     }
-    else
-    {
-        num = pReadFun(buffer);
-        return true;
-    }
+
+    num = pReadFun(buffer);
+    return true;
 }
 
 uint16_t NumParser::ReadByte(openpal::RSlice& buffer)

--- a/cpp/libs/src/opendnp3/app/parsing/NumParser.h
+++ b/cpp/libs/src/opendnp3/app/parsing/NumParser.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/ObjectHeaderParser.cpp
+++ b/cpp/libs/src/opendnp3/app/parsing/ObjectHeaderParser.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -39,13 +39,11 @@ ParseResult ObjectHeaderParser::ParseObjectHeader(ObjectHeader& header, RSlice& 
         SIMPLE_LOGGER_BLOCK(pLogger, flags::WARN, "Not enough data for header");
         return ParseResult::NOT_ENOUGH_DATA_FOR_HEADER;
     }
-    else
-    {
-        header.group = UInt8::ReadBuffer(buffer);
-        header.variation = UInt8::ReadBuffer(buffer);
-        header.qualifier = UInt8::ReadBuffer(buffer);
-        return ParseResult::OK;
-    }
+
+    header.group = UInt8::ReadBuffer(buffer);
+    header.variation = UInt8::ReadBuffer(buffer);
+    header.qualifier = UInt8::ReadBuffer(buffer);
+    return ParseResult::OK;
 }
 
 bool ObjectHeaderParser::ReadFirstGroupVariation(const openpal::RSlice& objects, GroupVariation& gv)

--- a/cpp/libs/src/opendnp3/app/parsing/ObjectHeaderParser.h
+++ b/cpp/libs/src/opendnp3/app/parsing/ObjectHeaderParser.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/ParseResult.h
+++ b/cpp/libs/src/opendnp3/app/parsing/ParseResult.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/ParserSettings.h
+++ b/cpp/libs/src/opendnp3/app/parsing/ParserSettings.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/PrefixFields.h
+++ b/cpp/libs/src/opendnp3/app/parsing/PrefixFields.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/app/parsing/RangeParser.h
+++ b/cpp/libs/src/opendnp3/app/parsing/RangeParser.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/CRC.cpp
+++ b/cpp/libs/src/opendnp3/link/CRC.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/CRC.h
+++ b/cpp/libs/src/opendnp3/link/CRC.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/IFrameSink.h
+++ b/cpp/libs/src/opendnp3/link/IFrameSink.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/ILinkLayer.h
+++ b/cpp/libs/src/opendnp3/link/ILinkLayer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/ILinkSession.h
+++ b/cpp/libs/src/opendnp3/link/ILinkSession.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/ILinkTx.h
+++ b/cpp/libs/src/opendnp3/link/ILinkTx.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/ITransportSegment.h
+++ b/cpp/libs/src/opendnp3/link/ITransportSegment.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/LinkContext.h
+++ b/cpp/libs/src/opendnp3/link/LinkContext.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -55,8 +55,8 @@ class LinkContext
 public:
     LinkContext(const openpal::Logger& logger,
                 const std::shared_ptr<openpal::IExecutor>&,
-                const std::shared_ptr<IUpperLayer>&,
-                const std::shared_ptr<opendnp3::ILinkListener>&,
+                std::shared_ptr<IUpperLayer>,
+                std::shared_ptr<opendnp3::ILinkListener>,
                 ILinkSession& session,
                 const LinkLayerConfig&);
 

--- a/cpp/libs/src/opendnp3/link/LinkFrame.cpp
+++ b/cpp/libs/src/opendnp3/link/LinkFrame.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -27,7 +27,7 @@
 #include "opendnp3/link/CRC.h"
 #include "opendnp3/link/LinkHeader.h"
 
-#include <assert.h>
+#include <cassert>
 
 using namespace openpal;
 
@@ -85,10 +85,8 @@ uint32_t LinkFrame::CalcUserDataSize(uint8_t dataLength)
         uint32_t size = (dataLength / LPDU_DATA_BLOCK_SIZE) * LPDU_DATA_PLUS_CRC_SIZE; // complete blocks
         return (mod16 > 0) ? (size + mod16 + LPDU_CRC_SIZE) : size;                    // possible partial block
     }
-    else
-    {
-        return 0;
-    }
+
+    return 0;
 }
 
 ////////////////////////////////////////////////

--- a/cpp/libs/src/opendnp3/link/LinkFrame.h
+++ b/cpp/libs/src/opendnp3/link/LinkFrame.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -39,25 +39,25 @@ public:
     //	Functions for formatting outgoing Sec to Pri frames
     ////////////////////////////////////////////////
 
-    static openpal::RSlice FormatAck(openpal::WSlice& output,
+    static openpal::RSlice FormatAck(openpal::WSlice& buffer,
                                      bool aIsMaster,
                                      bool aIsRcvBuffFull,
                                      uint16_t aDest,
                                      uint16_t aSrc,
                                      openpal::Logger* pLogger);
-    static openpal::RSlice FormatNack(openpal::WSlice& output,
+    static openpal::RSlice FormatNack(openpal::WSlice& buffer,
                                       bool aIsMaster,
                                       bool aIsRcvBuffFull,
                                       uint16_t aDest,
                                       uint16_t aSrc,
                                       openpal::Logger* pLogger);
-    static openpal::RSlice FormatLinkStatus(openpal::WSlice& output,
+    static openpal::RSlice FormatLinkStatus(openpal::WSlice& buffer,
                                             bool aIsMaster,
                                             bool aIsRcvBuffFull,
                                             uint16_t aDest,
                                             uint16_t aSrc,
                                             openpal::Logger* pLogger);
-    static openpal::RSlice FormatNotSupported(openpal::WSlice& output,
+    static openpal::RSlice FormatNotSupported(openpal::WSlice& buffer,
                                               bool aIsMaster,
                                               bool aIsRcvBuffFull,
                                               uint16_t aDest,
@@ -69,12 +69,12 @@ public:
     ////////////////////////////////////////////////
 
     static openpal::RSlice FormatTestLinkStatus(
-        openpal::WSlice& output, bool aIsMaster, bool aFcb, uint16_t aDest, uint16_t aSrc, openpal::Logger* pLogger);
+        openpal::WSlice& buffer, bool aIsMaster, bool aFcb, uint16_t aDest, uint16_t aSrc, openpal::Logger* pLogger);
     static openpal::RSlice FormatResetLinkStates(
-        openpal::WSlice& output, bool aIsMaster, uint16_t aDest, uint16_t aSrc, openpal::Logger* pLogger);
+        openpal::WSlice& buffer, bool aIsMaster, uint16_t aDest, uint16_t aSrc, openpal::Logger* pLogger);
     static openpal::RSlice FormatRequestLinkStatus(
-        openpal::WSlice& output, bool aIsMaster, uint16_t aDest, uint16_t aSrc, openpal::Logger* pLogger);
-    static openpal::RSlice FormatConfirmedUserData(openpal::WSlice& output,
+        openpal::WSlice& buffer, bool aIsMaster, uint16_t aDest, uint16_t aSrc, openpal::Logger* pLogger);
+    static openpal::RSlice FormatConfirmedUserData(openpal::WSlice& buffer,
                                                    bool aIsMaster,
                                                    bool aFcb,
                                                    uint16_t aDest,
@@ -82,7 +82,7 @@ public:
                                                    const uint8_t* apData,
                                                    uint8_t aDataLength,
                                                    openpal::Logger* pLogger);
-    static openpal::RSlice FormatUnconfirmedUserData(openpal::WSlice& output,
+    static openpal::RSlice FormatUnconfirmedUserData(openpal::WSlice& buffer,
                                                      bool aIsMaster,
                                                      uint16_t aDest,
                                                      uint16_t aSrc,
@@ -99,7 +99,7 @@ public:
     @param apDest Destination buffer to which the data is extracted
     @param aLength Length of user data to read to the dest buffer. The source buffer must be larger b/c of crc bytes.
     */
-    static void ReadUserData(const uint8_t* apSrc, uint8_t* apDest, uint32_t aLength);
+    static void ReadUserData(const uint8_t* apSrc, uint8_t* apDest, uint32_t length_);
 
     /** Validates FT3 user data integriry
     @param apBody Beginning of the FT3 user data
@@ -121,12 +121,12 @@ private:
     static void WriteUserData(const uint8_t* pSrc, uint8_t* pDest, uint8_t length);
 
     /** Write 10 header bytes to to buffer including 0x0564, all fields, and CRC */
-    static openpal::RSlice FormatHeader(openpal::WSlice& output,
+    static openpal::RSlice FormatHeader(openpal::WSlice& buffer,
                                         uint8_t aDataLength,
                                         bool aIsMaster,
                                         bool aFcb,
                                         bool aFcvDfc,
-                                        LinkFunction aCode,
+                                        LinkFunction aFuncCode,
                                         uint16_t aDest,
                                         uint16_t aSrc,
                                         openpal::Logger* pLogger);

--- a/cpp/libs/src/opendnp3/link/LinkHeader.cpp
+++ b/cpp/libs/src/opendnp3/link/LinkHeader.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/LinkHeader.h
+++ b/cpp/libs/src/opendnp3/link/LinkHeader.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -32,11 +32,11 @@ struct LinkHeader
 {
     LinkHeader();
 
-    LinkHeader(uint8_t len, uint16_t src, uint16_t dest, bool isFromMaster, bool fcvdfc, bool fcb, LinkFunction func);
+    LinkHeader(uint8_t len, uint16_t src, uint16_t dest, bool aFromMaster, bool fcvdfc, bool fcb, LinkFunction aCode);
 
     // Setter
 
-    void Set(uint8_t len, uint16_t src, uint16_t dest, bool isFromMaster, bool fcvdfc, bool fcb, LinkFunction func);
+    void Set(uint8_t len, uint16_t src, uint16_t dest, bool aFromMaster, bool fcvdfc, bool fcb, LinkFunction aCode);
 
     void ChangeFCB(bool aFCB);
 
@@ -90,11 +90,11 @@ struct LinkHeader
 
     /** Reads the header, setting all the fields. Does NOT validate 0x0564 or CRC
     @param apBuff Buffer of at least 10 bytes */
-    void Read(const uint8_t* data);
+    void Read(const uint8_t* apBuff);
 
     /** Writes header to buffer including, 0x0564 and CRC
     @param apBuff Buffer of at least 10 bytes */
-    void Write(uint8_t* dest) const;
+    void Write(uint8_t* apBuff) const;
 
     static uint8_t ControlByte(bool isMaster, bool fcb, bool fcvdfc, LinkFunction func);
 

--- a/cpp/libs/src/opendnp3/link/LinkHeaderFields.cpp
+++ b/cpp/libs/src/opendnp3/link/LinkHeaderFields.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/LinkLayer.cpp
+++ b/cpp/libs/src/opendnp3/link/LinkLayer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/LinkLayer.h
+++ b/cpp/libs/src/opendnp3/link/LinkLayer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/LinkLayerConfig.h
+++ b/cpp/libs/src/opendnp3/link/LinkLayerConfig.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/LinkLayerConstants.h
+++ b/cpp/libs/src/opendnp3/link/LinkLayerConstants.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/LinkLayerParser.cpp
+++ b/cpp/libs/src/opendnp3/link/LinkLayerParser.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -100,10 +100,8 @@ LinkLayerParser::State LinkLayerParser::ParseSync()
 
         return synced ? State::ReadHeader : State::FindSync;
     }
-    else
-    {
-        return State::FindSync;
-    }
+
+    return State::FindSync;
 }
 
 LinkLayerParser::State LinkLayerParser::ParseHeader()
@@ -114,11 +112,9 @@ LinkLayerParser::State LinkLayerParser::ParseHeader()
         {
             return State::ReadBody;
         }
-        else
-        {
-            this->FailFrame();
-            return State::FindSync;
-        }
+
+        this->FailFrame();
+        return State::FindSync;
     }
     else
     {
@@ -132,19 +128,15 @@ LinkLayerParser::State LinkLayerParser::ParseBody()
     {
         return State::ReadBody;
     }
-    else
+
+    if (this->ValidateBody())
     {
-        if (this->ValidateBody())
-        {
-            this->TransferUserData();
-            return State::Complete;
-        }
-        else
-        {
-            this->FailFrame();
-            return State::FindSync;
-        }
+        this->TransferUserData();
+        return State::Complete;
     }
+
+    this->FailFrame();
+    return State::FindSync;
 }
 
 void LinkLayerParser::PushFrame(IFrameSink& sink)
@@ -169,14 +161,7 @@ bool LinkLayerParser::ReadHeader()
     header.Read(buffer.ReadBuffer());
     if (CRC::IsCorrectCRC(buffer.ReadBuffer(), LI_CRC))
     {
-        if (ValidateHeaderParameters())
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
+        return ValidateHeaderParameters();
     }
     else
     {
@@ -199,12 +184,10 @@ bool LinkLayerParser::ValidateBody()
 
         return true;
     }
-    else
-    {
-        ++this->statistics.numBodyCrcError;
-        SIMPLE_LOG_BLOCK(logger, flags::ERR, "CRC failure in body");
-        return false;
-    }
+
+    ++this->statistics.numBodyCrcError;
+    SIMPLE_LOG_BLOCK(logger, flags::ERR, "CRC failure in body");
+    return false;
 }
 
 bool LinkLayerParser::ValidateHeaderParameters()

--- a/cpp/libs/src/opendnp3/link/LinkLayerParser.h
+++ b/cpp/libs/src/opendnp3/link/LinkLayerParser.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/PriLinkLayerStates.cpp
+++ b/cpp/libs/src/opendnp3/link/PriLinkLayerStates.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -33,28 +33,28 @@ namespace opendnp3
 // PriStateBase
 ////////////////////////////////////////
 
-PriStateBase& PriStateBase::OnAck(LinkContext& ctx, bool rxBuffFull)
+PriStateBase& PriStateBase::OnAck(LinkContext& ctx, bool /*rxBuffFull*/)
 {
     ++ctx.statistics.numUnexpectedFrame;
     SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "Frame context not understood");
     return *this;
 }
 
-PriStateBase& PriStateBase::OnNack(LinkContext& ctx, bool rxBuffFull)
+PriStateBase& PriStateBase::OnNack(LinkContext& ctx, bool /*rxBuffFull*/)
 {
     ++ctx.statistics.numUnexpectedFrame;
     SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "Frame context not understood");
     return *this;
 }
 
-PriStateBase& PriStateBase::OnLinkStatus(LinkContext& ctx, bool rxBuffFull)
+PriStateBase& PriStateBase::OnLinkStatus(LinkContext& ctx, bool /*rxBuffFull*/)
 {
     ++ctx.statistics.numUnexpectedFrame;
     SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "Frame context not understood");
     return *this;
 }
 
-PriStateBase& PriStateBase::OnNotSupported(LinkContext& ctx, bool rxBuffFull)
+PriStateBase& PriStateBase::OnNotSupported(LinkContext& ctx, bool /*rxBuffFull*/)
 {
     ++ctx.statistics.numUnexpectedFrame;
     SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "Frame context not understood");
@@ -73,17 +73,17 @@ PriStateBase& PriStateBase::OnTimeout(LinkContext& ctx)
     return *this;
 }
 
-PriStateBase& PriStateBase::TrySendConfirmed(LinkContext& ctx, ITransportSegment&)
+PriStateBase& PriStateBase::TrySendConfirmed(LinkContext& /*ctx*/, ITransportSegment& /*unused*/)
 {
     return *this;
 }
 
-PriStateBase& PriStateBase::TrySendUnconfirmed(LinkContext& ctx, ITransportSegment&)
+PriStateBase& PriStateBase::TrySendUnconfirmed(LinkContext& /*ctx*/, ITransportSegment& /*unused*/)
 {
     return *this;
 }
 
-PriStateBase& PriStateBase::TrySendRequestLinkStatus(LinkContext&)
+PriStateBase& PriStateBase::TrySendRequestLinkStatus(LinkContext& /*unused*/)
 {
     return *this;
 }
@@ -112,12 +112,10 @@ PriStateBase& PLLS_Idle::TrySendConfirmed(LinkContext& ctx, ITransportSegment& s
         ctx.QueueTransmit(buffer, true);
         return PLLS_ConfUserDataTransmitWait::Instance();
     }
-    else
-    {
-        ctx.ResetRetry();
-        ctx.QueueResetLinks(segments.GetAddresses().destination);
-        return PLLS_LinkResetTransmitWait::Instance();
-    }
+
+    ctx.ResetRetry();
+    ctx.QueueResetLinks(segments.GetAddresses().destination);
+    return PLLS_LinkResetTransmitWait::Instance();
 }
 
 PriStateBase& PLLS_Idle::TrySendRequestLinkStatus(LinkContext& ctx)
@@ -143,11 +141,10 @@ PriStateBase& PLLS_SendUnconfirmedTransmitWait::OnTxReady(LinkContext& ctx)
         ctx.QueueTransmit(output, true);
         return *this;
     }
-    else // we're done
-    {
-        ctx.CompleteSendOperation();
-        return PLLS_Idle::Instance();
-    }
+    // we're done
+
+    ctx.CompleteSendOperation();
+    return PLLS_Idle::Instance();
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -195,7 +192,7 @@ PriStateBase& PLLS_RequestLinkStatusTransmitWait::OnTxReady(LinkContext& ctx)
 
 PLLS_ResetLinkWait PLLS_ResetLinkWait::instance;
 
-PriStateBase& PLLS_ResetLinkWait::OnAck(LinkContext& ctx, bool rxBuffFull)
+PriStateBase& PLLS_ResetLinkWait::OnAck(LinkContext& ctx, bool /*rxBuffFull*/)
 {
     ctx.isRemoteReset = true;
     ctx.ResetWriteFCB();
@@ -215,12 +212,10 @@ PriStateBase& PLLS_ResetLinkWait::OnTimeout(LinkContext& ctx)
         ctx.QueueResetLinks(ctx.config.RemoteAddr);
         return PLLS_LinkResetTransmitWait::Instance();
     }
-    else
-    {
-        SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "Link reset final timeout, no retries remain");
-        ctx.CompleteSendOperation();
-        return PLLS_Idle::Instance();
-    }
+
+    SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "Link reset final timeout, no retries remain");
+    ctx.CompleteSendOperation();
+    return PLLS_Idle::Instance();
 }
 
 PriStateBase& PLLS_ResetLinkWait::Failure(LinkContext& ctx)
@@ -236,7 +231,7 @@ PriStateBase& PLLS_ResetLinkWait::Failure(LinkContext& ctx)
 
 PLLS_ConfDataWait PLLS_ConfDataWait::instance;
 
-PriStateBase& PLLS_ConfDataWait::OnAck(LinkContext& ctx, bool rxBuffFull)
+PriStateBase& PLLS_ConfDataWait::OnAck(LinkContext& ctx, bool /*rxBuffFull*/)
 {
     ctx.ToggleWriteFCB();
     ctx.CancelTimer();
@@ -248,11 +243,10 @@ PriStateBase& PLLS_ConfDataWait::OnAck(LinkContext& ctx, bool rxBuffFull)
         ctx.QueueTransmit(buffer, true);
         return PLLS_ConfUserDataTransmitWait::Instance();
     }
-    else // we're done!
-    {
-        ctx.CompleteSendOperation();
-        return PLLS_Idle::Instance();
-    }
+    // we're done!
+
+    ctx.CompleteSendOperation();
+    return PLLS_Idle::Instance();
 }
 
 PriStateBase& PLLS_ConfDataWait::OnNack(LinkContext& ctx, bool rxBuffFull)
@@ -263,13 +257,11 @@ PriStateBase& PLLS_ConfDataWait::OnNack(LinkContext& ctx, bool rxBuffFull)
     {
         return Failure(ctx);
     }
-    else
-    {
-        ctx.ResetRetry();
-        ctx.CancelTimer();
-        ctx.QueueResetLinks(ctx.pSegments->GetAddresses().destination);
-        return PLLS_LinkResetTransmitWait::Instance();
-    }
+
+    ctx.ResetRetry();
+    ctx.CancelTimer();
+    ctx.QueueResetLinks(ctx.pSegments->GetAddresses().destination);
+    return PLLS_LinkResetTransmitWait::Instance();
 }
 
 PriStateBase& PLLS_ConfDataWait::Failure(LinkContext& ctx)
@@ -290,13 +282,11 @@ PriStateBase& PLLS_ConfDataWait::OnTimeout(LinkContext& ctx)
         ctx.QueueTransmit(buffer, true);
         return PLLS_ConfUserDataTransmitWait::Instance();
     }
-    else
-    {
-        SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "Confirmed data final timeout, no retries remain");
-        ctx.listener->OnStateChange(opendnp3::LinkStatus::UNRESET);
-        ctx.CompleteSendOperation();
-        return PLLS_Idle::Instance();
-    }
+
+    SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "Confirmed data final timeout, no retries remain");
+    ctx.listener->OnStateChange(opendnp3::LinkStatus::UNRESET);
+    ctx.CompleteSendOperation();
+    return PLLS_Idle::Instance();
 }
 
 ////////////////////////////////////////////////////////
@@ -305,21 +295,21 @@ PriStateBase& PLLS_ConfDataWait::OnTimeout(LinkContext& ctx)
 
 PLLS_RequestLinkStatusWait PLLS_RequestLinkStatusWait::instance;
 
-PriStateBase& PLLS_RequestLinkStatusWait::OnNack(LinkContext& ctx, bool)
+PriStateBase& PLLS_RequestLinkStatusWait::OnNack(LinkContext& ctx, bool /*receiveBuffFull*/)
 {
     ctx.CancelTimer();
     ctx.FailKeepAlive(false);
     return PLLS_Idle::Instance();
 }
 
-PriStateBase& PLLS_RequestLinkStatusWait::OnLinkStatus(LinkContext& ctx, bool)
+PriStateBase& PLLS_RequestLinkStatusWait::OnLinkStatus(LinkContext& ctx, bool /*receiveBuffFull*/)
 {
     ctx.CancelTimer();
     ctx.CompleteKeepAlive();
     return PLLS_Idle::Instance();
 }
 
-PriStateBase& PLLS_RequestLinkStatusWait::OnNotSupported(LinkContext& ctx, bool)
+PriStateBase& PLLS_RequestLinkStatusWait::OnNotSupported(LinkContext& ctx, bool /*receiveBuffFull*/)
 {
     ctx.CancelTimer();
     ctx.FailKeepAlive(false);

--- a/cpp/libs/src/opendnp3/link/PriLinkLayerStates.h
+++ b/cpp/libs/src/opendnp3/link/PriLinkLayerStates.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -68,7 +68,7 @@ class PLLS_SendUnconfirmedTransmitWait final : public PriStateBase
 {
     MACRO_STATE_SINGLETON_INSTANCE(PLLS_SendUnconfirmedTransmitWait);
 
-    virtual PriStateBase& OnTxReady(LinkContext& link) override;
+    virtual PriStateBase& OnTxReady(LinkContext& ctx) override;
 };
 
 /////////////////////////////////////////////////////////////////////////////
@@ -79,7 +79,7 @@ class PLLS_LinkResetTransmitWait : public PriStateBase
 {
     MACRO_STATE_SINGLETON_INSTANCE(PLLS_LinkResetTransmitWait);
 
-    virtual PriStateBase& OnTxReady(LinkContext& link) override;
+    virtual PriStateBase& OnTxReady(LinkContext& ctx) override;
 };
 
 /////////////////////////////////////////////////////////////////////////////
@@ -90,7 +90,7 @@ class PLLS_ConfUserDataTransmitWait : public PriStateBase
 {
     MACRO_STATE_SINGLETON_INSTANCE(PLLS_ConfUserDataTransmitWait);
 
-    virtual PriStateBase& OnTxReady(LinkContext& link) override;
+    virtual PriStateBase& OnTxReady(LinkContext& ctx) override;
 };
 
 /////////////////////////////////////////////////////////////////////////////
@@ -101,7 +101,7 @@ class PLLS_RequestLinkStatusTransmitWait : public PriStateBase
 {
     MACRO_STATE_SINGLETON_INSTANCE(PLLS_RequestLinkStatusTransmitWait);
 
-    virtual PriStateBase& OnTxReady(LinkContext& link) override;
+    virtual PriStateBase& OnTxReady(LinkContext& ctx) override;
 };
 
 /////////////////////////////////////////////////////////////////////////////
@@ -144,7 +144,7 @@ class PLLS_ConfDataWait final : public PriStateBase
     MACRO_STATE_SINGLETON_INSTANCE(PLLS_ConfDataWait);
 
     PriStateBase& OnAck(LinkContext&, bool aIsRcvBuffFull) override;
-    PriStateBase& OnNack(LinkContext& link, bool) override;
+    PriStateBase& OnNack(LinkContext& ctx, bool) override;
     PriStateBase& OnLinkStatus(LinkContext& link, bool) override
     {
         return Failure(link);
@@ -169,9 +169,9 @@ class PLLS_RequestLinkStatusWait final : public PriStateBase
 {
     MACRO_STATE_SINGLETON_INSTANCE(PLLS_RequestLinkStatusWait);
 
-    PriStateBase& OnNack(LinkContext& link, bool) override;
-    PriStateBase& OnLinkStatus(LinkContext& link, bool) override;
-    PriStateBase& OnNotSupported(LinkContext& link, bool) override;
+    PriStateBase& OnNack(LinkContext& ctx, bool) override;
+    PriStateBase& OnLinkStatus(LinkContext& ctx, bool) override;
+    PriStateBase& OnNotSupported(LinkContext& ctx, bool) override;
     PriStateBase& OnTimeout(LinkContext&) override;
 };
 

--- a/cpp/libs/src/opendnp3/link/SecLinkLayerStates.cpp
+++ b/cpp/libs/src/opendnp3/link/SecLinkLayerStates.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -44,14 +44,17 @@ SecStateBase& SecStateBase::OnTxReady(LinkContext& ctx)
 ////////////////////////////////////////////////////////
 SLLS_NotReset SLLS_NotReset::instance;
 
-SecStateBase& SLLS_NotReset::OnTestLinkStatus(LinkContext& ctx, uint16_t source, bool fcb)
+SecStateBase& SLLS_NotReset::OnTestLinkStatus(LinkContext& ctx, uint16_t /*source*/, bool /*fcb*/)
 {
     ++ctx.statistics.numUnexpectedFrame;
     SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "TestLinkStatus ignored");
     return *this;
 }
 
-SecStateBase& SLLS_NotReset::OnConfirmedUserData(LinkContext& ctx, uint16_t source, bool fcb, const Message& message)
+SecStateBase& SLLS_NotReset::OnConfirmedUserData(LinkContext& ctx,
+                                                 uint16_t /*source*/,
+                                                 bool /*fcb*/,
+                                                 const Message& /*message*/)
 {
     ++ctx.statistics.numUnexpectedFrame;
     SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "ConfirmedUserData ignored: secondary not reset");
@@ -84,14 +87,12 @@ SecStateBase& SLLS_Reset::OnTestLinkStatus(LinkContext& ctx, uint16_t source, bo
         ctx.ToggleReadFCB();
         return SLLS_TransmitWaitReset::Instance();
     }
-    else
-    {
-        // "Re-transmit most recent response that contained function code 0 (ACK) or 1 (NACK)."
-        // This is a PITA implement
-        // TODO - see if this function is deprecated or not
-        SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "Received TestLinkStatus with invalid FCB");
-        return *this;
-    }
+
+    // "Re-transmit most recent response that contained function code 0 (ACK) or 1 (NACK)."
+    // This is a PITA implement
+    // TODO - see if this function is deprecated or not
+    SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "Received TestLinkStatus with invalid FCB");
+    return *this;
 }
 
 SecStateBase& SLLS_Reset::OnConfirmedUserData(LinkContext& ctx, uint16_t source, bool fcb, const Message& message)

--- a/cpp/libs/src/opendnp3/link/SecLinkLayerStates.h
+++ b/cpp/libs/src/opendnp3/link/SecLinkLayerStates.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/ShiftableBuffer.cpp
+++ b/cpp/libs/src/opendnp3/link/ShiftableBuffer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -21,8 +21,7 @@
 
 #include <openpal/Configure.h>
 
-#include <assert.h>
-
+#include <cassert>
 #include <cstring>
 #include <iostream>
 
@@ -71,11 +70,9 @@ bool ShiftableBuffer::Sync(uint32_t& skipCount)
         {
             return true;
         }
-        else
-        {
-            this->AdvanceRead(1); // skip the first byte
-            ++skipCount;
-        }
+
+        this->AdvanceRead(1); // skip the first byte
+        ++skipCount;
     }
 
     return false;

--- a/cpp/libs/src/opendnp3/link/ShiftableBuffer.h
+++ b/cpp/libs/src/opendnp3/link/ShiftableBuffer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/link/Singleton.h
+++ b/cpp/libs/src/opendnp3/link/Singleton.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/AssignClassTask.cpp
+++ b/cpp/libs/src/opendnp3/master/AssignClassTask.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -30,7 +30,7 @@ namespace opendnp3
 AssignClassTask::AssignClassTask(const std::shared_ptr<TaskContext>& context,
                                  IMasterApplication& application,
                                  const TaskBehavior& behavior,
-                                 openpal::Logger logger)
+                                 const openpal::Logger& logger)
     : IMasterTask(context, application, behavior, logger, TaskConfig::Default())
 {
 }

--- a/cpp/libs/src/opendnp3/master/AssignClassTask.h
+++ b/cpp/libs/src/opendnp3/master/AssignClassTask.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -33,7 +33,7 @@ public:
     AssignClassTask(const std::shared_ptr<TaskContext>& context,
                     IMasterApplication& application,
                     const TaskBehavior& behavior,
-                    openpal::Logger logger);
+                    const openpal::Logger& logger);
 
     virtual char const* Name() const override
     {

--- a/cpp/libs/src/opendnp3/master/ClearRestartTask.cpp
+++ b/cpp/libs/src/opendnp3/master/ClearRestartTask.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -32,7 +32,7 @@ namespace opendnp3
 
 ClearRestartTask::ClearRestartTask(const std::shared_ptr<TaskContext>& context,
                                    IMasterApplication& application,
-                                   openpal::Logger logger)
+                                   const openpal::Logger& logger)
     : IMasterTask(context, application, TaskBehavior::ReactsToIINOnly(), logger, TaskConfig::Default())
 {
 }
@@ -44,7 +44,7 @@ bool ClearRestartTask::BuildRequest(APDURequest& request, uint8_t seq)
 }
 
 IMasterTask::ResponseResult ClearRestartTask::ProcessResponse(const APDUResponseHeader& response,
-                                                              const openpal::RSlice& objects)
+                                                              const openpal::RSlice& /*objects*/)
 {
     // we only care that the response to this has FIR/FIN
     if (ValidateSingleResponse(response))
@@ -56,10 +56,8 @@ IMasterTask::ResponseResult ClearRestartTask::ProcessResponse(const APDUResponse
                              "Clear restart task failed to clear restart bit, permanently disabling task");
             return ResponseResult::ERROR_BAD_RESPONSE;
         }
-        else
-        {
-            return ResponseResult::OK_FINAL;
-        }
+
+        return ResponseResult::OK_FINAL;
     }
     else
     {

--- a/cpp/libs/src/opendnp3/master/ClearRestartTask.h
+++ b/cpp/libs/src/opendnp3/master/ClearRestartTask.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -35,7 +35,7 @@ class ClearRestartTask final : public IMasterTask
 public:
     ClearRestartTask(const std::shared_ptr<TaskContext>& context,
                      IMasterApplication& application,
-                     openpal::Logger logger);
+                     const openpal::Logger& logger);
 
     virtual char const* Name() const override
     {

--- a/cpp/libs/src/opendnp3/master/CommandSet.cpp
+++ b/cpp/libs/src/opendnp3/master/CommandSet.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -29,7 +29,7 @@ namespace opendnp3
 
 CommandSet::CommandSet(CommandSet&& other) : m_headers(std::move(other.m_headers)) {}
 
-CommandSet::~CommandSet() {}
+CommandSet::~CommandSet() = default;
 
 CommandSet::CommandSet(std::initializer_list<Indexed<ControlRelayOutputBlock>> items)
 {

--- a/cpp/libs/src/opendnp3/master/CommandSetOps.cpp
+++ b/cpp/libs/src/opendnp3/master/CommandSetOps.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -94,7 +94,7 @@ CommandSetOps::OperateResult CommandSetOps::ProcessOperateResponse(CommandSet& s
                                                                             : OperateResult::FAIL_PARSE;
 }
 
-bool CommandSetOps::IsAllowed(uint32_t headerCount, GroupVariation gv, QualifierCode qc)
+bool CommandSetOps::IsAllowed(uint32_t /*headerCount*/, GroupVariation gv, QualifierCode qc)
 {
     switch (qc)
     {

--- a/cpp/libs/src/opendnp3/master/CommandSetOps.h
+++ b/cpp/libs/src/opendnp3/master/CommandSetOps.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/CommandTask.h
+++ b/cpp/libs/src/opendnp3/master/CommandTask.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -45,16 +45,16 @@ class CommandTask : public IMasterTask
 
 public:
     CommandTask(const std::shared_ptr<TaskContext>& context,
-                CommandSet&& set,
+                CommandSet&& commands,
                 IndexQualifierMode mode,
                 IMasterApplication& app,
-                const CommandCallbackT& callback,
+                CommandCallbackT callback,
                 const openpal::MonotonicTimestamp& startExpiration,
                 const TaskConfig& config,
-                openpal::Logger logger);
+                const openpal::Logger& logger);
 
     static std::shared_ptr<IMasterTask> CreateDirectOperate(const std::shared_ptr<TaskContext>& context,
-                                                            CommandSet&& commands,
+                                                            CommandSet&& set,
                                                             IndexQualifierMode mode,
                                                             IMasterApplication& app,
                                                             const CommandCallbackT& callback,
@@ -62,7 +62,7 @@ public:
                                                             const TaskConfig& config,
                                                             openpal::Logger logger);
     static std::shared_ptr<IMasterTask> CreateSelectAndOperate(const std::shared_ptr<TaskContext>& context,
-                                                               CommandSet&& commands,
+                                                               CommandSet&& set,
                                                                IndexQualifierMode mode,
                                                                IMasterApplication& app,
                                                                const CommandCallbackT& callback,
@@ -105,7 +105,7 @@ private:
 
     virtual void Initialize() override final;
 
-    virtual ResponseResult ProcessResponse(const APDUResponseHeader& response,
+    virtual ResponseResult ProcessResponse(const APDUResponseHeader& header,
                                            const openpal::RSlice& objects) override final;
 
     virtual void OnTaskComplete(TaskCompletion result, openpal::MonotonicTimestamp now) override final;

--- a/cpp/libs/src/opendnp3/master/CommandTaskResult.cpp
+++ b/cpp/libs/src/opendnp3/master/CommandTaskResult.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/CommandTaskResult.h
+++ b/cpp/libs/src/opendnp3/master/CommandTaskResult.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/DisableUnsolicitedTask.cpp
+++ b/cpp/libs/src/opendnp3/master/DisableUnsolicitedTask.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -31,7 +31,7 @@ namespace opendnp3
 DisableUnsolicitedTask::DisableUnsolicitedTask(const std::shared_ptr<TaskContext>& context,
                                                IMasterApplication& application,
                                                const TaskBehavior& behavior,
-                                               openpal::Logger logger)
+                                               const openpal::Logger& logger)
     : IMasterTask(context, application, behavior, logger, TaskConfig::Default())
 {
 }

--- a/cpp/libs/src/opendnp3/master/DisableUnsolicitedTask.h
+++ b/cpp/libs/src/opendnp3/master/DisableUnsolicitedTask.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -33,7 +33,7 @@ public:
     DisableUnsolicitedTask(const std::shared_ptr<TaskContext>& context,
                            IMasterApplication& application,
                            const TaskBehavior& behavior,
-                           openpal::Logger logger);
+                           const openpal::Logger& logger);
 
     virtual char const* Name() const override
     {
@@ -63,7 +63,7 @@ private:
         return MasterTaskType::DISABLE_UNSOLICITED;
     }
 
-    virtual ResponseResult ProcessResponse(const APDUResponseHeader& response, const openpal::RSlice& objects) override;
+    virtual ResponseResult ProcessResponse(const APDUResponseHeader& header, const openpal::RSlice& objects) override;
 };
 
 } // namespace opendnp3

--- a/cpp/libs/src/opendnp3/master/EmptyResponseTask.cpp
+++ b/cpp/libs/src/opendnp3/master/EmptyResponseTask.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -21,6 +21,8 @@
 
 #include "opendnp3/master/TaskPriority.h"
 
+#include <utility>
+
 using namespace openpal;
 
 namespace opendnp3
@@ -28,16 +30,16 @@ namespace opendnp3
 
 EmptyResponseTask::EmptyResponseTask(const std::shared_ptr<TaskContext>& context,
                                      IMasterApplication& app,
-                                     const std::string& name,
+                                     std::string name,
                                      FunctionCode func,
-                                     const std::function<bool(HeaderWriter&)>& format,
+                                     std::function<bool(HeaderWriter&)> format,
                                      openpal::MonotonicTimestamp startExpiration,
-                                     openpal::Logger logger,
+                                     const openpal::Logger& logger,
                                      const TaskConfig& config)
     : IMasterTask(context, app, TaskBehavior::SingleExecutionNoRetry(startExpiration), logger, config),
-      name(name),
+      name(std::move(name)),
       func(func),
-      format(format)
+      format(std::move(format))
 {
 }
 

--- a/cpp/libs/src/opendnp3/master/EmptyResponseTask.h
+++ b/cpp/libs/src/opendnp3/master/EmptyResponseTask.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -35,11 +35,11 @@ class EmptyResponseTask final : public IMasterTask
 public:
     EmptyResponseTask(const std::shared_ptr<TaskContext>& context,
                       IMasterApplication& app,
-                      const std::string& name,
+                      std::string name,
                       FunctionCode func,
-                      const HeaderBuilderT& format,
+                      HeaderBuilderT format,
                       openpal::MonotonicTimestamp startExpiration,
-                      openpal::Logger logger,
+                      const openpal::Logger& logger,
                       const TaskConfig& config);
 
     bool BuildRequest(APDURequest& request, uint8_t seq) override;

--- a/cpp/libs/src/opendnp3/master/EnableUnsolicitedTask.cpp
+++ b/cpp/libs/src/opendnp3/master/EnableUnsolicitedTask.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -34,7 +34,7 @@ EnableUnsolicitedTask::EnableUnsolicitedTask(const std::shared_ptr<TaskContext>&
                                              IMasterApplication& app,
                                              const TaskBehavior& behavior,
                                              ClassField enabledClasses,
-                                             openpal::Logger logger)
+                                             const openpal::Logger& logger)
     : IMasterTask(context, app, behavior, logger, TaskConfig::Default()), enabledClasses(enabledClasses)
 {
 }

--- a/cpp/libs/src/opendnp3/master/EnableUnsolicitedTask.h
+++ b/cpp/libs/src/opendnp3/master/EnableUnsolicitedTask.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -44,7 +44,7 @@ public:
                           IMasterApplication& app,
                           const TaskBehavior& behavior,
                           ClassField enabledClasses,
-                          openpal::Logger logger);
+                          const openpal::Logger& logger);
 
     virtual bool IsRecurring() const override
     {

--- a/cpp/libs/src/opendnp3/master/EventScanTask.cpp
+++ b/cpp/libs/src/opendnp3/master/EventScanTask.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -58,7 +58,7 @@ EventScanTask::EventScanTask(const std::shared_ptr<TaskContext>& context,
                              IMasterApplication& application,
                              ISOEHandler& soeHandler,
                              ClassField classes,
-                             openpal::Logger logger)
+                             const openpal::Logger& logger)
     : PollTaskBase(context, application, soeHandler, TaskBehavior::ReactsToIINOnly(), logger, TaskConfig::Default()),
       classes(classes.OnlyEventClasses())
 {

--- a/cpp/libs/src/opendnp3/master/EventScanTask.h
+++ b/cpp/libs/src/opendnp3/master/EventScanTask.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -39,7 +39,7 @@ public:
                   IMasterApplication& application,
                   ISOEHandler& soeHandler,
                   ClassField classes,
-                  openpal::Logger logger);
+                  const openpal::Logger& logger);
 
     virtual bool IsRecurring() const override
     {

--- a/cpp/libs/src/opendnp3/master/HeaderBuilder.h
+++ b/cpp/libs/src/opendnp3/master/HeaderBuilder.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/HeaderTypes.cpp
+++ b/cpp/libs/src/opendnp3/master/HeaderTypes.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/ICommandHeader.h
+++ b/cpp/libs/src/opendnp3/master/ICommandHeader.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/IMasterScheduler.h
+++ b/cpp/libs/src/opendnp3/master/IMasterScheduler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/IMasterTask.cpp
+++ b/cpp/libs/src/opendnp3/master/IMasterTask.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -23,17 +23,19 @@
 
 #include "opendnp3/LogLevels.h"
 
+#include <utility>
+
 using namespace openpal;
 
 namespace opendnp3
 {
 
-IMasterTask::IMasterTask(const std::shared_ptr<TaskContext>& context,
+IMasterTask::IMasterTask(std::shared_ptr<TaskContext> context,
                          IMasterApplication& app,
-                         const TaskBehavior& behavior,
+                         TaskBehavior behavior,
                          const openpal::Logger& logger,
                          TaskConfig config)
-    : context(context), application(&app), logger(logger), config(config), behavior(behavior)
+    : context(std::move(context)), application(&app), logger(logger), config(config), behavior(std::move(behavior))
 {
 }
 
@@ -41,7 +43,7 @@ IMasterTask::~IMasterTask()
 {
     context->RemoveBlock(*this);
 
-    if (config.pCallback)
+    if (config.pCallback != nullptr)
     {
         config.pCallback->OnDestroyed();
     }
@@ -115,7 +117,7 @@ void IMasterTask::CompleteTask(TaskCompletion result, openpal::MonotonicTimestam
     }
     }
 
-    if (config.pCallback)
+    if (config.pCallback != nullptr)
     {
         config.pCallback->OnComplete(result);
     }
@@ -149,7 +151,7 @@ void IMasterTask::OnMessageFormatError(openpal::MonotonicTimestamp now)
 
 void IMasterTask::OnStart()
 {
-    if (config.pCallback)
+    if (config.pCallback != nullptr)
     {
         config.pCallback->OnStart();
     }
@@ -170,11 +172,9 @@ bool IMasterTask::ValidateSingleResponse(const APDUResponseHeader& header)
     {
         return true;
     }
-    else
-    {
-        SIMPLE_LOG_BLOCK(logger, flags::WARN, "Ignoring unexpected response FIR/FIN not set");
-        return false;
-    }
+
+    SIMPLE_LOG_BLOCK(logger, flags::WARN, "Ignoring unexpected response FIR/FIN not set");
+    return false;
 }
 
 bool IMasterTask::ValidateNullResponse(const APDUResponseHeader& header, const openpal::RSlice& objects)
@@ -190,10 +190,8 @@ bool IMasterTask::ValidateInternalIndications(const APDUResponseHeader& header)
                          this->Name());
         return false;
     }
-    else
-    {
-        return true;
-    }
+
+    return true;
 }
 
 bool IMasterTask::ValidateNoObjects(const openpal::RSlice& objects)
@@ -202,11 +200,9 @@ bool IMasterTask::ValidateNoObjects(const openpal::RSlice& objects)
     {
         return true;
     }
-    else
-    {
-        FORMAT_LOG_BLOCK(logger, flags::WARN, "Received unexpected response object headers for task: %s", this->Name());
-        return false;
-    }
+
+    FORMAT_LOG_BLOCK(logger, flags::WARN, "Received unexpected response object headers for task: %s", this->Name());
+    return false;
 }
 
 } // namespace opendnp3

--- a/cpp/libs/src/opendnp3/master/IMasterTask.h
+++ b/cpp/libs/src/opendnp3/master/IMasterTask.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -57,9 +57,9 @@ public:
         OK_CONTINUE
     };
 
-    IMasterTask(const std::shared_ptr<TaskContext>& context,
+    IMasterTask(std::shared_ptr<TaskContext> context,
                 IMasterApplication& app,
-                const TaskBehavior& behavior,
+                TaskBehavior behavior,
                 const openpal::Logger& logger,
                 TaskConfig config);
 
@@ -158,7 +158,7 @@ protected:
 
     virtual ResponseResult ProcessResponse(const APDUResponseHeader& response, const openpal::RSlice& objects) = 0;
 
-    void CompleteTask(TaskCompletion completion, openpal::MonotonicTimestamp now);
+    void CompleteTask(TaskCompletion result, openpal::MonotonicTimestamp now);
 
     virtual void OnTaskComplete(TaskCompletion result, openpal::MonotonicTimestamp now) {}
 

--- a/cpp/libs/src/opendnp3/master/IMasterTaskRunner.h
+++ b/cpp/libs/src/opendnp3/master/IMasterTaskRunner.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/IScheduleCallback.h
+++ b/cpp/libs/src/opendnp3/master/IScheduleCallback.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/LANTimeSyncTask.cpp
+++ b/cpp/libs/src/opendnp3/master/LANTimeSyncTask.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -31,7 +31,7 @@ namespace opendnp3
 
 LANTimeSyncTask::LANTimeSyncTask(const std::shared_ptr<TaskContext>& context,
                                  IMasterApplication& app,
-                                 openpal::Logger logger)
+                                 const openpal::Logger& logger)
     : IMasterTask(context, app, TaskBehavior::ReactsToIINOnly(), logger, TaskConfig::Default())
 {
 }
@@ -49,15 +49,13 @@ bool LANTimeSyncTask::BuildRequest(APDURequest& request, uint8_t seq)
         build::RecordCurrentTime(request, seq);
         return true;
     }
-    else
-    {
-        Group50Var3 time;
-        time.time = DNPTime(this->start.msSinceEpoch);
-        request.SetFunction(FunctionCode::WRITE);
-        request.SetControl(AppControlField::Request(seq));
-        auto writer = request.GetWriter();
-        return writer.WriteSingleValue<UInt8, Group50Var3>(QualifierCode::UINT8_CNT, time);
-    }
+
+    Group50Var3 time;
+    time.time = DNPTime(this->start.msSinceEpoch);
+    request.SetFunction(FunctionCode::WRITE);
+    request.SetControl(AppControlField::Request(seq));
+    auto writer = request.GetWriter();
+    return writer.WriteSingleValue<UInt8, Group50Var3>(QualifierCode::UINT8_CNT, time);
 }
 
 IMasterTask::ResponseResult LANTimeSyncTask::ProcessResponse(const APDUResponseHeader& response,

--- a/cpp/libs/src/opendnp3/master/LANTimeSyncTask.h
+++ b/cpp/libs/src/opendnp3/master/LANTimeSyncTask.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -39,7 +39,9 @@ class LANTimeSyncTask : public IMasterTask
     };
 
 public:
-    LANTimeSyncTask(const std::shared_ptr<TaskContext>& context, IMasterApplication& app, openpal::Logger logger);
+    LANTimeSyncTask(const std::shared_ptr<TaskContext>& context,
+                    IMasterApplication& app,
+                    const openpal::Logger& logger);
 
     virtual char const* Name() const override final
     {
@@ -77,7 +79,7 @@ private:
     virtual ResponseResult ProcessResponse(const APDUResponseHeader& response,
                                            const openpal::RSlice& objects) override final;
 
-    ResponseResult OnResponseRecordCurrentTime(const APDUResponseHeader& header, const openpal::RSlice& objects);
+    ResponseResult OnResponseRecordCurrentTime(const APDUResponseHeader& response, const openpal::RSlice& objects);
 
     ResponseResult OnResponseWriteTime(const APDUResponseHeader& header, const openpal::RSlice& objects);
 

--- a/cpp/libs/src/opendnp3/master/MasterContext.cpp
+++ b/cpp/libs/src/opendnp3/master/MasterContext.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -33,6 +33,8 @@
 #include "opendnp3/objects/Group12.h"
 #include "opendnp3/objects/Group41.h"
 
+#include <utility>
+
 using namespace openpal;
 
 namespace opendnp3
@@ -40,19 +42,19 @@ namespace opendnp3
 MContext::MContext(const Addresses& addresses,
                    const openpal::Logger& logger,
                    const std::shared_ptr<openpal::IExecutor>& executor,
-                   const std::shared_ptr<ILowerLayer>& lower,
+                   std::shared_ptr<ILowerLayer> lower,
                    const std::shared_ptr<ISOEHandler>& SOEHandler,
                    const std::shared_ptr<IMasterApplication>& application,
-                   const std::shared_ptr<IMasterScheduler>& scheduler,
+                   std::shared_ptr<IMasterScheduler> scheduler,
                    const MasterParams& params)
     : logger(logger),
       executor(executor),
-      lower(lower),
+      lower(std::move(lower)),
       addresses(addresses),
       params(params),
       SOEHandler(SOEHandler),
       application(application),
-      scheduler(scheduler),
+      scheduler(std::move(scheduler)),
       responseTimer(*executor),
       tasks(params, logger, *application, *SOEHandler),
       txBuffer(params.maxTxFragSize),
@@ -160,7 +162,7 @@ void MContext::CompleteActiveTask()
     }
 }
 
-void MContext::OnParsedHeader(const RSlice& apdu, const APDUResponseHeader& header, const RSlice& objects)
+void MContext::OnParsedHeader(const RSlice& /*apdu*/, const APDUResponseHeader& header, const RSlice& objects)
 {
     // Note: this looks silly, but OnParsedHeader() is virtual and can be overriden to do SA
     this->ProcessAPDU(header, objects);

--- a/cpp/libs/src/opendnp3/master/MasterContext.h
+++ b/cpp/libs/src/opendnp3/master/MasterContext.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -58,10 +58,10 @@ public:
     MContext(const Addresses& addresses,
              const openpal::Logger& logger,
              const std::shared_ptr<openpal::IExecutor>& executor,
-             const std::shared_ptr<ILowerLayer>& lower,
+             std::shared_ptr<ILowerLayer> lower,
              const std::shared_ptr<ISOEHandler>& SOEHandler,
              const std::shared_ptr<IMasterApplication>& application,
-             const std::shared_ptr<IMasterScheduler>& scheduler,
+             std::shared_ptr<IMasterScheduler> scheduler,
              const MasterParams& params);
 
     openpal::Logger logger;

--- a/cpp/libs/src/opendnp3/master/MasterSchedulerBackend.cpp
+++ b/cpp/libs/src/opendnp3/master/MasterSchedulerBackend.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -46,7 +46,7 @@ void MasterSchedulerBackend::Add(const std::shared_ptr<IMasterTask>& task, IMast
     if (this->isShutdown)
         return;
 
-    this->tasks.push_back(Record(task, runner));
+    this->tasks.emplace_back(task, runner);
     this->PostCheckForTaskRun();
 }
 
@@ -67,10 +67,8 @@ void MasterSchedulerBackend::SetRunnerOffline(const IMasterTaskRunner& runner)
 
             return true;
         }
-        else
-        {
-            return false;
-        }
+
+        return false;
     };
 
     if (this->current && checkForOwnership(this->current))
@@ -169,14 +167,12 @@ bool MasterSchedulerBackend::CheckForTaskRun()
 
         return true;
     }
-    else
-    {
-        auto callback = [this, self = shared_from_this()]() { this->CheckForTaskRun(); };
 
-        this->taskTimer.Restart(best_task->task->ExpirationTime(), callback);
+    auto callback = [this, self = shared_from_this()]() { this->CheckForTaskRun(); };
 
-        return false;
-    }
+    this->taskTimer.Restart(best_task->task->ExpirationTime(), callback);
+
+    return false;
 }
 
 void MasterSchedulerBackend::RestartTimeoutTimer()
@@ -266,7 +262,7 @@ MasterSchedulerBackend::Comparison MasterSchedulerBackend::CompareTime(const ope
     {
         return Comparison::LEFT;
     }
-    else if (rightTime < leftTime)
+    if (rightTime < leftTime)
     {
         return Comparison::RIGHT;
     }
@@ -282,7 +278,7 @@ MasterSchedulerBackend::Comparison MasterSchedulerBackend::CompareEnabledStatus(
     {
         return right.task->ExpirationTime().IsMax() ? Comparison::SAME : Comparison::RIGHT;
     }
-    else if (right.task->ExpirationTime().IsMax()) // left is enabled, right is disabled
+    if (right.task->ExpirationTime().IsMax()) // left is enabled, right is disabled
     {
         return Comparison::LEFT;
     }
@@ -299,10 +295,8 @@ MasterSchedulerBackend::Comparison MasterSchedulerBackend::CompareBlockedStatus(
     {
         return right.task->IsBlocked() ? Comparison::SAME : Comparison::RIGHT;
     }
-    else
-    {
-        return right.task->IsBlocked() ? Comparison::LEFT : Comparison::SAME;
-    }
+
+    return right.task->IsBlocked() ? Comparison::LEFT : Comparison::SAME;
 }
 
 MasterSchedulerBackend::Comparison MasterSchedulerBackend::ComparePriority(const Record& left, const Record& right)
@@ -311,7 +305,7 @@ MasterSchedulerBackend::Comparison MasterSchedulerBackend::ComparePriority(const
     {
         return Comparison::LEFT;
     }
-    else if (right.task->Priority() < left.task->Priority())
+    if (right.task->Priority() < left.task->Priority())
     {
         return Comparison::RIGHT;
     }

--- a/cpp/libs/src/opendnp3/master/MasterSchedulerBackend.h
+++ b/cpp/libs/src/opendnp3/master/MasterSchedulerBackend.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -113,7 +113,7 @@ private:
 
     static Comparison ComparePriority(const Record& left, const Record& right);
 
-    static Comparison CompareTime(const openpal::MonotonicTimestamp& time, const Record& left, const Record& right);
+    static Comparison CompareTime(const openpal::MonotonicTimestamp& now, const Record& left, const Record& right);
 };
 
 } // namespace opendnp3

--- a/cpp/libs/src/opendnp3/master/MasterTasks.cpp
+++ b/cpp/libs/src/opendnp3/master/MasterTasks.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/MasterTasks.h
+++ b/cpp/libs/src/opendnp3/master/MasterTasks.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/MeasurementHandler.cpp
+++ b/cpp/libs/src/opendnp3/master/MeasurementHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -81,7 +81,7 @@ IINField MeasurementHandler::ProcessHeader(const CountHeader& header, const ICol
     return IINField();
 }
 
-IINField MeasurementHandler::ProcessHeader(const CountHeader& header, const ICollection<Group51Var1>& values)
+IINField MeasurementHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group51Var1>& values)
 {
     Group51Var1 cto;
     if (values.ReadOnlyValue(cto))
@@ -92,7 +92,7 @@ IINField MeasurementHandler::ProcessHeader(const CountHeader& header, const ICol
     return IINField::Empty();
 }
 
-IINField MeasurementHandler::ProcessHeader(const CountHeader& header, const ICollection<Group51Var2>& values)
+IINField MeasurementHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group51Var2>& values)
 {
     Group51Var2 cto;
     if (values.ReadOnlyValue(cto))
@@ -164,10 +164,8 @@ IINField MeasurementHandler::ProcessHeader(const PrefixHeader& header, const ICo
     {
         return this->ProcessWithCTO(header, values);
     }
-    else
-    {
-        return this->LoadValues(header, ModeFromType(header.enumeration), values);
-    }
+
+    return this->LoadValues(header, ModeFromType(header.enumeration), values);
 }
 
 IINField MeasurementHandler::ProcessHeader(const PrefixHeader& header,
@@ -183,10 +181,8 @@ IINField MeasurementHandler::ProcessHeader(const PrefixHeader& header,
     {
         return this->ProcessWithCTO(header, values);
     }
-    else
-    {
-        return this->LoadValues(header, ModeFromType(header.enumeration), values);
-    }
+
+    return this->LoadValues(header, ModeFromType(header.enumeration), values);
 }
 
 IINField MeasurementHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<Counter>>& values)

--- a/cpp/libs/src/opendnp3/master/MeasurementHandler.h
+++ b/cpp/libs/src/opendnp3/master/MeasurementHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -71,8 +71,8 @@ private:
     IINField ProcessHeader(const CountHeader& header, const ICollection<Group50Var1>& values) override;
 
     // Handle the CTO objects
-    IINField ProcessHeader(const CountHeader& header, const ICollection<Group51Var1>& cto) override;
-    IINField ProcessHeader(const CountHeader& header, const ICollection<Group51Var2>& cto) override;
+    IINField ProcessHeader(const CountHeader& header, const ICollection<Group51Var1>& values) override;
+    IINField ProcessHeader(const CountHeader& header, const ICollection<Group51Var2>& values) override;
 
     IINField ProcessHeader(const RangeHeader& header, const ICollection<Indexed<Binary>>& values) override;
     IINField ProcessHeader(const RangeHeader& header, const ICollection<Indexed<DoubleBitBinary>>& values) override;
@@ -127,9 +127,9 @@ private:
 
     void CheckForTxStart();
 
-    static SecurityStat Convert(const Group121Var1& value);
-    static SecurityStat Convert(const Group122Var1& value);
-    static SecurityStat Convert(const Group122Var2& value);
+    static SecurityStat Convert(const Group121Var1& meas);
+    static SecurityStat Convert(const Group122Var1& meas);
+    static SecurityStat Convert(const Group122Var2& meas);
 
     template<class T, class U> static Indexed<U> Convert(const Indexed<T>& input)
     {

--- a/cpp/libs/src/opendnp3/master/PollTaskBase.cpp
+++ b/cpp/libs/src/opendnp3/master/PollTaskBase.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -33,7 +33,7 @@ PollTaskBase::PollTaskBase(const std::shared_ptr<TaskContext>& context,
                            IMasterApplication& application,
                            ISOEHandler& handler,
                            const TaskBehavior& behavior,
-                           openpal::Logger logger,
+                           const openpal::Logger& logger,
                            TaskConfig config)
     : IMasterTask(context, application, behavior, logger, config), handler(&handler)
 {
@@ -54,10 +54,8 @@ IMasterTask::ResponseResult PollTaskBase::ProcessResponse(const APDUResponseHead
             SIMPLE_LOG_BLOCK(logger, flags::WARN, "Ignoring unexpected FIR frame");
             return ResponseResult::ERROR_BAD_RESPONSE;
         }
-        else
-        {
-            return ProcessMeasurements(header, objects);
-        }
+
+        return ProcessMeasurements(header, objects);
     }
     else
     {
@@ -65,11 +63,9 @@ IMasterTask::ResponseResult PollTaskBase::ProcessResponse(const APDUResponseHead
         {
             return ProcessMeasurements(header, objects);
         }
-        else
-        {
-            SIMPLE_LOG_BLOCK(logger, flags::WARN, "Ignoring unexpected non-FIR frame");
-            return ResponseResult::ERROR_BAD_RESPONSE;
-        }
+
+        SIMPLE_LOG_BLOCK(logger, flags::WARN, "Ignoring unexpected non-FIR frame");
+        return ResponseResult::ERROR_BAD_RESPONSE;
     }
 }
 
@@ -82,10 +78,8 @@ IMasterTask::ResponseResult PollTaskBase::ProcessMeasurements(const APDUResponse
     {
         return header.control.FIN ? ResponseResult::OK_FINAL : ResponseResult::OK_CONTINUE;
     }
-    else
-    {
-        return ResponseResult::ERROR_BAD_RESPONSE;
-    }
+
+    return ResponseResult::ERROR_BAD_RESPONSE;
 }
 
 } // namespace opendnp3

--- a/cpp/libs/src/opendnp3/master/PollTaskBase.h
+++ b/cpp/libs/src/opendnp3/master/PollTaskBase.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -40,7 +40,7 @@ public:
                  IMasterApplication& application,
                  ISOEHandler& handler,
                  const TaskBehavior& behavior,
-                 openpal::Logger logger,
+                 const openpal::Logger& logger,
                  TaskConfig config);
 
     virtual const char* Name() const override
@@ -49,7 +49,7 @@ public:
     };
 
 protected:
-    virtual ResponseResult ProcessResponse(const APDUResponseHeader& response,
+    virtual ResponseResult ProcessResponse(const APDUResponseHeader& header,
                                            const openpal::RSlice& objects) override final;
 
     ResponseResult ProcessMeasurements(const APDUResponseHeader& header, const openpal::RSlice& objects);

--- a/cpp/libs/src/opendnp3/master/RestartOperationTask.h
+++ b/cpp/libs/src/opendnp3/master/RestartOperationTask.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -37,8 +37,8 @@ public:
                          IMasterApplication& app,
                          const openpal::MonotonicTimestamp& startTimeout,
                          RestartType operationType,
-                         const RestartOperationCallbackT& callback,
-                         openpal::Logger logger,
+                         RestartOperationCallbackT callback,
+                         const openpal::Logger& logger,
                          const TaskConfig& config);
 
     bool BuildRequest(APDURequest& request, uint8_t seq) override;

--- a/cpp/libs/src/opendnp3/master/ScanResult.h
+++ b/cpp/libs/src/opendnp3/master/ScanResult.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.cpp
+++ b/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -33,7 +33,7 @@ namespace opendnp3
 
 SerialTimeSyncTask::SerialTimeSyncTask(const std::shared_ptr<TaskContext>& context,
                                        IMasterApplication& app,
-                                       openpal::Logger logger)
+                                       const openpal::Logger& logger)
     : IMasterTask(context, app, TaskBehavior::ReactsToIINOnly(), logger, TaskConfig::Default()), delay(-1)
 {
 }
@@ -91,10 +91,8 @@ IMasterTask::ResponseResult SerialTimeSyncTask::OnResponseDelayMeas(const APDURe
 
                 return ResponseResult::OK_REPEAT;
             }
-            else
-            {
-                return ResponseResult::ERROR_BAD_RESPONSE;
-            }
+
+            return ResponseResult::ERROR_BAD_RESPONSE;
         }
         else
         {

--- a/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.h
+++ b/cpp/libs/src/opendnp3/master/SerialTimeSyncTask.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -33,7 +33,9 @@ class SerialTimeSyncTask : public IMasterTask
 {
 
 public:
-    SerialTimeSyncTask(const std::shared_ptr<TaskContext>& context, IMasterApplication& app, openpal::Logger logger);
+    SerialTimeSyncTask(const std::shared_ptr<TaskContext>& context,
+                       IMasterApplication& app,
+                       const openpal::Logger& logger);
 
     virtual char const* Name() const override final
     {
@@ -71,7 +73,7 @@ private:
     virtual ResponseResult ProcessResponse(const APDUResponseHeader& response,
                                            const openpal::RSlice& objects) override final;
 
-    ResponseResult OnResponseDelayMeas(const APDUResponseHeader& header, const openpal::RSlice& objects);
+    ResponseResult OnResponseDelayMeas(const APDUResponseHeader& response, const openpal::RSlice& objects);
 
     ResponseResult OnResponseWriteTime(const APDUResponseHeader& header, const openpal::RSlice& objects);
 

--- a/cpp/libs/src/opendnp3/master/StartupIntegrityPoll.cpp
+++ b/cpp/libs/src/opendnp3/master/StartupIntegrityPoll.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -38,7 +38,7 @@ StartupIntegrityPoll::StartupIntegrityPoll(const std::shared_ptr<TaskContext>& c
                                            ISOEHandler& soeHandler,
                                            ClassField classes,
                                            const TaskBehavior& behavior,
-                                           openpal::Logger logger)
+                                           const openpal::Logger& logger)
     : PollTaskBase(context, app, soeHandler, behavior, logger, TaskConfig::Default()), classes(classes)
 {
 }

--- a/cpp/libs/src/opendnp3/master/StartupIntegrityPoll.h
+++ b/cpp/libs/src/opendnp3/master/StartupIntegrityPoll.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -41,7 +41,7 @@ public:
                          ISOEHandler& soeHandler,
                          ClassField classes,
                          const TaskBehavior& behavior,
-                         openpal::Logger logger);
+                         const openpal::Logger& logger);
 
     virtual bool IsRecurring() const override
     {

--- a/cpp/libs/src/opendnp3/master/TaskBehavior.cpp
+++ b/cpp/libs/src/opendnp3/master/TaskBehavior.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/TaskBehavior.h
+++ b/cpp/libs/src/opendnp3/master/TaskBehavior.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/TaskContext.cpp
+++ b/cpp/libs/src/opendnp3/master/TaskContext.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/TaskContext.h
+++ b/cpp/libs/src/opendnp3/master/TaskContext.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/TaskPriority.h
+++ b/cpp/libs/src/opendnp3/master/TaskPriority.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/TimeSyncHandler.h
+++ b/cpp/libs/src/opendnp3/master/TimeSyncHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/TypedCommandHeader.h
+++ b/cpp/libs/src/opendnp3/master/TypedCommandHeader.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/master/UserPollTask.cpp
+++ b/cpp/libs/src/opendnp3/master/UserPollTask.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -19,20 +19,24 @@
  */
 #include "UserPollTask.h"
 
+#include <utility>
+
 using namespace openpal;
 
 namespace opendnp3
 {
 
 UserPollTask::UserPollTask(const std::shared_ptr<TaskContext>& context,
-                           const HeaderBuilderT& builder,
+                           HeaderBuilderT builder,
                            const TaskBehavior& behavior,
                            bool recurring,
                            IMasterApplication& app,
                            ISOEHandler& soeHandler,
-                           openpal::Logger logger,
+                           const openpal::Logger& logger,
                            TaskConfig config)
-    : PollTaskBase(context, app, soeHandler, behavior, logger, config), builder(builder), recurring(recurring)
+    : PollTaskBase(context, app, soeHandler, behavior, logger, config),
+      builder(std::move(builder)),
+      recurring(recurring)
 {
 }
 

--- a/cpp/libs/src/opendnp3/master/UserPollTask.h
+++ b/cpp/libs/src/opendnp3/master/UserPollTask.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -41,12 +41,12 @@ class UserPollTask final : public PollTaskBase
 
 public:
     UserPollTask(const std::shared_ptr<TaskContext>& context,
-                 const HeaderBuilderT& builder,
+                 HeaderBuilderT builder,
                  const TaskBehavior& behavior,
                  bool recurring,
                  IMasterApplication& app,
                  ISOEHandler& soeHandler,
-                 openpal::Logger logger,
+                 const openpal::Logger& logger,
                  TaskConfig config);
 
     virtual int Priority() const override

--- a/cpp/libs/src/opendnp3/objects/Group1.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group1.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,46 +33,46 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group1Var2 -------
 
-Group1Var2::Group1Var2() : flags(0)
-{}
+Group1Var2::Group1Var2() : flags(0) {}
 
 bool Group1Var2::Read(RSlice& buffer, Group1Var2& output)
 {
-  return Parse::Many(buffer, output.flags);
+    return Parse::Many(buffer, output.flags);
 }
 
 bool Group1Var2::Write(const Group1Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags);
+    return Format::Many(buffer, arg.flags);
 }
 
 bool Group1Var2::ReadTarget(RSlice& buff, Binary& output)
 {
-  Group1Var2 value;
-  if(Read(buff, value))
-  {
-    output = BinaryFactory::From(value.flags);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group1Var2 value;
+    if (Read(buff, value))
+    {
+        output = BinaryFactory::From(value.flags);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group1Var2::WriteTarget(const Binary& value, openpal::WSlice& buff)
 {
-  return Group1Var2::Write(ConvertGroup1Var2::Apply(value), buff);
+    return Group1Var2::Write(ConvertGroup1Var2::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group1.h
+++ b/cpp/libs/src/opendnp3/objects/Group1.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,48 +32,64 @@
 #ifndef OPENDNP3_GROUP1_H
 #define OPENDNP3_GROUP1_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Binary Input - Any Variation
 struct Group1Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(1,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(1, 0);
+    }
 };
 
 // Binary Input - Packed Format
 struct Group1Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(1,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(1, 1);
+    }
 };
 
 // Binary Input - With Flags
 struct Group1Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(1,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(1, 2);
+    }
 
-  Group1Var2();
+    Group1Var2();
 
-  static uint32_t Size() { return 1; }
-  static bool Read(openpal::RSlice&, Group1Var2&);
-  static bool Write(const Group1Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 1;
+    }
+    static bool Read(openpal::RSlice&, Group1Var2&);
+    static bool Write(const Group1Var2&, openpal::WSlice&);
 
-  uint8_t flags;
+    uint8_t flags;
 
-  typedef Binary Target;
-  typedef BinarySpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Binary&);
-  static bool WriteTarget(const Binary&, openpal::WSlice&);
-  static DNP3Serializer<Binary> Inst() { return DNP3Serializer<Binary>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Binary Target;
+    typedef BinarySpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Binary&);
+    static bool WriteTarget(const Binary&, openpal::WSlice&);
+    static DNP3Serializer<Binary> Inst()
+    {
+        return DNP3Serializer<Binary>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group10.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group10.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,46 +33,46 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group10Var2 -------
 
-Group10Var2::Group10Var2() : flags(0)
-{}
+Group10Var2::Group10Var2() : flags(0) {}
 
 bool Group10Var2::Read(RSlice& buffer, Group10Var2& output)
 {
-  return Parse::Many(buffer, output.flags);
+    return Parse::Many(buffer, output.flags);
 }
 
 bool Group10Var2::Write(const Group10Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags);
+    return Format::Many(buffer, arg.flags);
 }
 
 bool Group10Var2::ReadTarget(RSlice& buff, BinaryOutputStatus& output)
 {
-  Group10Var2 value;
-  if(Read(buff, value))
-  {
-    output = BinaryOutputStatusFactory::From(value.flags);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group10Var2 value;
+    if (Read(buff, value))
+    {
+        output = BinaryOutputStatusFactory::From(value.flags);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group10Var2::WriteTarget(const BinaryOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group10Var2::Write(ConvertGroup10Var2::Apply(value), buff);
+    return Group10Var2::Write(ConvertGroup10Var2::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group10.h
+++ b/cpp/libs/src/opendnp3/objects/Group10.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,48 +32,64 @@
 #ifndef OPENDNP3_GROUP10_H
 #define OPENDNP3_GROUP10_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Binary Output - Any Variation
 struct Group10Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(10,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(10, 0);
+    }
 };
 
 // Binary Output - Packed Format
 struct Group10Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(10,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(10, 1);
+    }
 };
 
 // Binary Output - Output Status With Flags
 struct Group10Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(10,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(10, 2);
+    }
 
-  Group10Var2();
+    Group10Var2();
 
-  static uint32_t Size() { return 1; }
-  static bool Read(openpal::RSlice&, Group10Var2&);
-  static bool Write(const Group10Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 1;
+    }
+    static bool Read(openpal::RSlice&, Group10Var2&);
+    static bool Write(const Group10Var2&, openpal::WSlice&);
 
-  uint8_t flags;
+    uint8_t flags;
 
-  typedef BinaryOutputStatus Target;
-  typedef BinaryOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, BinaryOutputStatus&);
-  static bool WriteTarget(const BinaryOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<BinaryOutputStatus> Inst() { return DNP3Serializer<BinaryOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef BinaryOutputStatus Target;
+    typedef BinaryOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, BinaryOutputStatus&);
+    static bool WriteTarget(const BinaryOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<BinaryOutputStatus> Inst()
+    {
+        return DNP3Serializer<BinaryOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group11.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group11.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,80 +33,79 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group11Var1 -------
 
-Group11Var1::Group11Var1() : flags(0)
-{}
+Group11Var1::Group11Var1() : flags(0) {}
 
 bool Group11Var1::Read(RSlice& buffer, Group11Var1& output)
 {
-  return Parse::Many(buffer, output.flags);
+    return Parse::Many(buffer, output.flags);
 }
 
 bool Group11Var1::Write(const Group11Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags);
+    return Format::Many(buffer, arg.flags);
 }
 
 bool Group11Var1::ReadTarget(RSlice& buff, BinaryOutputStatus& output)
 {
-  Group11Var1 value;
-  if(Read(buff, value))
-  {
-    output = BinaryOutputStatusFactory::From(value.flags);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group11Var1 value;
+    if (Read(buff, value))
+    {
+        output = BinaryOutputStatusFactory::From(value.flags);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group11Var1::WriteTarget(const BinaryOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group11Var1::Write(ConvertGroup11Var1::Apply(value), buff);
+    return Group11Var1::Write(ConvertGroup11Var1::Apply(value), buff);
 }
 
 // ------- Group11Var2 -------
 
-Group11Var2::Group11Var2() : flags(0), time(0)
-{}
+Group11Var2::Group11Var2() : flags(0), time(0) {}
 
 bool Group11Var2::Read(RSlice& buffer, Group11Var2& output)
 {
-  return Parse::Many(buffer, output.flags, output.time);
+    return Parse::Many(buffer, output.flags, output.time);
 }
 
 bool Group11Var2::Write(const Group11Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.time);
+    return Format::Many(buffer, arg.flags, arg.time);
 }
 
 bool Group11Var2::ReadTarget(RSlice& buff, BinaryOutputStatus& output)
 {
-  Group11Var2 value;
-  if(Read(buff, value))
-  {
-    output = BinaryOutputStatusFactory::From(value.flags, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group11Var2 value;
+    if (Read(buff, value))
+    {
+        output = BinaryOutputStatusFactory::From(value.flags, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group11Var2::WriteTarget(const BinaryOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group11Var2::Write(ConvertGroup11Var2::Apply(value), buff);
+    return Group11Var2::Write(ConvertGroup11Var2::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group11.h
+++ b/cpp/libs/src/opendnp3/objects/Group11.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,63 +32,85 @@
 #ifndef OPENDNP3_GROUP11_H
 #define OPENDNP3_GROUP11_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Binary Output Event - Any Variation
 struct Group11Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(11,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(11, 0);
+    }
 };
 
 // Binary Output Event - Output Status Without Time
 struct Group11Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(11,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(11, 1);
+    }
 
-  Group11Var1();
+    Group11Var1();
 
-  static uint32_t Size() { return 1; }
-  static bool Read(openpal::RSlice&, Group11Var1&);
-  static bool Write(const Group11Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 1;
+    }
+    static bool Read(openpal::RSlice&, Group11Var1&);
+    static bool Write(const Group11Var1&, openpal::WSlice&);
 
-  uint8_t flags;
+    uint8_t flags;
 
-  typedef BinaryOutputStatus Target;
-  typedef BinaryOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, BinaryOutputStatus&);
-  static bool WriteTarget(const BinaryOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<BinaryOutputStatus> Inst() { return DNP3Serializer<BinaryOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef BinaryOutputStatus Target;
+    typedef BinaryOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, BinaryOutputStatus&);
+    static bool WriteTarget(const BinaryOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<BinaryOutputStatus> Inst()
+    {
+        return DNP3Serializer<BinaryOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Binary Output Event - Output Status With Time
 struct Group11Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(11,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(11, 2);
+    }
 
-  Group11Var2();
+    Group11Var2();
 
-  static uint32_t Size() { return 7; }
-  static bool Read(openpal::RSlice&, Group11Var2&);
-  static bool Write(const Group11Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 7;
+    }
+    static bool Read(openpal::RSlice&, Group11Var2&);
+    static bool Write(const Group11Var2&, openpal::WSlice&);
 
-  uint8_t flags;
-  DNPTime time;
+    uint8_t flags;
+    DNPTime time;
 
-  typedef BinaryOutputStatus Target;
-  typedef BinaryOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, BinaryOutputStatus&);
-  static bool WriteTarget(const BinaryOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<BinaryOutputStatus> Inst() { return DNP3Serializer<BinaryOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef BinaryOutputStatus Target;
+    typedef BinaryOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, BinaryOutputStatus&);
+    static bool WriteTarget(const BinaryOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<BinaryOutputStatus> Inst()
+    {
+        return DNP3Serializer<BinaryOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group110.h
+++ b/cpp/libs/src/opendnp3/objects/Group110.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,15 +34,18 @@
 
 #include "opendnp3/app/GroupVariationID.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Octet String - Sized by variation
 struct Group110Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(110,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(110, 0);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group111.h
+++ b/cpp/libs/src/opendnp3/objects/Group111.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,15 +34,18 @@
 
 #include "opendnp3/app/GroupVariationID.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Octet String Event - Sized by variation
 struct Group111Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(111,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(111, 0);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group112.h
+++ b/cpp/libs/src/opendnp3/objects/Group112.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,15 +34,18 @@
 
 #include "opendnp3/app/GroupVariationID.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Virtual Terminal Output Block - Sized by variation
 struct Group112Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(112,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(112, 0);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group113.h
+++ b/cpp/libs/src/opendnp3/objects/Group113.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,15 +34,18 @@
 
 #include "opendnp3/app/GroupVariationID.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Virtual Terminal Event Data - Sized by variation
 struct Group113Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(113,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(113, 0);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group12.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group12.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,46 +33,47 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group12Var1 -------
 
-Group12Var1::Group12Var1() : code(0), count(0), onTime(0), offTime(0), status(0)
-{}
+Group12Var1::Group12Var1() : code(0), count(0), onTime(0), offTime(0), status(0) {}
 
 bool Group12Var1::Read(RSlice& buffer, Group12Var1& output)
 {
-  return Parse::Many(buffer, output.code, output.count, output.onTime, output.offTime, output.status);
+    return Parse::Many(buffer, output.code, output.count, output.onTime, output.offTime, output.status);
 }
 
 bool Group12Var1::Write(const Group12Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.code, arg.count, arg.onTime, arg.offTime, arg.status);
+    return Format::Many(buffer, arg.code, arg.count, arg.onTime, arg.offTime, arg.status);
 }
 
 bool Group12Var1::ReadTarget(RSlice& buff, ControlRelayOutputBlock& output)
 {
-  Group12Var1 value;
-  if(Read(buff, value))
-  {
-    output = ControlRelayOutputBlockFactory::From(value.code, value.count, value.onTime, value.offTime, value.status);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group12Var1 value;
+    if (Read(buff, value))
+    {
+        output
+            = ControlRelayOutputBlockFactory::From(value.code, value.count, value.onTime, value.offTime, value.status);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group12Var1::WriteTarget(const ControlRelayOutputBlock& value, openpal::WSlice& buff)
 {
-  return Group12Var1::Write(ConvertGroup12Var1::Apply(value), buff);
+    return Group12Var1::Write(ConvertGroup12Var1::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group12.h
+++ b/cpp/libs/src/opendnp3/objects/Group12.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,45 +32,58 @@
 #ifndef OPENDNP3_GROUP12_H
 #define OPENDNP3_GROUP12_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
-#include "opendnp3/app/DNP3Serializer.h"
-#include "opendnp3/app/ControlRelayOutputBlock.h"
 
-namespace opendnp3 {
+#include "opendnp3/app/ControlRelayOutputBlock.h"
+#include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
+
+namespace opendnp3
+{
 
 // Binary Command - Any Variation
 struct Group12Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(12,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(12, 0);
+    }
 };
 
 // Binary Command - CROB
 struct Group12Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(12,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(12, 1);
+    }
 
-  Group12Var1();
+    Group12Var1();
 
-  static uint32_t Size() { return 11; }
-  static bool Read(openpal::RSlice&, Group12Var1&);
-  static bool Write(const Group12Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 11;
+    }
+    static bool Read(openpal::RSlice&, Group12Var1&);
+    static bool Write(const Group12Var1&, openpal::WSlice&);
 
-  uint8_t code;
-  uint8_t count;
-  uint32_t onTime;
-  uint32_t offTime;
-  uint8_t status;
+    uint8_t code;
+    uint8_t count;
+    uint32_t onTime;
+    uint32_t offTime;
+    uint8_t status;
 
-  typedef ControlRelayOutputBlock Target;
-  static bool ReadTarget(openpal::RSlice&, ControlRelayOutputBlock&);
-  static bool WriteTarget(const ControlRelayOutputBlock&, openpal::WSlice&);
-  static DNP3Serializer<ControlRelayOutputBlock> Inst() { return DNP3Serializer<ControlRelayOutputBlock>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef ControlRelayOutputBlock Target;
+    static bool ReadTarget(openpal::RSlice&, ControlRelayOutputBlock&);
+    static bool WriteTarget(const ControlRelayOutputBlock&, openpal::WSlice&);
+    static DNP3Serializer<ControlRelayOutputBlock> Inst()
+    {
+        return DNP3Serializer<ControlRelayOutputBlock>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group120.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group120.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,801 +31,752 @@
 
 #include "Group120.h"
 
-#include <openpal/serialization/Serialization.h>
-#include "opendnp3/app/parsing/PrefixFields.h"
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+#include <openpal/serialization/Serialization.h>
+
+#include "opendnp3/app/parsing/PrefixFields.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group120Var1 -------
 
-Group120Var1::Group120Var1() : 
-  challengeSeqNum(0), userNum(0), hmacAlgo(HMACType::UNKNOWN), challengeReason(ChallengeReason::UNKNOWN)
-{}
+Group120Var1::Group120Var1()
+    : challengeSeqNum(0), userNum(0), hmacAlgo(HMACType::UNKNOWN), challengeReason(ChallengeReason::UNKNOWN)
+{
+}
 
-Group120Var1::Group120Var1(
-  uint32_t challengeSeqNum_,
-  uint16_t userNum_,
-  HMACType hmacAlgo_,
-  ChallengeReason challengeReason_,
-  const openpal::RSlice& challengeData_
-) : 
-  challengeSeqNum(challengeSeqNum_),
-  userNum(userNum_),
-  hmacAlgo(hmacAlgo_),
-  challengeReason(challengeReason_),
-  challengeData(challengeData_)
-{}
+Group120Var1::Group120Var1(uint32_t challengeSeqNum_,
+                           uint16_t userNum_,
+                           HMACType hmacAlgo_,
+                           ChallengeReason challengeReason_,
+                           const openpal::RSlice& challengeData_)
+    : challengeSeqNum(challengeSeqNum_),
+      userNum(userNum_),
+      hmacAlgo(hmacAlgo_),
+      challengeReason(challengeReason_),
+      challengeData(challengeData_)
+{
+}
 
 uint32_t Group120Var1::Size() const
 {
-  return MIN_SIZE + challengeData.Size();
+    return MIN_SIZE + challengeData.Size();
 }
 
 bool Group120Var1::Read(const RSlice& buffer)
 {
-  if(buffer.Size() < Group120Var1::MIN_SIZE)
-  {
-    return false;
-  }
+    if (buffer.Size() < Group120Var1::MIN_SIZE)
+    {
+        return false;
+    }
 
-  RSlice copy(buffer); //mutable copy for parsing
+    RSlice copy(buffer); // mutable copy for parsing
 
-  this->challengeSeqNum = UInt32::ReadBuffer(copy);
-  this->userNum = UInt16::ReadBuffer(copy);
-  this->hmacAlgo = HMACTypeFromType(UInt8::ReadBuffer(copy));
-  this->challengeReason = ChallengeReasonFromType(UInt8::ReadBuffer(copy));
+    this->challengeSeqNum = UInt32::ReadBuffer(copy);
+    this->userNum = UInt16::ReadBuffer(copy);
+    this->hmacAlgo = HMACTypeFromType(UInt8::ReadBuffer(copy));
+    this->challengeReason = ChallengeReasonFromType(UInt8::ReadBuffer(copy));
 
-  this->challengeData = copy; // whatever is left over
-  return true;
+    this->challengeData = copy; // whatever is left over
+    return true;
 }
 
 bool Group120Var1::Write(openpal::WSlice& buffer) const
 {
-  if(this->Size() > buffer.Size())
-  {
-    return false;
-  }
+    if (this->Size() > buffer.Size())
+    {
+        return false;
+    }
 
-  UInt32::WriteBuffer(buffer, this->challengeSeqNum);
-  UInt16::WriteBuffer(buffer, this->userNum);
-  UInt8::WriteBuffer(buffer, HMACTypeToType(this->hmacAlgo));
-  UInt8::WriteBuffer(buffer, ChallengeReasonToType(this->challengeReason));
+    UInt32::WriteBuffer(buffer, this->challengeSeqNum);
+    UInt16::WriteBuffer(buffer, this->userNum);
+    UInt8::WriteBuffer(buffer, HMACTypeToType(this->hmacAlgo));
+    UInt8::WriteBuffer(buffer, ChallengeReasonToType(this->challengeReason));
 
-  challengeData.CopyTo(buffer);
-  return true;
+    challengeData.CopyTo(buffer);
+    return true;
 }
 
 // ------- Group120Var2 -------
 
-Group120Var2::Group120Var2() : 
-  challengeSeqNum(0), userNum(0)
-{}
+Group120Var2::Group120Var2() : challengeSeqNum(0), userNum(0) {}
 
-Group120Var2::Group120Var2(
-  uint32_t challengeSeqNum_,
-  uint16_t userNum_,
-  const openpal::RSlice& hmacValue_
-) : 
-  challengeSeqNum(challengeSeqNum_),
-  userNum(userNum_),
-  hmacValue(hmacValue_)
-{}
+Group120Var2::Group120Var2(uint32_t challengeSeqNum_, uint16_t userNum_, const openpal::RSlice& hmacValue_)
+    : challengeSeqNum(challengeSeqNum_), userNum(userNum_), hmacValue(hmacValue_)
+{
+}
 
 uint32_t Group120Var2::Size() const
 {
-  return MIN_SIZE + hmacValue.Size();
+    return MIN_SIZE + hmacValue.Size();
 }
 
 bool Group120Var2::Read(const RSlice& buffer)
 {
-  if(buffer.Size() < Group120Var2::MIN_SIZE)
-  {
-    return false;
-  }
+    if (buffer.Size() < Group120Var2::MIN_SIZE)
+    {
+        return false;
+    }
 
-  RSlice copy(buffer); //mutable copy for parsing
+    RSlice copy(buffer); // mutable copy for parsing
 
-  this->challengeSeqNum = UInt32::ReadBuffer(copy);
-  this->userNum = UInt16::ReadBuffer(copy);
+    this->challengeSeqNum = UInt32::ReadBuffer(copy);
+    this->userNum = UInt16::ReadBuffer(copy);
 
-  this->hmacValue = copy; // whatever is left over
-  return true;
+    this->hmacValue = copy; // whatever is left over
+    return true;
 }
 
 bool Group120Var2::Write(openpal::WSlice& buffer) const
 {
-  if(this->Size() > buffer.Size())
-  {
-    return false;
-  }
+    if (this->Size() > buffer.Size())
+    {
+        return false;
+    }
 
-  UInt32::WriteBuffer(buffer, this->challengeSeqNum);
-  UInt16::WriteBuffer(buffer, this->userNum);
+    UInt32::WriteBuffer(buffer, this->challengeSeqNum);
+    UInt16::WriteBuffer(buffer, this->userNum);
 
-  hmacValue.CopyTo(buffer);
-  return true;
+    hmacValue.CopyTo(buffer);
+    return true;
 }
 
 // ------- Group120Var3 -------
 
-Group120Var3::Group120Var3() : challengeSeqNum(0), userNum(0)
-{}
+Group120Var3::Group120Var3() : challengeSeqNum(0), userNum(0) {}
 
 bool Group120Var3::Read(RSlice& buffer, Group120Var3& output)
 {
-  return Parse::Many(buffer, output.challengeSeqNum, output.userNum);
+    return Parse::Many(buffer, output.challengeSeqNum, output.userNum);
 }
 
 bool Group120Var3::Write(const Group120Var3& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.challengeSeqNum, arg.userNum);
+    return Format::Many(buffer, arg.challengeSeqNum, arg.userNum);
 }
 
 // ------- Group120Var4 -------
 
-Group120Var4::Group120Var4() : userNum(0)
-{}
+Group120Var4::Group120Var4() : userNum(0) {}
 
 bool Group120Var4::Read(RSlice& buffer, Group120Var4& output)
 {
-  return Parse::Many(buffer, output.userNum);
+    return Parse::Many(buffer, output.userNum);
 }
 
 bool Group120Var4::Write(const Group120Var4& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.userNum);
+    return Format::Many(buffer, arg.userNum);
 }
 
 // ------- Group120Var5 -------
 
-Group120Var5::Group120Var5() : 
-  keyChangeSeqNum(0), userNum(0), keyWrapAlgo(KeyWrapAlgorithm::UNDEFINED), keyStatus(KeyStatus::UNDEFINED), hmacAlgo(HMACType::UNKNOWN)
-{}
+Group120Var5::Group120Var5()
+    : keyChangeSeqNum(0),
+      userNum(0),
+      keyWrapAlgo(KeyWrapAlgorithm::UNDEFINED),
+      keyStatus(KeyStatus::UNDEFINED),
+      hmacAlgo(HMACType::UNKNOWN)
+{
+}
 
-Group120Var5::Group120Var5(
-  uint32_t keyChangeSeqNum_,
-  uint16_t userNum_,
-  KeyWrapAlgorithm keyWrapAlgo_,
-  KeyStatus keyStatus_,
-  HMACType hmacAlgo_,
-  const openpal::RSlice& challengeData_,
-  const openpal::RSlice& hmacValue_
-) : 
-  keyChangeSeqNum(keyChangeSeqNum_),
-  userNum(userNum_),
-  keyWrapAlgo(keyWrapAlgo_),
-  keyStatus(keyStatus_),
-  hmacAlgo(hmacAlgo_),
-  challengeData(challengeData_),
-  hmacValue(hmacValue_)
-{}
+Group120Var5::Group120Var5(uint32_t keyChangeSeqNum_,
+                           uint16_t userNum_,
+                           KeyWrapAlgorithm keyWrapAlgo_,
+                           KeyStatus keyStatus_,
+                           HMACType hmacAlgo_,
+                           const openpal::RSlice& challengeData_,
+                           const openpal::RSlice& hmacValue_)
+    : keyChangeSeqNum(keyChangeSeqNum_),
+      userNum(userNum_),
+      keyWrapAlgo(keyWrapAlgo_),
+      keyStatus(keyStatus_),
+      hmacAlgo(hmacAlgo_),
+      challengeData(challengeData_),
+      hmacValue(hmacValue_)
+{
+}
 
 uint32_t Group120Var5::Size() const
 {
-  return MIN_SIZE + challengeData.Size() + hmacValue.Size();
+    return MIN_SIZE + challengeData.Size() + hmacValue.Size();
 }
 
 bool Group120Var5::Read(const RSlice& buffer)
 {
-  if(buffer.Size() < Group120Var5::MIN_SIZE)
-  {
-    return false;
-  }
+    if (buffer.Size() < Group120Var5::MIN_SIZE)
+    {
+        return false;
+    }
 
-  RSlice copy(buffer); //mutable copy for parsing
+    RSlice copy(buffer); // mutable copy for parsing
 
-  this->keyChangeSeqNum = UInt32::ReadBuffer(copy);
-  this->userNum = UInt16::ReadBuffer(copy);
-  this->keyWrapAlgo = KeyWrapAlgorithmFromType(UInt8::ReadBuffer(copy));
-  this->keyStatus = KeyStatusFromType(UInt8::ReadBuffer(copy));
-  this->hmacAlgo = HMACTypeFromType(UInt8::ReadBuffer(copy));
+    this->keyChangeSeqNum = UInt32::ReadBuffer(copy);
+    this->userNum = UInt16::ReadBuffer(copy);
+    this->keyWrapAlgo = KeyWrapAlgorithmFromType(UInt8::ReadBuffer(copy));
+    this->keyStatus = KeyStatusFromType(UInt8::ReadBuffer(copy));
+    this->hmacAlgo = HMACTypeFromType(UInt8::ReadBuffer(copy));
 
-  if(!PrefixFields::Read(copy, challengeData))
-  {
-    return false;
-  }
+    if (!PrefixFields::Read(copy, challengeData))
+    {
+        return false;
+    }
 
-  this->hmacValue = copy; // whatever is left over
-  return true;
+    this->hmacValue = copy; // whatever is left over
+    return true;
 }
 
 bool Group120Var5::Write(openpal::WSlice& buffer) const
 {
-  if(this->Size() > buffer.Size())
-  {
-    return false;
-  }
+    if (this->Size() > buffer.Size())
+    {
+        return false;
+    }
 
-  // All of the fields that have a uint16_t length must have the proper size
-  if(!PrefixFields::LengthFitsInUInt16(challengeData))
-  {
-    return false;
-  }
+    // All of the fields that have a uint16_t length must have the proper size
+    if (!PrefixFields::LengthFitsInUInt16(challengeData))
+    {
+        return false;
+    }
 
-  UInt32::WriteBuffer(buffer, this->keyChangeSeqNum);
-  UInt16::WriteBuffer(buffer, this->userNum);
-  UInt8::WriteBuffer(buffer, KeyWrapAlgorithmToType(this->keyWrapAlgo));
-  UInt8::WriteBuffer(buffer, KeyStatusToType(this->keyStatus));
-  UInt8::WriteBuffer(buffer, HMACTypeToType(this->hmacAlgo));
+    UInt32::WriteBuffer(buffer, this->keyChangeSeqNum);
+    UInt16::WriteBuffer(buffer, this->userNum);
+    UInt8::WriteBuffer(buffer, KeyWrapAlgorithmToType(this->keyWrapAlgo));
+    UInt8::WriteBuffer(buffer, KeyStatusToType(this->keyStatus));
+    UInt8::WriteBuffer(buffer, HMACTypeToType(this->hmacAlgo));
 
-  if(!PrefixFields::Write(buffer, challengeData))
-  {
-    return false;
-  }
+    if (!PrefixFields::Write(buffer, challengeData))
+    {
+        return false;
+    }
 
-  hmacValue.CopyTo(buffer);
-  return true;
+    hmacValue.CopyTo(buffer);
+    return true;
 }
 
 // ------- Group120Var6 -------
 
-Group120Var6::Group120Var6() : 
-  keyChangeSeqNum(0), userNum(0)
-{}
+Group120Var6::Group120Var6() : keyChangeSeqNum(0), userNum(0) {}
 
-Group120Var6::Group120Var6(
-  uint32_t keyChangeSeqNum_,
-  uint16_t userNum_,
-  const openpal::RSlice& keyWrapData_
-) : 
-  keyChangeSeqNum(keyChangeSeqNum_),
-  userNum(userNum_),
-  keyWrapData(keyWrapData_)
-{}
+Group120Var6::Group120Var6(uint32_t keyChangeSeqNum_, uint16_t userNum_, const openpal::RSlice& keyWrapData_)
+    : keyChangeSeqNum(keyChangeSeqNum_), userNum(userNum_), keyWrapData(keyWrapData_)
+{
+}
 
 uint32_t Group120Var6::Size() const
 {
-  return MIN_SIZE + keyWrapData.Size();
+    return MIN_SIZE + keyWrapData.Size();
 }
 
 bool Group120Var6::Read(const RSlice& buffer)
 {
-  if(buffer.Size() < Group120Var6::MIN_SIZE)
-  {
-    return false;
-  }
+    if (buffer.Size() < Group120Var6::MIN_SIZE)
+    {
+        return false;
+    }
 
-  RSlice copy(buffer); //mutable copy for parsing
+    RSlice copy(buffer); // mutable copy for parsing
 
-  this->keyChangeSeqNum = UInt32::ReadBuffer(copy);
-  this->userNum = UInt16::ReadBuffer(copy);
+    this->keyChangeSeqNum = UInt32::ReadBuffer(copy);
+    this->userNum = UInt16::ReadBuffer(copy);
 
-  this->keyWrapData = copy; // whatever is left over
-  return true;
+    this->keyWrapData = copy; // whatever is left over
+    return true;
 }
 
 bool Group120Var6::Write(openpal::WSlice& buffer) const
 {
-  if(this->Size() > buffer.Size())
-  {
-    return false;
-  }
+    if (this->Size() > buffer.Size())
+    {
+        return false;
+    }
 
-  UInt32::WriteBuffer(buffer, this->keyChangeSeqNum);
-  UInt16::WriteBuffer(buffer, this->userNum);
+    UInt32::WriteBuffer(buffer, this->keyChangeSeqNum);
+    UInt16::WriteBuffer(buffer, this->userNum);
 
-  keyWrapData.CopyTo(buffer);
-  return true;
+    keyWrapData.CopyTo(buffer);
+    return true;
 }
 
 // ------- Group120Var7 -------
 
-Group120Var7::Group120Var7() : 
-  challengeSeqNum(0), userNum(0), assocId(0), errorCode(AuthErrorCode::UNKNOWN), time(0)
-{}
+Group120Var7::Group120Var7() : challengeSeqNum(0), userNum(0), assocId(0), errorCode(AuthErrorCode::UNKNOWN), time(0) {}
 
-Group120Var7::Group120Var7(
-  uint32_t challengeSeqNum_,
-  uint16_t userNum_,
-  uint16_t assocId_,
-  AuthErrorCode errorCode_,
-  DNPTime time_,
-  const openpal::RSlice& errorText_
-) : 
-  challengeSeqNum(challengeSeqNum_),
-  userNum(userNum_),
-  assocId(assocId_),
-  errorCode(errorCode_),
-  time(time_),
-  errorText(errorText_)
-{}
+Group120Var7::Group120Var7(uint32_t challengeSeqNum_,
+                           uint16_t userNum_,
+                           uint16_t assocId_,
+                           AuthErrorCode errorCode_,
+                           DNPTime time_,
+                           const openpal::RSlice& errorText_)
+    : challengeSeqNum(challengeSeqNum_),
+      userNum(userNum_),
+      assocId(assocId_),
+      errorCode(errorCode_),
+      time(time_),
+      errorText(errorText_)
+{
+}
 
 uint32_t Group120Var7::Size() const
 {
-  return MIN_SIZE + errorText.Size();
+    return MIN_SIZE + errorText.Size();
 }
 
 bool Group120Var7::Read(const RSlice& buffer)
 {
-  if(buffer.Size() < Group120Var7::MIN_SIZE)
-  {
-    return false;
-  }
+    if (buffer.Size() < Group120Var7::MIN_SIZE)
+    {
+        return false;
+    }
 
-  RSlice copy(buffer); //mutable copy for parsing
+    RSlice copy(buffer); // mutable copy for parsing
 
-  this->challengeSeqNum = UInt32::ReadBuffer(copy);
-  this->userNum = UInt16::ReadBuffer(copy);
-  this->assocId = UInt16::ReadBuffer(copy);
-  this->errorCode = AuthErrorCodeFromType(UInt8::ReadBuffer(copy));
-  this->time = UInt48::ReadBuffer(copy);
+    this->challengeSeqNum = UInt32::ReadBuffer(copy);
+    this->userNum = UInt16::ReadBuffer(copy);
+    this->assocId = UInt16::ReadBuffer(copy);
+    this->errorCode = AuthErrorCodeFromType(UInt8::ReadBuffer(copy));
+    this->time = UInt48::ReadBuffer(copy);
 
-  this->errorText = copy; // whatever is left over
-  return true;
+    this->errorText = copy; // whatever is left over
+    return true;
 }
 
 bool Group120Var7::Write(openpal::WSlice& buffer) const
 {
-  if(this->Size() > buffer.Size())
-  {
-    return false;
-  }
+    if (this->Size() > buffer.Size())
+    {
+        return false;
+    }
 
-  UInt32::WriteBuffer(buffer, this->challengeSeqNum);
-  UInt16::WriteBuffer(buffer, this->userNum);
-  UInt16::WriteBuffer(buffer, this->assocId);
-  UInt8::WriteBuffer(buffer, AuthErrorCodeToType(this->errorCode));
-  UInt48::WriteBuffer(buffer, this->time);
+    UInt32::WriteBuffer(buffer, this->challengeSeqNum);
+    UInt16::WriteBuffer(buffer, this->userNum);
+    UInt16::WriteBuffer(buffer, this->assocId);
+    UInt8::WriteBuffer(buffer, AuthErrorCodeToType(this->errorCode));
+    UInt48::WriteBuffer(buffer, this->time);
 
-  errorText.CopyTo(buffer);
-  return true;
+    errorText.CopyTo(buffer);
+    return true;
 }
 
 // ------- Group120Var8 -------
 
-Group120Var8::Group120Var8() : 
-  keyChangeMethod(KeyChangeMethod::UNDEFINED), certificateType(CertificateType::UNKNOWN)
-{}
+Group120Var8::Group120Var8() : keyChangeMethod(KeyChangeMethod::UNDEFINED), certificateType(CertificateType::UNKNOWN) {}
 
-Group120Var8::Group120Var8(
-  KeyChangeMethod keyChangeMethod_,
-  CertificateType certificateType_,
-  const openpal::RSlice& certificate_
-) : 
-  keyChangeMethod(keyChangeMethod_),
-  certificateType(certificateType_),
-  certificate(certificate_)
-{}
+Group120Var8::Group120Var8(KeyChangeMethod keyChangeMethod_,
+                           CertificateType certificateType_,
+                           const openpal::RSlice& certificate_)
+    : keyChangeMethod(keyChangeMethod_), certificateType(certificateType_), certificate(certificate_)
+{
+}
 
 uint32_t Group120Var8::Size() const
 {
-  return MIN_SIZE + certificate.Size();
+    return MIN_SIZE + certificate.Size();
 }
 
 bool Group120Var8::Read(const RSlice& buffer)
 {
-  if(buffer.Size() < Group120Var8::MIN_SIZE)
-  {
-    return false;
-  }
+    if (buffer.Size() < Group120Var8::MIN_SIZE)
+    {
+        return false;
+    }
 
-  RSlice copy(buffer); //mutable copy for parsing
+    RSlice copy(buffer); // mutable copy for parsing
 
-  this->keyChangeMethod = KeyChangeMethodFromType(UInt8::ReadBuffer(copy));
-  this->certificateType = CertificateTypeFromType(UInt8::ReadBuffer(copy));
+    this->keyChangeMethod = KeyChangeMethodFromType(UInt8::ReadBuffer(copy));
+    this->certificateType = CertificateTypeFromType(UInt8::ReadBuffer(copy));
 
-  this->certificate = copy; // whatever is left over
-  return true;
+    this->certificate = copy; // whatever is left over
+    return true;
 }
 
 bool Group120Var8::Write(openpal::WSlice& buffer) const
 {
-  if(this->Size() > buffer.Size())
-  {
-    return false;
-  }
+    if (this->Size() > buffer.Size())
+    {
+        return false;
+    }
 
-  UInt8::WriteBuffer(buffer, KeyChangeMethodToType(this->keyChangeMethod));
-  UInt8::WriteBuffer(buffer, CertificateTypeToType(this->certificateType));
+    UInt8::WriteBuffer(buffer, KeyChangeMethodToType(this->keyChangeMethod));
+    UInt8::WriteBuffer(buffer, CertificateTypeToType(this->certificateType));
 
-  certificate.CopyTo(buffer);
-  return true;
+    certificate.CopyTo(buffer);
+    return true;
 }
 
 // ------- Group120Var9 -------
 
-Group120Var9::Group120Var9()
-{}
+Group120Var9::Group120Var9() {}
 
-Group120Var9::Group120Var9(
-  const openpal::RSlice& hmacValue_
-) : 
-  hmacValue(hmacValue_)
-{}
+Group120Var9::Group120Var9(const openpal::RSlice& hmacValue_) : hmacValue(hmacValue_) {}
 
 uint32_t Group120Var9::Size() const
 {
-  return MIN_SIZE + hmacValue.Size();
+    return MIN_SIZE + hmacValue.Size();
 }
 
 bool Group120Var9::Read(const RSlice& buffer)
 {
-  this->hmacValue = buffer; // the object is just the remainder field
-  return true;
+    this->hmacValue = buffer; // the object is just the remainder field
+    return true;
 }
 
 bool Group120Var9::Write(openpal::WSlice& buffer) const
 {
-  if(this->Size() > buffer.Size())
-  {
-    return false;
-  }
+    if (this->Size() > buffer.Size())
+    {
+        return false;
+    }
 
-  hmacValue.CopyTo(buffer);
-  return true;
+    hmacValue.CopyTo(buffer);
+    return true;
 }
 
 // ------- Group120Var10 -------
 
-Group120Var10::Group120Var10() : 
-  keyChangeMethod(KeyChangeMethod::UNDEFINED), userOperation(UserOperation::OP_UNDEFINED), statusChangeSeqNum(0), userRole(0), userRoleExpDays(0)
-{}
+Group120Var10::Group120Var10()
+    : keyChangeMethod(KeyChangeMethod::UNDEFINED),
+      userOperation(UserOperation::OP_UNDEFINED),
+      statusChangeSeqNum(0),
+      userRole(0),
+      userRoleExpDays(0)
+{
+}
 
-Group120Var10::Group120Var10(
-  KeyChangeMethod keyChangeMethod_,
-  UserOperation userOperation_,
-  uint32_t statusChangeSeqNum_,
-  uint16_t userRole_,
-  uint16_t userRoleExpDays_,
-  const openpal::RSlice& userName_,
-  const openpal::RSlice& userPublicKey_,
-  const openpal::RSlice& certificationData_
-) : 
-  keyChangeMethod(keyChangeMethod_),
-  userOperation(userOperation_),
-  statusChangeSeqNum(statusChangeSeqNum_),
-  userRole(userRole_),
-  userRoleExpDays(userRoleExpDays_),
-  userName(userName_),
-  userPublicKey(userPublicKey_),
-  certificationData(certificationData_)
-{}
+Group120Var10::Group120Var10(KeyChangeMethod keyChangeMethod_,
+                             UserOperation userOperation_,
+                             uint32_t statusChangeSeqNum_,
+                             uint16_t userRole_,
+                             uint16_t userRoleExpDays_,
+                             const openpal::RSlice& userName_,
+                             const openpal::RSlice& userPublicKey_,
+                             const openpal::RSlice& certificationData_)
+    : keyChangeMethod(keyChangeMethod_),
+      userOperation(userOperation_),
+      statusChangeSeqNum(statusChangeSeqNum_),
+      userRole(userRole_),
+      userRoleExpDays(userRoleExpDays_),
+      userName(userName_),
+      userPublicKey(userPublicKey_),
+      certificationData(certificationData_)
+{
+}
 
 uint32_t Group120Var10::Size() const
 {
-  return MIN_SIZE + userName.Size() + userPublicKey.Size() + certificationData.Size();
+    return MIN_SIZE + userName.Size() + userPublicKey.Size() + certificationData.Size();
 }
 
 bool Group120Var10::Read(const RSlice& buffer)
 {
-  if(buffer.Size() < Group120Var10::MIN_SIZE)
-  {
-    return false;
-  }
+    if (buffer.Size() < Group120Var10::MIN_SIZE)
+    {
+        return false;
+    }
 
-  RSlice copy(buffer); //mutable copy for parsing
+    RSlice copy(buffer); // mutable copy for parsing
 
-  this->keyChangeMethod = KeyChangeMethodFromType(UInt8::ReadBuffer(copy));
-  this->userOperation = UserOperationFromType(UInt8::ReadBuffer(copy));
-  this->statusChangeSeqNum = UInt32::ReadBuffer(copy);
-  this->userRole = UInt16::ReadBuffer(copy);
-  this->userRoleExpDays = UInt16::ReadBuffer(copy);
+    this->keyChangeMethod = KeyChangeMethodFromType(UInt8::ReadBuffer(copy));
+    this->userOperation = UserOperationFromType(UInt8::ReadBuffer(copy));
+    this->statusChangeSeqNum = UInt32::ReadBuffer(copy);
+    this->userRole = UInt16::ReadBuffer(copy);
+    this->userRoleExpDays = UInt16::ReadBuffer(copy);
 
-  if(!PrefixFields::Read(copy, userName, userPublicKey, certificationData))
-  {
-    return false;
-  }
+    if (!PrefixFields::Read(copy, userName, userPublicKey, certificationData))
+    {
+        return false;
+    }
 
-  // object does not have a remainder field so it should be fully consumed
-  // The header length disagrees with object encoding so abort
-  if(copy.IsNotEmpty())
-  {
-    return false;
-  }
+    // object does not have a remainder field so it should be fully consumed
+    // The header length disagrees with object encoding so abort
+    if (copy.IsNotEmpty())
+    {
+        return false;
+    }
 
-  return true;
+    return true;
 }
 
 bool Group120Var10::Write(openpal::WSlice& buffer) const
 {
-  if(this->Size() > buffer.Size())
-  {
-    return false;
-  }
+    if (this->Size() > buffer.Size())
+    {
+        return false;
+    }
 
-  // All of the fields that have a uint16_t length must have the proper size
-  if(!PrefixFields::LengthFitsInUInt16(userName, userPublicKey, certificationData))
-  {
-    return false;
-  }
+    // All of the fields that have a uint16_t length must have the proper size
+    if (!PrefixFields::LengthFitsInUInt16(userName, userPublicKey, certificationData))
+    {
+        return false;
+    }
 
-  UInt8::WriteBuffer(buffer, KeyChangeMethodToType(this->keyChangeMethod));
-  UInt8::WriteBuffer(buffer, UserOperationToType(this->userOperation));
-  UInt32::WriteBuffer(buffer, this->statusChangeSeqNum);
-  UInt16::WriteBuffer(buffer, this->userRole);
-  UInt16::WriteBuffer(buffer, this->userRoleExpDays);
+    UInt8::WriteBuffer(buffer, KeyChangeMethodToType(this->keyChangeMethod));
+    UInt8::WriteBuffer(buffer, UserOperationToType(this->userOperation));
+    UInt32::WriteBuffer(buffer, this->statusChangeSeqNum);
+    UInt16::WriteBuffer(buffer, this->userRole);
+    UInt16::WriteBuffer(buffer, this->userRoleExpDays);
 
-  if(!PrefixFields::Write(buffer, userName, userPublicKey, certificationData))
-  {
-    return false;
-  }
+    if (!PrefixFields::Write(buffer, userName, userPublicKey, certificationData))
+    {
+        return false;
+    }
 
-  return true;
+    return true;
 }
 
 // ------- Group120Var11 -------
 
-Group120Var11::Group120Var11() : 
-  keyChangeMethod(KeyChangeMethod::UNDEFINED)
-{}
+Group120Var11::Group120Var11() : keyChangeMethod(KeyChangeMethod::UNDEFINED) {}
 
-Group120Var11::Group120Var11(
-  KeyChangeMethod keyChangeMethod_,
-  const openpal::RSlice& userName_,
-  const openpal::RSlice& challengeData_
-) : 
-  keyChangeMethod(keyChangeMethod_),
-  userName(userName_),
-  challengeData(challengeData_)
-{}
+Group120Var11::Group120Var11(KeyChangeMethod keyChangeMethod_,
+                             const openpal::RSlice& userName_,
+                             const openpal::RSlice& challengeData_)
+    : keyChangeMethod(keyChangeMethod_), userName(userName_), challengeData(challengeData_)
+{
+}
 
 uint32_t Group120Var11::Size() const
 {
-  return MIN_SIZE + userName.Size() + challengeData.Size();
+    return MIN_SIZE + userName.Size() + challengeData.Size();
 }
 
 bool Group120Var11::Read(const RSlice& buffer)
 {
-  if(buffer.Size() < Group120Var11::MIN_SIZE)
-  {
-    return false;
-  }
+    if (buffer.Size() < Group120Var11::MIN_SIZE)
+    {
+        return false;
+    }
 
-  RSlice copy(buffer); //mutable copy for parsing
+    RSlice copy(buffer); // mutable copy for parsing
 
-  this->keyChangeMethod = KeyChangeMethodFromType(UInt8::ReadBuffer(copy));
+    this->keyChangeMethod = KeyChangeMethodFromType(UInt8::ReadBuffer(copy));
 
-  if(!PrefixFields::Read(copy, userName, challengeData))
-  {
-    return false;
-  }
+    if (!PrefixFields::Read(copy, userName, challengeData))
+    {
+        return false;
+    }
 
-  // object does not have a remainder field so it should be fully consumed
-  // The header length disagrees with object encoding so abort
-  if(copy.IsNotEmpty())
-  {
-    return false;
-  }
+    // object does not have a remainder field so it should be fully consumed
+    // The header length disagrees with object encoding so abort
+    if (copy.IsNotEmpty())
+    {
+        return false;
+    }
 
-  return true;
+    return true;
 }
 
 bool Group120Var11::Write(openpal::WSlice& buffer) const
 {
-  if(this->Size() > buffer.Size())
-  {
-    return false;
-  }
+    if (this->Size() > buffer.Size())
+    {
+        return false;
+    }
 
-  // All of the fields that have a uint16_t length must have the proper size
-  if(!PrefixFields::LengthFitsInUInt16(userName, challengeData))
-  {
-    return false;
-  }
+    // All of the fields that have a uint16_t length must have the proper size
+    if (!PrefixFields::LengthFitsInUInt16(userName, challengeData))
+    {
+        return false;
+    }
 
-  UInt8::WriteBuffer(buffer, KeyChangeMethodToType(this->keyChangeMethod));
+    UInt8::WriteBuffer(buffer, KeyChangeMethodToType(this->keyChangeMethod));
 
-  if(!PrefixFields::Write(buffer, userName, challengeData))
-  {
-    return false;
-  }
+    if (!PrefixFields::Write(buffer, userName, challengeData))
+    {
+        return false;
+    }
 
-  return true;
+    return true;
 }
 
 // ------- Group120Var12 -------
 
-Group120Var12::Group120Var12() : 
-  keyChangeSeqNum(0), userNum(0)
-{}
+Group120Var12::Group120Var12() : keyChangeSeqNum(0), userNum(0) {}
 
-Group120Var12::Group120Var12(
-  uint32_t keyChangeSeqNum_,
-  uint16_t userNum_,
-  const openpal::RSlice& challengeData_
-) : 
-  keyChangeSeqNum(keyChangeSeqNum_),
-  userNum(userNum_),
-  challengeData(challengeData_)
-{}
+Group120Var12::Group120Var12(uint32_t keyChangeSeqNum_, uint16_t userNum_, const openpal::RSlice& challengeData_)
+    : keyChangeSeqNum(keyChangeSeqNum_), userNum(userNum_), challengeData(challengeData_)
+{
+}
 
 uint32_t Group120Var12::Size() const
 {
-  return MIN_SIZE + challengeData.Size();
+    return MIN_SIZE + challengeData.Size();
 }
 
 bool Group120Var12::Read(const RSlice& buffer)
 {
-  if(buffer.Size() < Group120Var12::MIN_SIZE)
-  {
-    return false;
-  }
+    if (buffer.Size() < Group120Var12::MIN_SIZE)
+    {
+        return false;
+    }
 
-  RSlice copy(buffer); //mutable copy for parsing
+    RSlice copy(buffer); // mutable copy for parsing
 
-  this->keyChangeSeqNum = UInt32::ReadBuffer(copy);
-  this->userNum = UInt16::ReadBuffer(copy);
+    this->keyChangeSeqNum = UInt32::ReadBuffer(copy);
+    this->userNum = UInt16::ReadBuffer(copy);
 
-  if(!PrefixFields::Read(copy, challengeData))
-  {
-    return false;
-  }
+    if (!PrefixFields::Read(copy, challengeData))
+    {
+        return false;
+    }
 
-  // object does not have a remainder field so it should be fully consumed
-  // The header length disagrees with object encoding so abort
-  if(copy.IsNotEmpty())
-  {
-    return false;
-  }
+    // object does not have a remainder field so it should be fully consumed
+    // The header length disagrees with object encoding so abort
+    if (copy.IsNotEmpty())
+    {
+        return false;
+    }
 
-  return true;
+    return true;
 }
 
 bool Group120Var12::Write(openpal::WSlice& buffer) const
 {
-  if(this->Size() > buffer.Size())
-  {
-    return false;
-  }
+    if (this->Size() > buffer.Size())
+    {
+        return false;
+    }
 
-  // All of the fields that have a uint16_t length must have the proper size
-  if(!PrefixFields::LengthFitsInUInt16(challengeData))
-  {
-    return false;
-  }
+    // All of the fields that have a uint16_t length must have the proper size
+    if (!PrefixFields::LengthFitsInUInt16(challengeData))
+    {
+        return false;
+    }
 
-  UInt32::WriteBuffer(buffer, this->keyChangeSeqNum);
-  UInt16::WriteBuffer(buffer, this->userNum);
+    UInt32::WriteBuffer(buffer, this->keyChangeSeqNum);
+    UInt16::WriteBuffer(buffer, this->userNum);
 
-  if(!PrefixFields::Write(buffer, challengeData))
-  {
-    return false;
-  }
+    if (!PrefixFields::Write(buffer, challengeData))
+    {
+        return false;
+    }
 
-  return true;
+    return true;
 }
 
 // ------- Group120Var13 -------
 
-Group120Var13::Group120Var13() : 
-  keyChangeSeqNum(0), userNum(0)
-{}
+Group120Var13::Group120Var13() : keyChangeSeqNum(0), userNum(0) {}
 
-Group120Var13::Group120Var13(
-  uint32_t keyChangeSeqNum_,
-  uint16_t userNum_,
-  const openpal::RSlice& encryptedUpdateKey_
-) : 
-  keyChangeSeqNum(keyChangeSeqNum_),
-  userNum(userNum_),
-  encryptedUpdateKey(encryptedUpdateKey_)
-{}
+Group120Var13::Group120Var13(uint32_t keyChangeSeqNum_, uint16_t userNum_, const openpal::RSlice& encryptedUpdateKey_)
+    : keyChangeSeqNum(keyChangeSeqNum_), userNum(userNum_), encryptedUpdateKey(encryptedUpdateKey_)
+{
+}
 
 uint32_t Group120Var13::Size() const
 {
-  return MIN_SIZE + encryptedUpdateKey.Size();
+    return MIN_SIZE + encryptedUpdateKey.Size();
 }
 
 bool Group120Var13::Read(const RSlice& buffer)
 {
-  if(buffer.Size() < Group120Var13::MIN_SIZE)
-  {
-    return false;
-  }
+    if (buffer.Size() < Group120Var13::MIN_SIZE)
+    {
+        return false;
+    }
 
-  RSlice copy(buffer); //mutable copy for parsing
+    RSlice copy(buffer); // mutable copy for parsing
 
-  this->keyChangeSeqNum = UInt32::ReadBuffer(copy);
-  this->userNum = UInt16::ReadBuffer(copy);
+    this->keyChangeSeqNum = UInt32::ReadBuffer(copy);
+    this->userNum = UInt16::ReadBuffer(copy);
 
-  if(!PrefixFields::Read(copy, encryptedUpdateKey))
-  {
-    return false;
-  }
+    if (!PrefixFields::Read(copy, encryptedUpdateKey))
+    {
+        return false;
+    }
 
-  // object does not have a remainder field so it should be fully consumed
-  // The header length disagrees with object encoding so abort
-  if(copy.IsNotEmpty())
-  {
-    return false;
-  }
+    // object does not have a remainder field so it should be fully consumed
+    // The header length disagrees with object encoding so abort
+    if (copy.IsNotEmpty())
+    {
+        return false;
+    }
 
-  return true;
+    return true;
 }
 
 bool Group120Var13::Write(openpal::WSlice& buffer) const
 {
-  if(this->Size() > buffer.Size())
-  {
-    return false;
-  }
+    if (this->Size() > buffer.Size())
+    {
+        return false;
+    }
 
-  // All of the fields that have a uint16_t length must have the proper size
-  if(!PrefixFields::LengthFitsInUInt16(encryptedUpdateKey))
-  {
-    return false;
-  }
+    // All of the fields that have a uint16_t length must have the proper size
+    if (!PrefixFields::LengthFitsInUInt16(encryptedUpdateKey))
+    {
+        return false;
+    }
 
-  UInt32::WriteBuffer(buffer, this->keyChangeSeqNum);
-  UInt16::WriteBuffer(buffer, this->userNum);
+    UInt32::WriteBuffer(buffer, this->keyChangeSeqNum);
+    UInt16::WriteBuffer(buffer, this->userNum);
 
-  if(!PrefixFields::Write(buffer, encryptedUpdateKey))
-  {
-    return false;
-  }
+    if (!PrefixFields::Write(buffer, encryptedUpdateKey))
+    {
+        return false;
+    }
 
-  return true;
+    return true;
 }
 
 // ------- Group120Var14 -------
 
-Group120Var14::Group120Var14()
-{}
+Group120Var14::Group120Var14() {}
 
-Group120Var14::Group120Var14(
-  const openpal::RSlice& digitalSignature_
-) : 
-  digitalSignature(digitalSignature_)
-{}
+Group120Var14::Group120Var14(const openpal::RSlice& digitalSignature_) : digitalSignature(digitalSignature_) {}
 
 uint32_t Group120Var14::Size() const
 {
-  return MIN_SIZE + digitalSignature.Size();
+    return MIN_SIZE + digitalSignature.Size();
 }
 
 bool Group120Var14::Read(const RSlice& buffer)
 {
-  this->digitalSignature = buffer; // the object is just the remainder field
-  return true;
+    this->digitalSignature = buffer; // the object is just the remainder field
+    return true;
 }
 
 bool Group120Var14::Write(openpal::WSlice& buffer) const
 {
-  if(this->Size() > buffer.Size())
-  {
-    return false;
-  }
+    if (this->Size() > buffer.Size())
+    {
+        return false;
+    }
 
-  digitalSignature.CopyTo(buffer);
-  return true;
+    digitalSignature.CopyTo(buffer);
+    return true;
 }
 
 // ------- Group120Var15 -------
 
-Group120Var15::Group120Var15()
-{}
+Group120Var15::Group120Var15() {}
 
-Group120Var15::Group120Var15(
-  const openpal::RSlice& hmacValue_
-) : 
-  hmacValue(hmacValue_)
-{}
+Group120Var15::Group120Var15(const openpal::RSlice& hmacValue_) : hmacValue(hmacValue_) {}
 
 uint32_t Group120Var15::Size() const
 {
-  return MIN_SIZE + hmacValue.Size();
+    return MIN_SIZE + hmacValue.Size();
 }
 
 bool Group120Var15::Read(const RSlice& buffer)
 {
-  this->hmacValue = buffer; // the object is just the remainder field
-  return true;
+    this->hmacValue = buffer; // the object is just the remainder field
+    return true;
 }
 
 bool Group120Var15::Write(openpal::WSlice& buffer) const
 {
-  if(this->Size() > buffer.Size())
-  {
-    return false;
-  }
+    if (this->Size() > buffer.Size())
+    {
+        return false;
+    }
 
-  hmacValue.CopyTo(buffer);
-  return true;
+    hmacValue.CopyTo(buffer);
+    return true;
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group120.h
+++ b/cpp/libs/src/opendnp3/objects/Group120.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,419 +32,474 @@
 #ifndef OPENDNP3_GROUP120_H
 #define OPENDNP3_GROUP120_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
+
 #include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/IVariableLength.h"
-#include "opendnp3/gen/HMACType.h"
-#include "opendnp3/gen/ChallengeReason.h"
-#include "opendnp3/gen/KeyWrapAlgorithm.h"
-#include "opendnp3/gen/KeyStatus.h"
 #include "opendnp3/gen/AuthErrorCode.h"
-#include "opendnp3/gen/KeyChangeMethod.h"
 #include "opendnp3/gen/CertificateType.h"
+#include "opendnp3/gen/ChallengeReason.h"
+#include "opendnp3/gen/HMACType.h"
+#include "opendnp3/gen/KeyChangeMethod.h"
+#include "opendnp3/gen/KeyStatus.h"
+#include "opendnp3/gen/KeyWrapAlgorithm.h"
 #include "opendnp3/gen/UserOperation.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Authentication - Challenge
 struct Group120Var1 : public IVariableLength
 {
-  static GroupVariationID ID() { return GroupVariationID(120,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 1);
+    }
 
-  virtual GroupVariationID InstanceID() const override final { return ID(); }
+    virtual GroupVariationID InstanceID() const override final
+    {
+        return ID();
+    }
 
-  Group120Var1();
+    Group120Var1();
 
-  Group120Var1(
-    uint32_t challengeSeqNum,
-    uint16_t userNum,
-    HMACType hmacAlgo,
-    ChallengeReason challengeReason,
-    const openpal::RSlice& challengeData
-  );
+    Group120Var1(uint32_t challengeSeqNum,
+                 uint16_t userNum,
+                 HMACType hmacAlgo,
+                 ChallengeReason challengeReason,
+                 const openpal::RSlice& challengeData);
 
-  virtual uint32_t Size() const override final;
-  virtual bool Read(const openpal::RSlice&) override final;
-  virtual bool Write(openpal::WSlice&) const override final;
+    virtual uint32_t Size() const override final;
+    virtual bool Read(const openpal::RSlice&) override final;
+    virtual bool Write(openpal::WSlice&) const override final;
 
-  static const uint32_t MIN_SIZE = 8;
+    static const uint32_t MIN_SIZE = 8;
 
-  // member variables
-  uint32_t challengeSeqNum;
-  uint16_t userNum;
-  HMACType hmacAlgo;
-  ChallengeReason challengeReason;
-  openpal::RSlice challengeData;
+    // member variables
+    uint32_t challengeSeqNum;
+    uint16_t userNum;
+    HMACType hmacAlgo;
+    ChallengeReason challengeReason;
+    openpal::RSlice challengeData;
 };
 
 // Authentication - Reply
 struct Group120Var2 : public IVariableLength
 {
-  static GroupVariationID ID() { return GroupVariationID(120,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 2);
+    }
 
-  virtual GroupVariationID InstanceID() const override final { return ID(); }
+    virtual GroupVariationID InstanceID() const override final
+    {
+        return ID();
+    }
 
-  Group120Var2();
+    Group120Var2();
 
-  Group120Var2(
-    uint32_t challengeSeqNum,
-    uint16_t userNum,
-    const openpal::RSlice& hmacValue
-  );
+    Group120Var2(uint32_t challengeSeqNum, uint16_t userNum, const openpal::RSlice& hmacValue);
 
-  virtual uint32_t Size() const override final;
-  virtual bool Read(const openpal::RSlice&) override final;
-  virtual bool Write(openpal::WSlice&) const override final;
+    virtual uint32_t Size() const override final;
+    virtual bool Read(const openpal::RSlice&) override final;
+    virtual bool Write(openpal::WSlice&) const override final;
 
-  static const uint32_t MIN_SIZE = 6;
+    static const uint32_t MIN_SIZE = 6;
 
-  // member variables
-  uint32_t challengeSeqNum;
-  uint16_t userNum;
-  openpal::RSlice hmacValue;
+    // member variables
+    uint32_t challengeSeqNum;
+    uint16_t userNum;
+    openpal::RSlice hmacValue;
 };
 
 // Authentication - Aggressive Mode Request
 struct Group120Var3
 {
-  static GroupVariationID ID() { return GroupVariationID(120,3); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 3);
+    }
 
-  Group120Var3();
+    Group120Var3();
 
-  static uint32_t Size() { return 6; }
-  static bool Read(openpal::RSlice&, Group120Var3&);
-  static bool Write(const Group120Var3&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 6;
+    }
+    static bool Read(openpal::RSlice&, Group120Var3&);
+    static bool Write(const Group120Var3&, openpal::WSlice&);
 
-  uint32_t challengeSeqNum;
-  uint16_t userNum;
+    uint32_t challengeSeqNum;
+    uint16_t userNum;
 };
 
 // Authentication - Session Key Status Request
 struct Group120Var4
 {
-  static GroupVariationID ID() { return GroupVariationID(120,4); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 4);
+    }
 
-  Group120Var4();
+    Group120Var4();
 
-  static uint32_t Size() { return 2; }
-  static bool Read(openpal::RSlice&, Group120Var4&);
-  static bool Write(const Group120Var4&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 2;
+    }
+    static bool Read(openpal::RSlice&, Group120Var4&);
+    static bool Write(const Group120Var4&, openpal::WSlice&);
 
-  uint16_t userNum;
+    uint16_t userNum;
 };
 
 // Authentication - Session Key Status
 struct Group120Var5 : public IVariableLength
 {
-  static GroupVariationID ID() { return GroupVariationID(120,5); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 5);
+    }
 
-  virtual GroupVariationID InstanceID() const override final { return ID(); }
+    virtual GroupVariationID InstanceID() const override final
+    {
+        return ID();
+    }
 
-  Group120Var5();
+    Group120Var5();
 
-  Group120Var5(
-    uint32_t keyChangeSeqNum,
-    uint16_t userNum,
-    KeyWrapAlgorithm keyWrapAlgo,
-    KeyStatus keyStatus,
-    HMACType hmacAlgo,
-    const openpal::RSlice& challengeData,
-    const openpal::RSlice& hmacValue
-  );
+    Group120Var5(uint32_t keyChangeSeqNum,
+                 uint16_t userNum,
+                 KeyWrapAlgorithm keyWrapAlgo,
+                 KeyStatus keyStatus,
+                 HMACType hmacAlgo,
+                 const openpal::RSlice& challengeData,
+                 const openpal::RSlice& hmacValue);
 
-  virtual uint32_t Size() const override final;
-  virtual bool Read(const openpal::RSlice&) override final;
-  virtual bool Write(openpal::WSlice&) const override final;
+    virtual uint32_t Size() const override final;
+    virtual bool Read(const openpal::RSlice&) override final;
+    virtual bool Write(openpal::WSlice&) const override final;
 
-  static const uint32_t MIN_SIZE = 11;
+    static const uint32_t MIN_SIZE = 11;
 
-  // member variables
-  uint32_t keyChangeSeqNum;
-  uint16_t userNum;
-  KeyWrapAlgorithm keyWrapAlgo;
-  KeyStatus keyStatus;
-  HMACType hmacAlgo;
-  openpal::RSlice challengeData;
-  openpal::RSlice hmacValue;
+    // member variables
+    uint32_t keyChangeSeqNum;
+    uint16_t userNum;
+    KeyWrapAlgorithm keyWrapAlgo;
+    KeyStatus keyStatus;
+    HMACType hmacAlgo;
+    openpal::RSlice challengeData;
+    openpal::RSlice hmacValue;
 };
 
 // Authentication - Session Key Change
 struct Group120Var6 : public IVariableLength
 {
-  static GroupVariationID ID() { return GroupVariationID(120,6); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 6);
+    }
 
-  virtual GroupVariationID InstanceID() const override final { return ID(); }
+    virtual GroupVariationID InstanceID() const override final
+    {
+        return ID();
+    }
 
-  Group120Var6();
+    Group120Var6();
 
-  Group120Var6(
-    uint32_t keyChangeSeqNum,
-    uint16_t userNum,
-    const openpal::RSlice& keyWrapData
-  );
+    Group120Var6(uint32_t keyChangeSeqNum, uint16_t userNum, const openpal::RSlice& keyWrapData);
 
-  virtual uint32_t Size() const override final;
-  virtual bool Read(const openpal::RSlice&) override final;
-  virtual bool Write(openpal::WSlice&) const override final;
+    virtual uint32_t Size() const override final;
+    virtual bool Read(const openpal::RSlice&) override final;
+    virtual bool Write(openpal::WSlice&) const override final;
 
-  static const uint32_t MIN_SIZE = 6;
+    static const uint32_t MIN_SIZE = 6;
 
-  // member variables
-  uint32_t keyChangeSeqNum;
-  uint16_t userNum;
-  openpal::RSlice keyWrapData;
+    // member variables
+    uint32_t keyChangeSeqNum;
+    uint16_t userNum;
+    openpal::RSlice keyWrapData;
 };
 
 // Authentication - Error
 struct Group120Var7 : public IVariableLength
 {
-  static GroupVariationID ID() { return GroupVariationID(120,7); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 7);
+    }
 
-  virtual GroupVariationID InstanceID() const override final { return ID(); }
+    virtual GroupVariationID InstanceID() const override final
+    {
+        return ID();
+    }
 
-  Group120Var7();
+    Group120Var7();
 
-  Group120Var7(
-    uint32_t challengeSeqNum,
-    uint16_t userNum,
-    uint16_t assocId,
-    AuthErrorCode errorCode,
-    DNPTime time,
-    const openpal::RSlice& errorText
-  );
+    Group120Var7(uint32_t challengeSeqNum,
+                 uint16_t userNum,
+                 uint16_t assocId,
+                 AuthErrorCode errorCode,
+                 DNPTime time,
+                 const openpal::RSlice& errorText);
 
-  virtual uint32_t Size() const override final;
-  virtual bool Read(const openpal::RSlice&) override final;
-  virtual bool Write(openpal::WSlice&) const override final;
+    virtual uint32_t Size() const override final;
+    virtual bool Read(const openpal::RSlice&) override final;
+    virtual bool Write(openpal::WSlice&) const override final;
 
-  static const uint32_t MIN_SIZE = 15;
+    static const uint32_t MIN_SIZE = 15;
 
-  // member variables
-  uint32_t challengeSeqNum;
-  uint16_t userNum;
-  uint16_t assocId;
-  AuthErrorCode errorCode;
-  DNPTime time;
-  openpal::RSlice errorText;
+    // member variables
+    uint32_t challengeSeqNum;
+    uint16_t userNum;
+    uint16_t assocId;
+    AuthErrorCode errorCode;
+    DNPTime time;
+    openpal::RSlice errorText;
 };
 
 // Authentication - User Certificate
 struct Group120Var8 : public IVariableLength
 {
-  static GroupVariationID ID() { return GroupVariationID(120,8); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 8);
+    }
 
-  virtual GroupVariationID InstanceID() const override final { return ID(); }
+    virtual GroupVariationID InstanceID() const override final
+    {
+        return ID();
+    }
 
-  Group120Var8();
+    Group120Var8();
 
-  Group120Var8(
-    KeyChangeMethod keyChangeMethod,
-    CertificateType certificateType,
-    const openpal::RSlice& certificate
-  );
+    Group120Var8(KeyChangeMethod keyChangeMethod, CertificateType certificateType, const openpal::RSlice& certificate);
 
-  virtual uint32_t Size() const override final;
-  virtual bool Read(const openpal::RSlice&) override final;
-  virtual bool Write(openpal::WSlice&) const override final;
+    virtual uint32_t Size() const override final;
+    virtual bool Read(const openpal::RSlice&) override final;
+    virtual bool Write(openpal::WSlice&) const override final;
 
-  static const uint32_t MIN_SIZE = 2;
+    static const uint32_t MIN_SIZE = 2;
 
-  // member variables
-  KeyChangeMethod keyChangeMethod;
-  CertificateType certificateType;
-  openpal::RSlice certificate;
+    // member variables
+    KeyChangeMethod keyChangeMethod;
+    CertificateType certificateType;
+    openpal::RSlice certificate;
 };
 
 // Authentication - HMAC
 struct Group120Var9 : public IVariableLength
 {
-  static GroupVariationID ID() { return GroupVariationID(120,9); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 9);
+    }
 
-  virtual GroupVariationID InstanceID() const override final { return ID(); }
+    virtual GroupVariationID InstanceID() const override final
+    {
+        return ID();
+    }
 
-  Group120Var9();
+    Group120Var9();
 
-  explicit Group120Var9(
-    const openpal::RSlice& hmacValue
-  );
+    explicit Group120Var9(const openpal::RSlice& hmacValue);
 
-  virtual uint32_t Size() const override final;
-  virtual bool Read(const openpal::RSlice&) override final;
-  virtual bool Write(openpal::WSlice&) const override final;
+    virtual uint32_t Size() const override final;
+    virtual bool Read(const openpal::RSlice&) override final;
+    virtual bool Write(openpal::WSlice&) const override final;
 
-  static const uint32_t MIN_SIZE = 0;
+    static const uint32_t MIN_SIZE = 0;
 
-  // member variables
-  openpal::RSlice hmacValue;
+    // member variables
+    openpal::RSlice hmacValue;
 };
 
 // Authentication - User Status Change
 struct Group120Var10 : public IVariableLength
 {
-  static GroupVariationID ID() { return GroupVariationID(120,10); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 10);
+    }
 
-  virtual GroupVariationID InstanceID() const override final { return ID(); }
+    virtual GroupVariationID InstanceID() const override final
+    {
+        return ID();
+    }
 
-  Group120Var10();
+    Group120Var10();
 
-  Group120Var10(
-    KeyChangeMethod keyChangeMethod,
-    UserOperation userOperation,
-    uint32_t statusChangeSeqNum,
-    uint16_t userRole,
-    uint16_t userRoleExpDays,
-    const openpal::RSlice& userName,
-    const openpal::RSlice& userPublicKey,
-    const openpal::RSlice& certificationData
-  );
+    Group120Var10(KeyChangeMethod keyChangeMethod,
+                  UserOperation userOperation,
+                  uint32_t statusChangeSeqNum,
+                  uint16_t userRole,
+                  uint16_t userRoleExpDays,
+                  const openpal::RSlice& userName,
+                  const openpal::RSlice& userPublicKey,
+                  const openpal::RSlice& certificationData);
 
-  virtual uint32_t Size() const override final;
-  virtual bool Read(const openpal::RSlice&) override final;
-  virtual bool Write(openpal::WSlice&) const override final;
+    virtual uint32_t Size() const override final;
+    virtual bool Read(const openpal::RSlice&) override final;
+    virtual bool Write(openpal::WSlice&) const override final;
 
-  static const uint32_t MIN_SIZE = 16;
+    static const uint32_t MIN_SIZE = 16;
 
-  // member variables
-  KeyChangeMethod keyChangeMethod;
-  UserOperation userOperation;
-  uint32_t statusChangeSeqNum;
-  uint16_t userRole;
-  uint16_t userRoleExpDays;
-  openpal::RSlice userName;
-  openpal::RSlice userPublicKey;
-  openpal::RSlice certificationData;
+    // member variables
+    KeyChangeMethod keyChangeMethod;
+    UserOperation userOperation;
+    uint32_t statusChangeSeqNum;
+    uint16_t userRole;
+    uint16_t userRoleExpDays;
+    openpal::RSlice userName;
+    openpal::RSlice userPublicKey;
+    openpal::RSlice certificationData;
 };
 
 // Authentication - Update Key Change Request
 struct Group120Var11 : public IVariableLength
 {
-  static GroupVariationID ID() { return GroupVariationID(120,11); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 11);
+    }
 
-  virtual GroupVariationID InstanceID() const override final { return ID(); }
+    virtual GroupVariationID InstanceID() const override final
+    {
+        return ID();
+    }
 
-  Group120Var11();
+    Group120Var11();
 
-  Group120Var11(
-    KeyChangeMethod keyChangeMethod,
-    const openpal::RSlice& userName,
-    const openpal::RSlice& challengeData
-  );
+    Group120Var11(KeyChangeMethod keyChangeMethod,
+                  const openpal::RSlice& userName,
+                  const openpal::RSlice& challengeData);
 
-  virtual uint32_t Size() const override final;
-  virtual bool Read(const openpal::RSlice&) override final;
-  virtual bool Write(openpal::WSlice&) const override final;
+    virtual uint32_t Size() const override final;
+    virtual bool Read(const openpal::RSlice&) override final;
+    virtual bool Write(openpal::WSlice&) const override final;
 
-  static const uint32_t MIN_SIZE = 5;
+    static const uint32_t MIN_SIZE = 5;
 
-  // member variables
-  KeyChangeMethod keyChangeMethod;
-  openpal::RSlice userName;
-  openpal::RSlice challengeData;
+    // member variables
+    KeyChangeMethod keyChangeMethod;
+    openpal::RSlice userName;
+    openpal::RSlice challengeData;
 };
 
 // Authentication - Update Key Change Reply
 struct Group120Var12 : public IVariableLength
 {
-  static GroupVariationID ID() { return GroupVariationID(120,12); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 12);
+    }
 
-  virtual GroupVariationID InstanceID() const override final { return ID(); }
+    virtual GroupVariationID InstanceID() const override final
+    {
+        return ID();
+    }
 
-  Group120Var12();
+    Group120Var12();
 
-  Group120Var12(
-    uint32_t keyChangeSeqNum,
-    uint16_t userNum,
-    const openpal::RSlice& challengeData
-  );
+    Group120Var12(uint32_t keyChangeSeqNum, uint16_t userNum, const openpal::RSlice& challengeData);
 
-  virtual uint32_t Size() const override final;
-  virtual bool Read(const openpal::RSlice&) override final;
-  virtual bool Write(openpal::WSlice&) const override final;
+    virtual uint32_t Size() const override final;
+    virtual bool Read(const openpal::RSlice&) override final;
+    virtual bool Write(openpal::WSlice&) const override final;
 
-  static const uint32_t MIN_SIZE = 8;
+    static const uint32_t MIN_SIZE = 8;
 
-  // member variables
-  uint32_t keyChangeSeqNum;
-  uint16_t userNum;
-  openpal::RSlice challengeData;
+    // member variables
+    uint32_t keyChangeSeqNum;
+    uint16_t userNum;
+    openpal::RSlice challengeData;
 };
 
 // Authentication - Update Key Change
 struct Group120Var13 : public IVariableLength
 {
-  static GroupVariationID ID() { return GroupVariationID(120,13); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 13);
+    }
 
-  virtual GroupVariationID InstanceID() const override final { return ID(); }
+    virtual GroupVariationID InstanceID() const override final
+    {
+        return ID();
+    }
 
-  Group120Var13();
+    Group120Var13();
 
-  Group120Var13(
-    uint32_t keyChangeSeqNum,
-    uint16_t userNum,
-    const openpal::RSlice& encryptedUpdateKey
-  );
+    Group120Var13(uint32_t keyChangeSeqNum, uint16_t userNum, const openpal::RSlice& encryptedUpdateKey);
 
-  virtual uint32_t Size() const override final;
-  virtual bool Read(const openpal::RSlice&) override final;
-  virtual bool Write(openpal::WSlice&) const override final;
+    virtual uint32_t Size() const override final;
+    virtual bool Read(const openpal::RSlice&) override final;
+    virtual bool Write(openpal::WSlice&) const override final;
 
-  static const uint32_t MIN_SIZE = 8;
+    static const uint32_t MIN_SIZE = 8;
 
-  // member variables
-  uint32_t keyChangeSeqNum;
-  uint16_t userNum;
-  openpal::RSlice encryptedUpdateKey;
+    // member variables
+    uint32_t keyChangeSeqNum;
+    uint16_t userNum;
+    openpal::RSlice encryptedUpdateKey;
 };
 
 // Authentication - Update Key Change Signature
 struct Group120Var14 : public IVariableLength
 {
-  static GroupVariationID ID() { return GroupVariationID(120,14); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 14);
+    }
 
-  virtual GroupVariationID InstanceID() const override final { return ID(); }
+    virtual GroupVariationID InstanceID() const override final
+    {
+        return ID();
+    }
 
-  Group120Var14();
+    Group120Var14();
 
-  explicit Group120Var14(
-    const openpal::RSlice& digitalSignature
-  );
+    explicit Group120Var14(const openpal::RSlice& digitalSignature);
 
-  virtual uint32_t Size() const override final;
-  virtual bool Read(const openpal::RSlice&) override final;
-  virtual bool Write(openpal::WSlice&) const override final;
+    virtual uint32_t Size() const override final;
+    virtual bool Read(const openpal::RSlice&) override final;
+    virtual bool Write(openpal::WSlice&) const override final;
 
-  static const uint32_t MIN_SIZE = 0;
+    static const uint32_t MIN_SIZE = 0;
 
-  // member variables
-  openpal::RSlice digitalSignature;
+    // member variables
+    openpal::RSlice digitalSignature;
 };
 
 // Authentication - Update Key Change Confirmation
 struct Group120Var15 : public IVariableLength
 {
-  static GroupVariationID ID() { return GroupVariationID(120,15); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(120, 15);
+    }
 
-  virtual GroupVariationID InstanceID() const override final { return ID(); }
+    virtual GroupVariationID InstanceID() const override final
+    {
+        return ID();
+    }
 
-  Group120Var15();
+    Group120Var15();
 
-  explicit Group120Var15(
-    const openpal::RSlice& hmacValue
-  );
+    explicit Group120Var15(const openpal::RSlice& hmacValue);
 
-  virtual uint32_t Size() const override final;
-  virtual bool Read(const openpal::RSlice&) override final;
-  virtual bool Write(openpal::WSlice&) const override final;
+    virtual uint32_t Size() const override final;
+    virtual bool Read(const openpal::RSlice&) override final;
+    virtual bool Write(openpal::WSlice&) const override final;
 
-  static const uint32_t MIN_SIZE = 0;
+    static const uint32_t MIN_SIZE = 0;
 
-  // member variables
-  openpal::RSlice hmacValue;
+    // member variables
+    openpal::RSlice hmacValue;
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group121.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group121.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,46 +33,46 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group121Var1 -------
 
-Group121Var1::Group121Var1() : flags(0), assocId(0), value(0)
-{}
+Group121Var1::Group121Var1() : flags(0), assocId(0), value(0) {}
 
 bool Group121Var1::Read(RSlice& buffer, Group121Var1& output)
 {
-  return Parse::Many(buffer, output.flags, output.assocId, output.value);
+    return Parse::Many(buffer, output.flags, output.assocId, output.value);
 }
 
 bool Group121Var1::Write(const Group121Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.assocId, arg.value);
+    return Format::Many(buffer, arg.flags, arg.assocId, arg.value);
 }
 
 bool Group121Var1::ReadTarget(RSlice& buff, SecurityStat& output)
 {
-  Group121Var1 value;
-  if(Read(buff, value))
-  {
-    output = SecurityStatFactory::From(value.flags, value.assocId, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group121Var1 value;
+    if (Read(buff, value))
+    {
+        output = SecurityStatFactory::From(value.flags, value.assocId, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group121Var1::WriteTarget(const SecurityStat& value, openpal::WSlice& buff)
 {
-  return Group121Var1::Write(ConvertGroup121Var1::Apply(value), buff);
+    return Group121Var1::Write(ConvertGroup121Var1::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group121.h
+++ b/cpp/libs/src/opendnp3/objects/Group121.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,45 +32,58 @@
 #ifndef OPENDNP3_GROUP121_H
 #define OPENDNP3_GROUP121_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Security statistic - Any Variation
 struct Group121Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(121,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(121, 0);
+    }
 };
 
 // Security statistic - 32-bit With Flag
 struct Group121Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(121,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(121, 1);
+    }
 
-  Group121Var1();
+    Group121Var1();
 
-  static uint32_t Size() { return 7; }
-  static bool Read(openpal::RSlice&, Group121Var1&);
-  static bool Write(const Group121Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 7;
+    }
+    static bool Read(openpal::RSlice&, Group121Var1&);
+    static bool Write(const Group121Var1&, openpal::WSlice&);
 
-  typedef uint32_t ValueType;
-  uint8_t flags;
-  uint16_t assocId;
-  uint32_t value;
+    typedef uint32_t ValueType;
+    uint8_t flags;
+    uint16_t assocId;
+    uint32_t value;
 
-  typedef SecurityStat Target;
-  typedef SecurityStatSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, SecurityStat&);
-  static bool WriteTarget(const SecurityStat&, openpal::WSlice&);
-  static DNP3Serializer<SecurityStat> Inst() { return DNP3Serializer<SecurityStat>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef SecurityStat Target;
+    typedef SecurityStatSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, SecurityStat&);
+    static bool WriteTarget(const SecurityStat&, openpal::WSlice&);
+    static DNP3Serializer<SecurityStat> Inst()
+    {
+        return DNP3Serializer<SecurityStat>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group122.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group122.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,80 +33,79 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group122Var1 -------
 
-Group122Var1::Group122Var1() : flags(0), assocId(0), value(0)
-{}
+Group122Var1::Group122Var1() : flags(0), assocId(0), value(0) {}
 
 bool Group122Var1::Read(RSlice& buffer, Group122Var1& output)
 {
-  return Parse::Many(buffer, output.flags, output.assocId, output.value);
+    return Parse::Many(buffer, output.flags, output.assocId, output.value);
 }
 
 bool Group122Var1::Write(const Group122Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.assocId, arg.value);
+    return Format::Many(buffer, arg.flags, arg.assocId, arg.value);
 }
 
 bool Group122Var1::ReadTarget(RSlice& buff, SecurityStat& output)
 {
-  Group122Var1 value;
-  if(Read(buff, value))
-  {
-    output = SecurityStatFactory::From(value.flags, value.assocId, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group122Var1 value;
+    if (Read(buff, value))
+    {
+        output = SecurityStatFactory::From(value.flags, value.assocId, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group122Var1::WriteTarget(const SecurityStat& value, openpal::WSlice& buff)
 {
-  return Group122Var1::Write(ConvertGroup122Var1::Apply(value), buff);
+    return Group122Var1::Write(ConvertGroup122Var1::Apply(value), buff);
 }
 
 // ------- Group122Var2 -------
 
-Group122Var2::Group122Var2() : flags(0), assocId(0), value(0), time(0)
-{}
+Group122Var2::Group122Var2() : flags(0), assocId(0), value(0), time(0) {}
 
 bool Group122Var2::Read(RSlice& buffer, Group122Var2& output)
 {
-  return Parse::Many(buffer, output.flags, output.assocId, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.assocId, output.value, output.time);
 }
 
 bool Group122Var2::Write(const Group122Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.assocId, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.assocId, arg.value, arg.time);
 }
 
 bool Group122Var2::ReadTarget(RSlice& buff, SecurityStat& output)
 {
-  Group122Var2 value;
-  if(Read(buff, value))
-  {
-    output = SecurityStatFactory::From(value.flags, value.assocId, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group122Var2 value;
+    if (Read(buff, value))
+    {
+        output = SecurityStatFactory::From(value.flags, value.assocId, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group122Var2::WriteTarget(const SecurityStat& value, openpal::WSlice& buff)
 {
-  return Group122Var2::Write(ConvertGroup122Var2::Apply(value), buff);
+    return Group122Var2::Write(ConvertGroup122Var2::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group122.h
+++ b/cpp/libs/src/opendnp3/objects/Group122.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,69 +32,91 @@
 #ifndef OPENDNP3_GROUP122_H
 #define OPENDNP3_GROUP122_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Security Statistic event - Any Variation
 struct Group122Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(122,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(122, 0);
+    }
 };
 
 // Security Statistic event - 32-bit With Flag
 struct Group122Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(122,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(122, 1);
+    }
 
-  Group122Var1();
+    Group122Var1();
 
-  static uint32_t Size() { return 7; }
-  static bool Read(openpal::RSlice&, Group122Var1&);
-  static bool Write(const Group122Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 7;
+    }
+    static bool Read(openpal::RSlice&, Group122Var1&);
+    static bool Write(const Group122Var1&, openpal::WSlice&);
 
-  typedef uint32_t ValueType;
-  uint8_t flags;
-  uint16_t assocId;
-  uint32_t value;
+    typedef uint32_t ValueType;
+    uint8_t flags;
+    uint16_t assocId;
+    uint32_t value;
 
-  typedef SecurityStat Target;
-  typedef SecurityStatSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, SecurityStat&);
-  static bool WriteTarget(const SecurityStat&, openpal::WSlice&);
-  static DNP3Serializer<SecurityStat> Inst() { return DNP3Serializer<SecurityStat>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef SecurityStat Target;
+    typedef SecurityStatSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, SecurityStat&);
+    static bool WriteTarget(const SecurityStat&, openpal::WSlice&);
+    static DNP3Serializer<SecurityStat> Inst()
+    {
+        return DNP3Serializer<SecurityStat>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Security Statistic event - 32-bit With Flag and Time
 struct Group122Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(122,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(122, 2);
+    }
 
-  Group122Var2();
+    Group122Var2();
 
-  static uint32_t Size() { return 13; }
-  static bool Read(openpal::RSlice&, Group122Var2&);
-  static bool Write(const Group122Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 13;
+    }
+    static bool Read(openpal::RSlice&, Group122Var2&);
+    static bool Write(const Group122Var2&, openpal::WSlice&);
 
-  typedef uint32_t ValueType;
-  uint8_t flags;
-  uint16_t assocId;
-  uint32_t value;
-  DNPTime time;
+    typedef uint32_t ValueType;
+    uint8_t flags;
+    uint16_t assocId;
+    uint32_t value;
+    DNPTime time;
 
-  typedef SecurityStat Target;
-  typedef SecurityStatSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, SecurityStat&);
-  static bool WriteTarget(const SecurityStat&, openpal::WSlice&);
-  static DNP3Serializer<SecurityStat> Inst() { return DNP3Serializer<SecurityStat>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef SecurityStat Target;
+    typedef SecurityStatSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, SecurityStat&);
+    static bool WriteTarget(const SecurityStat&, openpal::WSlice&);
+    static DNP3Serializer<SecurityStat> Inst()
+    {
+        return DNP3Serializer<SecurityStat>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group13.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group13.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,80 +33,79 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group13Var1 -------
 
-Group13Var1::Group13Var1() : flags(0)
-{}
+Group13Var1::Group13Var1() : flags(0) {}
 
 bool Group13Var1::Read(RSlice& buffer, Group13Var1& output)
 {
-  return Parse::Many(buffer, output.flags);
+    return Parse::Many(buffer, output.flags);
 }
 
 bool Group13Var1::Write(const Group13Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags);
+    return Format::Many(buffer, arg.flags);
 }
 
 bool Group13Var1::ReadTarget(RSlice& buff, BinaryCommandEvent& output)
 {
-  Group13Var1 value;
-  if(Read(buff, value))
-  {
-    output = BinaryCommandEventFactory::From(value.flags);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group13Var1 value;
+    if (Read(buff, value))
+    {
+        output = BinaryCommandEventFactory::From(value.flags);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group13Var1::WriteTarget(const BinaryCommandEvent& value, openpal::WSlice& buff)
 {
-  return Group13Var1::Write(ConvertGroup13Var1::Apply(value), buff);
+    return Group13Var1::Write(ConvertGroup13Var1::Apply(value), buff);
 }
 
 // ------- Group13Var2 -------
 
-Group13Var2::Group13Var2() : flags(0), time(0)
-{}
+Group13Var2::Group13Var2() : flags(0), time(0) {}
 
 bool Group13Var2::Read(RSlice& buffer, Group13Var2& output)
 {
-  return Parse::Many(buffer, output.flags, output.time);
+    return Parse::Many(buffer, output.flags, output.time);
 }
 
 bool Group13Var2::Write(const Group13Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.time);
+    return Format::Many(buffer, arg.flags, arg.time);
 }
 
 bool Group13Var2::ReadTarget(RSlice& buff, BinaryCommandEvent& output)
 {
-  Group13Var2 value;
-  if(Read(buff, value))
-  {
-    output = BinaryCommandEventFactory::From(value.flags, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group13Var2 value;
+    if (Read(buff, value))
+    {
+        output = BinaryCommandEventFactory::From(value.flags, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group13Var2::WriteTarget(const BinaryCommandEvent& value, openpal::WSlice& buff)
 {
-  return Group13Var2::Write(ConvertGroup13Var2::Apply(value), buff);
+    return Group13Var2::Write(ConvertGroup13Var2::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group13.h
+++ b/cpp/libs/src/opendnp3/objects/Group13.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,55 +32,74 @@
 #ifndef OPENDNP3_GROUP13_H
 #define OPENDNP3_GROUP13_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
-#include "opendnp3/app/DNP3Serializer.h"
-#include "opendnp3/app/BinaryCommandEvent.h"
 
-namespace opendnp3 {
+#include "opendnp3/app/BinaryCommandEvent.h"
+#include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
+
+namespace opendnp3
+{
 
 // Binary Command Event - Without Time
 struct Group13Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(13,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(13, 1);
+    }
 
-  Group13Var1();
+    Group13Var1();
 
-  static uint32_t Size() { return 1; }
-  static bool Read(openpal::RSlice&, Group13Var1&);
-  static bool Write(const Group13Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 1;
+    }
+    static bool Read(openpal::RSlice&, Group13Var1&);
+    static bool Write(const Group13Var1&, openpal::WSlice&);
 
-  uint8_t flags;
+    uint8_t flags;
 
-  typedef BinaryCommandEvent Target;
-  static bool ReadTarget(openpal::RSlice&, BinaryCommandEvent&);
-  static bool WriteTarget(const BinaryCommandEvent&, openpal::WSlice&);
-  static DNP3Serializer<BinaryCommandEvent> Inst() { return DNP3Serializer<BinaryCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef BinaryCommandEvent Target;
+    static bool ReadTarget(openpal::RSlice&, BinaryCommandEvent&);
+    static bool WriteTarget(const BinaryCommandEvent&, openpal::WSlice&);
+    static DNP3Serializer<BinaryCommandEvent> Inst()
+    {
+        return DNP3Serializer<BinaryCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Binary Command Event - With Time
 struct Group13Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(13,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(13, 2);
+    }
 
-  Group13Var2();
+    Group13Var2();
 
-  static uint32_t Size() { return 7; }
-  static bool Read(openpal::RSlice&, Group13Var2&);
-  static bool Write(const Group13Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 7;
+    }
+    static bool Read(openpal::RSlice&, Group13Var2&);
+    static bool Write(const Group13Var2&, openpal::WSlice&);
 
-  uint8_t flags;
-  DNPTime time;
+    uint8_t flags;
+    DNPTime time;
 
-  typedef BinaryCommandEvent Target;
-  static bool ReadTarget(openpal::RSlice&, BinaryCommandEvent&);
-  static bool WriteTarget(const BinaryCommandEvent&, openpal::WSlice&);
-  static DNP3Serializer<BinaryCommandEvent> Inst() { return DNP3Serializer<BinaryCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef BinaryCommandEvent Target;
+    static bool ReadTarget(openpal::RSlice&, BinaryCommandEvent&);
+    static bool WriteTarget(const BinaryCommandEvent&, openpal::WSlice&);
+    static DNP3Serializer<BinaryCommandEvent> Inst()
+    {
+        return DNP3Serializer<BinaryCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group2.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group2.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,114 +33,112 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group2Var1 -------
 
-Group2Var1::Group2Var1() : flags(0)
-{}
+Group2Var1::Group2Var1() : flags(0) {}
 
 bool Group2Var1::Read(RSlice& buffer, Group2Var1& output)
 {
-  return Parse::Many(buffer, output.flags);
+    return Parse::Many(buffer, output.flags);
 }
 
 bool Group2Var1::Write(const Group2Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags);
+    return Format::Many(buffer, arg.flags);
 }
 
 bool Group2Var1::ReadTarget(RSlice& buff, Binary& output)
 {
-  Group2Var1 value;
-  if(Read(buff, value))
-  {
-    output = BinaryFactory::From(value.flags);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group2Var1 value;
+    if (Read(buff, value))
+    {
+        output = BinaryFactory::From(value.flags);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group2Var1::WriteTarget(const Binary& value, openpal::WSlice& buff)
 {
-  return Group2Var1::Write(ConvertGroup2Var1::Apply(value), buff);
+    return Group2Var1::Write(ConvertGroup2Var1::Apply(value), buff);
 }
 
 // ------- Group2Var2 -------
 
-Group2Var2::Group2Var2() : flags(0), time(0)
-{}
+Group2Var2::Group2Var2() : flags(0), time(0) {}
 
 bool Group2Var2::Read(RSlice& buffer, Group2Var2& output)
 {
-  return Parse::Many(buffer, output.flags, output.time);
+    return Parse::Many(buffer, output.flags, output.time);
 }
 
 bool Group2Var2::Write(const Group2Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.time);
+    return Format::Many(buffer, arg.flags, arg.time);
 }
 
 bool Group2Var2::ReadTarget(RSlice& buff, Binary& output)
 {
-  Group2Var2 value;
-  if(Read(buff, value))
-  {
-    output = BinaryFactory::From(value.flags, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group2Var2 value;
+    if (Read(buff, value))
+    {
+        output = BinaryFactory::From(value.flags, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group2Var2::WriteTarget(const Binary& value, openpal::WSlice& buff)
 {
-  return Group2Var2::Write(ConvertGroup2Var2::Apply(value), buff);
+    return Group2Var2::Write(ConvertGroup2Var2::Apply(value), buff);
 }
 
 // ------- Group2Var3 -------
 
-Group2Var3::Group2Var3() : flags(0), time(0)
-{}
+Group2Var3::Group2Var3() : flags(0), time(0) {}
 
 bool Group2Var3::Read(RSlice& buffer, Group2Var3& output)
 {
-  return Parse::Many(buffer, output.flags, output.time);
+    return Parse::Many(buffer, output.flags, output.time);
 }
 
 bool Group2Var3::Write(const Group2Var3& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.time);
+    return Format::Many(buffer, arg.flags, arg.time);
 }
 
 bool Group2Var3::ReadTarget(RSlice& buff, Binary& output)
 {
-  Group2Var3 value;
-  if(Read(buff, value))
-  {
-    output = BinaryFactory::From(value.flags, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group2Var3 value;
+    if (Read(buff, value))
+    {
+        output = BinaryFactory::From(value.flags, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group2Var3::WriteTarget(const Binary& value, openpal::WSlice& buff)
 {
-  return Group2Var3::Write(ConvertGroup2Var3::Apply(value), buff);
+    return Group2Var3::Write(ConvertGroup2Var3::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group2.h
+++ b/cpp/libs/src/opendnp3/objects/Group2.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,84 +32,115 @@
 #ifndef OPENDNP3_GROUP2_H
 #define OPENDNP3_GROUP2_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Binary Input Event - Any Variation
 struct Group2Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(2,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(2, 0);
+    }
 };
 
 // Binary Input Event - Without Time
 struct Group2Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(2,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(2, 1);
+    }
 
-  Group2Var1();
+    Group2Var1();
 
-  static uint32_t Size() { return 1; }
-  static bool Read(openpal::RSlice&, Group2Var1&);
-  static bool Write(const Group2Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 1;
+    }
+    static bool Read(openpal::RSlice&, Group2Var1&);
+    static bool Write(const Group2Var1&, openpal::WSlice&);
 
-  uint8_t flags;
+    uint8_t flags;
 
-  typedef Binary Target;
-  typedef BinarySpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Binary&);
-  static bool WriteTarget(const Binary&, openpal::WSlice&);
-  static DNP3Serializer<Binary> Inst() { return DNP3Serializer<Binary>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Binary Target;
+    typedef BinarySpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Binary&);
+    static bool WriteTarget(const Binary&, openpal::WSlice&);
+    static DNP3Serializer<Binary> Inst()
+    {
+        return DNP3Serializer<Binary>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Binary Input Event - With Absolute Time
 struct Group2Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(2,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(2, 2);
+    }
 
-  Group2Var2();
+    Group2Var2();
 
-  static uint32_t Size() { return 7; }
-  static bool Read(openpal::RSlice&, Group2Var2&);
-  static bool Write(const Group2Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 7;
+    }
+    static bool Read(openpal::RSlice&, Group2Var2&);
+    static bool Write(const Group2Var2&, openpal::WSlice&);
 
-  uint8_t flags;
-  DNPTime time;
+    uint8_t flags;
+    DNPTime time;
 
-  typedef Binary Target;
-  typedef BinarySpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Binary&);
-  static bool WriteTarget(const Binary&, openpal::WSlice&);
-  static DNP3Serializer<Binary> Inst() { return DNP3Serializer<Binary>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Binary Target;
+    typedef BinarySpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Binary&);
+    static bool WriteTarget(const Binary&, openpal::WSlice&);
+    static DNP3Serializer<Binary> Inst()
+    {
+        return DNP3Serializer<Binary>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Binary Input Event - With Relative Time
 struct Group2Var3
 {
-  static GroupVariationID ID() { return GroupVariationID(2,3); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(2, 3);
+    }
 
-  Group2Var3();
+    Group2Var3();
 
-  static uint32_t Size() { return 3; }
-  static bool Read(openpal::RSlice&, Group2Var3&);
-  static bool Write(const Group2Var3&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 3;
+    }
+    static bool Read(openpal::RSlice&, Group2Var3&);
+    static bool Write(const Group2Var3&, openpal::WSlice&);
 
-  uint8_t flags;
-  uint16_t time;
+    uint8_t flags;
+    uint16_t time;
 
-  typedef Binary Target;
-  typedef BinarySpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Binary&);
-  static bool WriteTarget(const Binary&, openpal::WSlice&);
-  static DNP3Serializer<Binary> Inst() { return DNP3Serializer<Binary>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Binary Target;
+    typedef BinarySpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Binary&);
+    static bool WriteTarget(const Binary&, openpal::WSlice&);
+    static DNP3Serializer<Binary> Inst()
+    {
+        return DNP3Serializer<Binary>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group20.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group20.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,148 +33,145 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group20Var1 -------
 
-Group20Var1::Group20Var1() : flags(0), value(0)
-{}
+Group20Var1::Group20Var1() : flags(0), value(0) {}
 
 bool Group20Var1::Read(RSlice& buffer, Group20Var1& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group20Var1::Write(const Group20Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group20Var1::ReadTarget(RSlice& buff, Counter& output)
 {
-  Group20Var1 value;
-  if(Read(buff, value))
-  {
-    output = CounterFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group20Var1 value;
+    if (Read(buff, value))
+    {
+        output = CounterFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group20Var1::WriteTarget(const Counter& value, openpal::WSlice& buff)
 {
-  return Group20Var1::Write(ConvertGroup20Var1::Apply(value), buff);
+    return Group20Var1::Write(ConvertGroup20Var1::Apply(value), buff);
 }
 
 // ------- Group20Var2 -------
 
-Group20Var2::Group20Var2() : flags(0), value(0)
-{}
+Group20Var2::Group20Var2() : flags(0), value(0) {}
 
 bool Group20Var2::Read(RSlice& buffer, Group20Var2& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group20Var2::Write(const Group20Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group20Var2::ReadTarget(RSlice& buff, Counter& output)
 {
-  Group20Var2 value;
-  if(Read(buff, value))
-  {
-    output = CounterFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group20Var2 value;
+    if (Read(buff, value))
+    {
+        output = CounterFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group20Var2::WriteTarget(const Counter& value, openpal::WSlice& buff)
 {
-  return Group20Var2::Write(ConvertGroup20Var2::Apply(value), buff);
+    return Group20Var2::Write(ConvertGroup20Var2::Apply(value), buff);
 }
 
 // ------- Group20Var5 -------
 
-Group20Var5::Group20Var5() : value(0)
-{}
+Group20Var5::Group20Var5() : value(0) {}
 
 bool Group20Var5::Read(RSlice& buffer, Group20Var5& output)
 {
-  return Parse::Many(buffer, output.value);
+    return Parse::Many(buffer, output.value);
 }
 
 bool Group20Var5::Write(const Group20Var5& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.value);
+    return Format::Many(buffer, arg.value);
 }
 
 bool Group20Var5::ReadTarget(RSlice& buff, Counter& output)
 {
-  Group20Var5 value;
-  if(Read(buff, value))
-  {
-    output = CounterFactory::From(value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group20Var5 value;
+    if (Read(buff, value))
+    {
+        output = CounterFactory::From(value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group20Var5::WriteTarget(const Counter& value, openpal::WSlice& buff)
 {
-  return Group20Var5::Write(ConvertGroup20Var5::Apply(value), buff);
+    return Group20Var5::Write(ConvertGroup20Var5::Apply(value), buff);
 }
 
 // ------- Group20Var6 -------
 
-Group20Var6::Group20Var6() : value(0)
-{}
+Group20Var6::Group20Var6() : value(0) {}
 
 bool Group20Var6::Read(RSlice& buffer, Group20Var6& output)
 {
-  return Parse::Many(buffer, output.value);
+    return Parse::Many(buffer, output.value);
 }
 
 bool Group20Var6::Write(const Group20Var6& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.value);
+    return Format::Many(buffer, arg.value);
 }
 
 bool Group20Var6::ReadTarget(RSlice& buff, Counter& output)
 {
-  Group20Var6 value;
-  if(Read(buff, value))
-  {
-    output = CounterFactory::From(value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group20Var6 value;
+    if (Read(buff, value))
+    {
+        output = CounterFactory::From(value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group20Var6::WriteTarget(const Counter& value, openpal::WSlice& buff)
 {
-  return Group20Var6::Write(ConvertGroup20Var6::Apply(value), buff);
+    return Group20Var6::Write(ConvertGroup20Var6::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group20.h
+++ b/cpp/libs/src/opendnp3/objects/Group20.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,108 +32,148 @@
 #ifndef OPENDNP3_GROUP20_H
 #define OPENDNP3_GROUP20_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Counter - Any Variation
 struct Group20Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(20,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(20, 0);
+    }
 };
 
 // Counter - 32-bit With Flag
 struct Group20Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(20,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(20, 1);
+    }
 
-  Group20Var1();
+    Group20Var1();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group20Var1&);
-  static bool Write(const Group20Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group20Var1&);
+    static bool Write(const Group20Var1&, openpal::WSlice&);
 
-  typedef uint32_t ValueType;
-  uint8_t flags;
-  uint32_t value;
+    typedef uint32_t ValueType;
+    uint8_t flags;
+    uint32_t value;
 
-  typedef Counter Target;
-  typedef CounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Counter&);
-  static bool WriteTarget(const Counter&, openpal::WSlice&);
-  static DNP3Serializer<Counter> Inst() { return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Counter Target;
+    typedef CounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Counter&);
+    static bool WriteTarget(const Counter&, openpal::WSlice&);
+    static DNP3Serializer<Counter> Inst()
+    {
+        return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Counter - 16-bit With Flag
 struct Group20Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(20,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(20, 2);
+    }
 
-  Group20Var2();
+    Group20Var2();
 
-  static uint32_t Size() { return 3; }
-  static bool Read(openpal::RSlice&, Group20Var2&);
-  static bool Write(const Group20Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 3;
+    }
+    static bool Read(openpal::RSlice&, Group20Var2&);
+    static bool Write(const Group20Var2&, openpal::WSlice&);
 
-  typedef uint16_t ValueType;
-  uint8_t flags;
-  uint16_t value;
+    typedef uint16_t ValueType;
+    uint8_t flags;
+    uint16_t value;
 
-  typedef Counter Target;
-  typedef CounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Counter&);
-  static bool WriteTarget(const Counter&, openpal::WSlice&);
-  static DNP3Serializer<Counter> Inst() { return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Counter Target;
+    typedef CounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Counter&);
+    static bool WriteTarget(const Counter&, openpal::WSlice&);
+    static DNP3Serializer<Counter> Inst()
+    {
+        return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Counter - 32-bit Without Flag
 struct Group20Var5
 {
-  static GroupVariationID ID() { return GroupVariationID(20,5); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(20, 5);
+    }
 
-  Group20Var5();
+    Group20Var5();
 
-  static uint32_t Size() { return 4; }
-  static bool Read(openpal::RSlice&, Group20Var5&);
-  static bool Write(const Group20Var5&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 4;
+    }
+    static bool Read(openpal::RSlice&, Group20Var5&);
+    static bool Write(const Group20Var5&, openpal::WSlice&);
 
-  typedef uint32_t ValueType;
-  uint32_t value;
+    typedef uint32_t ValueType;
+    uint32_t value;
 
-  typedef Counter Target;
-  typedef CounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Counter&);
-  static bool WriteTarget(const Counter&, openpal::WSlice&);
-  static DNP3Serializer<Counter> Inst() { return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Counter Target;
+    typedef CounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Counter&);
+    static bool WriteTarget(const Counter&, openpal::WSlice&);
+    static DNP3Serializer<Counter> Inst()
+    {
+        return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Counter - 16-bit Without Flag
 struct Group20Var6
 {
-  static GroupVariationID ID() { return GroupVariationID(20,6); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(20, 6);
+    }
 
-  Group20Var6();
+    Group20Var6();
 
-  static uint32_t Size() { return 2; }
-  static bool Read(openpal::RSlice&, Group20Var6&);
-  static bool Write(const Group20Var6&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 2;
+    }
+    static bool Read(openpal::RSlice&, Group20Var6&);
+    static bool Write(const Group20Var6&, openpal::WSlice&);
 
-  typedef uint16_t ValueType;
-  uint16_t value;
+    typedef uint16_t ValueType;
+    uint16_t value;
 
-  typedef Counter Target;
-  typedef CounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Counter&);
-  static bool WriteTarget(const Counter&, openpal::WSlice&);
-  static DNP3Serializer<Counter> Inst() { return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Counter Target;
+    typedef CounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Counter&);
+    static bool WriteTarget(const Counter&, openpal::WSlice&);
+    static DNP3Serializer<Counter> Inst()
+    {
+        return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group21.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group21.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,216 +33,211 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group21Var1 -------
 
-Group21Var1::Group21Var1() : flags(0), value(0)
-{}
+Group21Var1::Group21Var1() : flags(0), value(0) {}
 
 bool Group21Var1::Read(RSlice& buffer, Group21Var1& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group21Var1::Write(const Group21Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group21Var1::ReadTarget(RSlice& buff, FrozenCounter& output)
 {
-  Group21Var1 value;
-  if(Read(buff, value))
-  {
-    output = FrozenCounterFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group21Var1 value;
+    if (Read(buff, value))
+    {
+        output = FrozenCounterFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group21Var1::WriteTarget(const FrozenCounter& value, openpal::WSlice& buff)
 {
-  return Group21Var1::Write(ConvertGroup21Var1::Apply(value), buff);
+    return Group21Var1::Write(ConvertGroup21Var1::Apply(value), buff);
 }
 
 // ------- Group21Var2 -------
 
-Group21Var2::Group21Var2() : flags(0), value(0)
-{}
+Group21Var2::Group21Var2() : flags(0), value(0) {}
 
 bool Group21Var2::Read(RSlice& buffer, Group21Var2& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group21Var2::Write(const Group21Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group21Var2::ReadTarget(RSlice& buff, FrozenCounter& output)
 {
-  Group21Var2 value;
-  if(Read(buff, value))
-  {
-    output = FrozenCounterFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group21Var2 value;
+    if (Read(buff, value))
+    {
+        output = FrozenCounterFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group21Var2::WriteTarget(const FrozenCounter& value, openpal::WSlice& buff)
 {
-  return Group21Var2::Write(ConvertGroup21Var2::Apply(value), buff);
+    return Group21Var2::Write(ConvertGroup21Var2::Apply(value), buff);
 }
 
 // ------- Group21Var5 -------
 
-Group21Var5::Group21Var5() : flags(0), value(0), time(0)
-{}
+Group21Var5::Group21Var5() : flags(0), value(0), time(0) {}
 
 bool Group21Var5::Read(RSlice& buffer, Group21Var5& output)
 {
-  return Parse::Many(buffer, output.flags, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.value, output.time);
 }
 
 bool Group21Var5::Write(const Group21Var5& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.value, arg.time);
 }
 
 bool Group21Var5::ReadTarget(RSlice& buff, FrozenCounter& output)
 {
-  Group21Var5 value;
-  if(Read(buff, value))
-  {
-    output = FrozenCounterFactory::From(value.flags, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group21Var5 value;
+    if (Read(buff, value))
+    {
+        output = FrozenCounterFactory::From(value.flags, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group21Var5::WriteTarget(const FrozenCounter& value, openpal::WSlice& buff)
 {
-  return Group21Var5::Write(ConvertGroup21Var5::Apply(value), buff);
+    return Group21Var5::Write(ConvertGroup21Var5::Apply(value), buff);
 }
 
 // ------- Group21Var6 -------
 
-Group21Var6::Group21Var6() : flags(0), value(0), time(0)
-{}
+Group21Var6::Group21Var6() : flags(0), value(0), time(0) {}
 
 bool Group21Var6::Read(RSlice& buffer, Group21Var6& output)
 {
-  return Parse::Many(buffer, output.flags, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.value, output.time);
 }
 
 bool Group21Var6::Write(const Group21Var6& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.value, arg.time);
 }
 
 bool Group21Var6::ReadTarget(RSlice& buff, FrozenCounter& output)
 {
-  Group21Var6 value;
-  if(Read(buff, value))
-  {
-    output = FrozenCounterFactory::From(value.flags, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group21Var6 value;
+    if (Read(buff, value))
+    {
+        output = FrozenCounterFactory::From(value.flags, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group21Var6::WriteTarget(const FrozenCounter& value, openpal::WSlice& buff)
 {
-  return Group21Var6::Write(ConvertGroup21Var6::Apply(value), buff);
+    return Group21Var6::Write(ConvertGroup21Var6::Apply(value), buff);
 }
 
 // ------- Group21Var9 -------
 
-Group21Var9::Group21Var9() : value(0)
-{}
+Group21Var9::Group21Var9() : value(0) {}
 
 bool Group21Var9::Read(RSlice& buffer, Group21Var9& output)
 {
-  return Parse::Many(buffer, output.value);
+    return Parse::Many(buffer, output.value);
 }
 
 bool Group21Var9::Write(const Group21Var9& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.value);
+    return Format::Many(buffer, arg.value);
 }
 
 bool Group21Var9::ReadTarget(RSlice& buff, FrozenCounter& output)
 {
-  Group21Var9 value;
-  if(Read(buff, value))
-  {
-    output = FrozenCounterFactory::From(value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group21Var9 value;
+    if (Read(buff, value))
+    {
+        output = FrozenCounterFactory::From(value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group21Var9::WriteTarget(const FrozenCounter& value, openpal::WSlice& buff)
 {
-  return Group21Var9::Write(ConvertGroup21Var9::Apply(value), buff);
+    return Group21Var9::Write(ConvertGroup21Var9::Apply(value), buff);
 }
 
 // ------- Group21Var10 -------
 
-Group21Var10::Group21Var10() : value(0)
-{}
+Group21Var10::Group21Var10() : value(0) {}
 
 bool Group21Var10::Read(RSlice& buffer, Group21Var10& output)
 {
-  return Parse::Many(buffer, output.value);
+    return Parse::Many(buffer, output.value);
 }
 
 bool Group21Var10::Write(const Group21Var10& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.value);
+    return Format::Many(buffer, arg.value);
 }
 
 bool Group21Var10::ReadTarget(RSlice& buff, FrozenCounter& output)
 {
-  Group21Var10 value;
-  if(Read(buff, value))
-  {
-    output = FrozenCounterFactory::From(value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group21Var10 value;
+    if (Read(buff, value))
+    {
+        output = FrozenCounterFactory::From(value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group21Var10::WriteTarget(const FrozenCounter& value, openpal::WSlice& buff)
 {
-  return Group21Var10::Write(ConvertGroup21Var10::Apply(value), buff);
+    return Group21Var10::Write(ConvertGroup21Var10::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group21.h
+++ b/cpp/libs/src/opendnp3/objects/Group21.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,154 +32,212 @@
 #ifndef OPENDNP3_GROUP21_H
 #define OPENDNP3_GROUP21_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Frozen Counter - Any Variation
 struct Group21Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(21,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(21, 0);
+    }
 };
 
 // Frozen Counter - 32-bit With Flag
 struct Group21Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(21,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(21, 1);
+    }
 
-  Group21Var1();
+    Group21Var1();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group21Var1&);
-  static bool Write(const Group21Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group21Var1&);
+    static bool Write(const Group21Var1&, openpal::WSlice&);
 
-  typedef uint32_t ValueType;
-  uint8_t flags;
-  uint32_t value;
+    typedef uint32_t ValueType;
+    uint8_t flags;
+    uint32_t value;
 
-  typedef FrozenCounter Target;
-  typedef FrozenCounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
-  static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
-  static DNP3Serializer<FrozenCounter> Inst() { return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef FrozenCounter Target;
+    typedef FrozenCounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
+    static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
+    static DNP3Serializer<FrozenCounter> Inst()
+    {
+        return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Frozen Counter - 16-bit With Flag
 struct Group21Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(21,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(21, 2);
+    }
 
-  Group21Var2();
+    Group21Var2();
 
-  static uint32_t Size() { return 3; }
-  static bool Read(openpal::RSlice&, Group21Var2&);
-  static bool Write(const Group21Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 3;
+    }
+    static bool Read(openpal::RSlice&, Group21Var2&);
+    static bool Write(const Group21Var2&, openpal::WSlice&);
 
-  typedef uint16_t ValueType;
-  uint8_t flags;
-  uint16_t value;
+    typedef uint16_t ValueType;
+    uint8_t flags;
+    uint16_t value;
 
-  typedef FrozenCounter Target;
-  typedef FrozenCounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
-  static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
-  static DNP3Serializer<FrozenCounter> Inst() { return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef FrozenCounter Target;
+    typedef FrozenCounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
+    static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
+    static DNP3Serializer<FrozenCounter> Inst()
+    {
+        return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Frozen Counter - 32-bit With Flag and Time
 struct Group21Var5
 {
-  static GroupVariationID ID() { return GroupVariationID(21,5); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(21, 5);
+    }
 
-  Group21Var5();
+    Group21Var5();
 
-  static uint32_t Size() { return 11; }
-  static bool Read(openpal::RSlice&, Group21Var5&);
-  static bool Write(const Group21Var5&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 11;
+    }
+    static bool Read(openpal::RSlice&, Group21Var5&);
+    static bool Write(const Group21Var5&, openpal::WSlice&);
 
-  typedef uint32_t ValueType;
-  uint8_t flags;
-  uint32_t value;
-  DNPTime time;
+    typedef uint32_t ValueType;
+    uint8_t flags;
+    uint32_t value;
+    DNPTime time;
 
-  typedef FrozenCounter Target;
-  typedef FrozenCounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
-  static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
-  static DNP3Serializer<FrozenCounter> Inst() { return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef FrozenCounter Target;
+    typedef FrozenCounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
+    static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
+    static DNP3Serializer<FrozenCounter> Inst()
+    {
+        return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Frozen Counter - 16-bit With Flag and Time
 struct Group21Var6
 {
-  static GroupVariationID ID() { return GroupVariationID(21,6); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(21, 6);
+    }
 
-  Group21Var6();
+    Group21Var6();
 
-  static uint32_t Size() { return 9; }
-  static bool Read(openpal::RSlice&, Group21Var6&);
-  static bool Write(const Group21Var6&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 9;
+    }
+    static bool Read(openpal::RSlice&, Group21Var6&);
+    static bool Write(const Group21Var6&, openpal::WSlice&);
 
-  typedef uint16_t ValueType;
-  uint8_t flags;
-  uint16_t value;
-  DNPTime time;
+    typedef uint16_t ValueType;
+    uint8_t flags;
+    uint16_t value;
+    DNPTime time;
 
-  typedef FrozenCounter Target;
-  typedef FrozenCounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
-  static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
-  static DNP3Serializer<FrozenCounter> Inst() { return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef FrozenCounter Target;
+    typedef FrozenCounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
+    static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
+    static DNP3Serializer<FrozenCounter> Inst()
+    {
+        return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Frozen Counter - 32-bit Without Flag
 struct Group21Var9
 {
-  static GroupVariationID ID() { return GroupVariationID(21,9); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(21, 9);
+    }
 
-  Group21Var9();
+    Group21Var9();
 
-  static uint32_t Size() { return 4; }
-  static bool Read(openpal::RSlice&, Group21Var9&);
-  static bool Write(const Group21Var9&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 4;
+    }
+    static bool Read(openpal::RSlice&, Group21Var9&);
+    static bool Write(const Group21Var9&, openpal::WSlice&);
 
-  typedef uint32_t ValueType;
-  uint32_t value;
+    typedef uint32_t ValueType;
+    uint32_t value;
 
-  typedef FrozenCounter Target;
-  typedef FrozenCounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
-  static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
-  static DNP3Serializer<FrozenCounter> Inst() { return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef FrozenCounter Target;
+    typedef FrozenCounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
+    static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
+    static DNP3Serializer<FrozenCounter> Inst()
+    {
+        return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Frozen Counter - 16-bit Without Flag
 struct Group21Var10
 {
-  static GroupVariationID ID() { return GroupVariationID(21,10); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(21, 10);
+    }
 
-  Group21Var10();
+    Group21Var10();
 
-  static uint32_t Size() { return 2; }
-  static bool Read(openpal::RSlice&, Group21Var10&);
-  static bool Write(const Group21Var10&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 2;
+    }
+    static bool Read(openpal::RSlice&, Group21Var10&);
+    static bool Write(const Group21Var10&, openpal::WSlice&);
 
-  typedef uint16_t ValueType;
-  uint16_t value;
+    typedef uint16_t ValueType;
+    uint16_t value;
 
-  typedef FrozenCounter Target;
-  typedef FrozenCounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
-  static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
-  static DNP3Serializer<FrozenCounter> Inst() { return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef FrozenCounter Target;
+    typedef FrozenCounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
+    static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
+    static DNP3Serializer<FrozenCounter> Inst()
+    {
+        return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group22.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group22.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,148 +33,145 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group22Var1 -------
 
-Group22Var1::Group22Var1() : flags(0), value(0)
-{}
+Group22Var1::Group22Var1() : flags(0), value(0) {}
 
 bool Group22Var1::Read(RSlice& buffer, Group22Var1& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group22Var1::Write(const Group22Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group22Var1::ReadTarget(RSlice& buff, Counter& output)
 {
-  Group22Var1 value;
-  if(Read(buff, value))
-  {
-    output = CounterFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group22Var1 value;
+    if (Read(buff, value))
+    {
+        output = CounterFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group22Var1::WriteTarget(const Counter& value, openpal::WSlice& buff)
 {
-  return Group22Var1::Write(ConvertGroup22Var1::Apply(value), buff);
+    return Group22Var1::Write(ConvertGroup22Var1::Apply(value), buff);
 }
 
 // ------- Group22Var2 -------
 
-Group22Var2::Group22Var2() : flags(0), value(0)
-{}
+Group22Var2::Group22Var2() : flags(0), value(0) {}
 
 bool Group22Var2::Read(RSlice& buffer, Group22Var2& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group22Var2::Write(const Group22Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group22Var2::ReadTarget(RSlice& buff, Counter& output)
 {
-  Group22Var2 value;
-  if(Read(buff, value))
-  {
-    output = CounterFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group22Var2 value;
+    if (Read(buff, value))
+    {
+        output = CounterFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group22Var2::WriteTarget(const Counter& value, openpal::WSlice& buff)
 {
-  return Group22Var2::Write(ConvertGroup22Var2::Apply(value), buff);
+    return Group22Var2::Write(ConvertGroup22Var2::Apply(value), buff);
 }
 
 // ------- Group22Var5 -------
 
-Group22Var5::Group22Var5() : flags(0), value(0), time(0)
-{}
+Group22Var5::Group22Var5() : flags(0), value(0), time(0) {}
 
 bool Group22Var5::Read(RSlice& buffer, Group22Var5& output)
 {
-  return Parse::Many(buffer, output.flags, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.value, output.time);
 }
 
 bool Group22Var5::Write(const Group22Var5& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.value, arg.time);
 }
 
 bool Group22Var5::ReadTarget(RSlice& buff, Counter& output)
 {
-  Group22Var5 value;
-  if(Read(buff, value))
-  {
-    output = CounterFactory::From(value.flags, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group22Var5 value;
+    if (Read(buff, value))
+    {
+        output = CounterFactory::From(value.flags, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group22Var5::WriteTarget(const Counter& value, openpal::WSlice& buff)
 {
-  return Group22Var5::Write(ConvertGroup22Var5::Apply(value), buff);
+    return Group22Var5::Write(ConvertGroup22Var5::Apply(value), buff);
 }
 
 // ------- Group22Var6 -------
 
-Group22Var6::Group22Var6() : flags(0), value(0), time(0)
-{}
+Group22Var6::Group22Var6() : flags(0), value(0), time(0) {}
 
 bool Group22Var6::Read(RSlice& buffer, Group22Var6& output)
 {
-  return Parse::Many(buffer, output.flags, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.value, output.time);
 }
 
 bool Group22Var6::Write(const Group22Var6& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.value, arg.time);
 }
 
 bool Group22Var6::ReadTarget(RSlice& buff, Counter& output)
 {
-  Group22Var6 value;
-  if(Read(buff, value))
-  {
-    output = CounterFactory::From(value.flags, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group22Var6 value;
+    if (Read(buff, value))
+    {
+        output = CounterFactory::From(value.flags, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group22Var6::WriteTarget(const Counter& value, openpal::WSlice& buff)
 {
-  return Group22Var6::Write(ConvertGroup22Var6::Apply(value), buff);
+    return Group22Var6::Write(ConvertGroup22Var6::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group22.h
+++ b/cpp/libs/src/opendnp3/objects/Group22.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,112 +32,152 @@
 #ifndef OPENDNP3_GROUP22_H
 #define OPENDNP3_GROUP22_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Counter Event - Any Variation
 struct Group22Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(22,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(22, 0);
+    }
 };
 
 // Counter Event - 32-bit With Flag
 struct Group22Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(22,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(22, 1);
+    }
 
-  Group22Var1();
+    Group22Var1();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group22Var1&);
-  static bool Write(const Group22Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group22Var1&);
+    static bool Write(const Group22Var1&, openpal::WSlice&);
 
-  typedef uint32_t ValueType;
-  uint8_t flags;
-  uint32_t value;
+    typedef uint32_t ValueType;
+    uint8_t flags;
+    uint32_t value;
 
-  typedef Counter Target;
-  typedef CounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Counter&);
-  static bool WriteTarget(const Counter&, openpal::WSlice&);
-  static DNP3Serializer<Counter> Inst() { return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Counter Target;
+    typedef CounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Counter&);
+    static bool WriteTarget(const Counter&, openpal::WSlice&);
+    static DNP3Serializer<Counter> Inst()
+    {
+        return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Counter Event - 16-bit With Flag
 struct Group22Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(22,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(22, 2);
+    }
 
-  Group22Var2();
+    Group22Var2();
 
-  static uint32_t Size() { return 3; }
-  static bool Read(openpal::RSlice&, Group22Var2&);
-  static bool Write(const Group22Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 3;
+    }
+    static bool Read(openpal::RSlice&, Group22Var2&);
+    static bool Write(const Group22Var2&, openpal::WSlice&);
 
-  typedef uint16_t ValueType;
-  uint8_t flags;
-  uint16_t value;
+    typedef uint16_t ValueType;
+    uint8_t flags;
+    uint16_t value;
 
-  typedef Counter Target;
-  typedef CounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Counter&);
-  static bool WriteTarget(const Counter&, openpal::WSlice&);
-  static DNP3Serializer<Counter> Inst() { return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Counter Target;
+    typedef CounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Counter&);
+    static bool WriteTarget(const Counter&, openpal::WSlice&);
+    static DNP3Serializer<Counter> Inst()
+    {
+        return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Counter Event - 32-bit With Flag and Time
 struct Group22Var5
 {
-  static GroupVariationID ID() { return GroupVariationID(22,5); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(22, 5);
+    }
 
-  Group22Var5();
+    Group22Var5();
 
-  static uint32_t Size() { return 11; }
-  static bool Read(openpal::RSlice&, Group22Var5&);
-  static bool Write(const Group22Var5&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 11;
+    }
+    static bool Read(openpal::RSlice&, Group22Var5&);
+    static bool Write(const Group22Var5&, openpal::WSlice&);
 
-  typedef uint32_t ValueType;
-  uint8_t flags;
-  uint32_t value;
-  DNPTime time;
+    typedef uint32_t ValueType;
+    uint8_t flags;
+    uint32_t value;
+    DNPTime time;
 
-  typedef Counter Target;
-  typedef CounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Counter&);
-  static bool WriteTarget(const Counter&, openpal::WSlice&);
-  static DNP3Serializer<Counter> Inst() { return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Counter Target;
+    typedef CounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Counter&);
+    static bool WriteTarget(const Counter&, openpal::WSlice&);
+    static DNP3Serializer<Counter> Inst()
+    {
+        return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Counter Event - 16-bit With Flag and Time
 struct Group22Var6
 {
-  static GroupVariationID ID() { return GroupVariationID(22,6); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(22, 6);
+    }
 
-  Group22Var6();
+    Group22Var6();
 
-  static uint32_t Size() { return 9; }
-  static bool Read(openpal::RSlice&, Group22Var6&);
-  static bool Write(const Group22Var6&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 9;
+    }
+    static bool Read(openpal::RSlice&, Group22Var6&);
+    static bool Write(const Group22Var6&, openpal::WSlice&);
 
-  typedef uint16_t ValueType;
-  uint8_t flags;
-  uint16_t value;
-  DNPTime time;
+    typedef uint16_t ValueType;
+    uint8_t flags;
+    uint16_t value;
+    DNPTime time;
 
-  typedef Counter Target;
-  typedef CounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Counter&);
-  static bool WriteTarget(const Counter&, openpal::WSlice&);
-  static DNP3Serializer<Counter> Inst() { return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Counter Target;
+    typedef CounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Counter&);
+    static bool WriteTarget(const Counter&, openpal::WSlice&);
+    static DNP3Serializer<Counter> Inst()
+    {
+        return DNP3Serializer<Counter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group23.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group23.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,148 +33,145 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group23Var1 -------
 
-Group23Var1::Group23Var1() : flags(0), value(0)
-{}
+Group23Var1::Group23Var1() : flags(0), value(0) {}
 
 bool Group23Var1::Read(RSlice& buffer, Group23Var1& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group23Var1::Write(const Group23Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group23Var1::ReadTarget(RSlice& buff, FrozenCounter& output)
 {
-  Group23Var1 value;
-  if(Read(buff, value))
-  {
-    output = FrozenCounterFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group23Var1 value;
+    if (Read(buff, value))
+    {
+        output = FrozenCounterFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group23Var1::WriteTarget(const FrozenCounter& value, openpal::WSlice& buff)
 {
-  return Group23Var1::Write(ConvertGroup23Var1::Apply(value), buff);
+    return Group23Var1::Write(ConvertGroup23Var1::Apply(value), buff);
 }
 
 // ------- Group23Var2 -------
 
-Group23Var2::Group23Var2() : flags(0), value(0)
-{}
+Group23Var2::Group23Var2() : flags(0), value(0) {}
 
 bool Group23Var2::Read(RSlice& buffer, Group23Var2& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group23Var2::Write(const Group23Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group23Var2::ReadTarget(RSlice& buff, FrozenCounter& output)
 {
-  Group23Var2 value;
-  if(Read(buff, value))
-  {
-    output = FrozenCounterFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group23Var2 value;
+    if (Read(buff, value))
+    {
+        output = FrozenCounterFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group23Var2::WriteTarget(const FrozenCounter& value, openpal::WSlice& buff)
 {
-  return Group23Var2::Write(ConvertGroup23Var2::Apply(value), buff);
+    return Group23Var2::Write(ConvertGroup23Var2::Apply(value), buff);
 }
 
 // ------- Group23Var5 -------
 
-Group23Var5::Group23Var5() : flags(0), value(0), time(0)
-{}
+Group23Var5::Group23Var5() : flags(0), value(0), time(0) {}
 
 bool Group23Var5::Read(RSlice& buffer, Group23Var5& output)
 {
-  return Parse::Many(buffer, output.flags, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.value, output.time);
 }
 
 bool Group23Var5::Write(const Group23Var5& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.value, arg.time);
 }
 
 bool Group23Var5::ReadTarget(RSlice& buff, FrozenCounter& output)
 {
-  Group23Var5 value;
-  if(Read(buff, value))
-  {
-    output = FrozenCounterFactory::From(value.flags, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group23Var5 value;
+    if (Read(buff, value))
+    {
+        output = FrozenCounterFactory::From(value.flags, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group23Var5::WriteTarget(const FrozenCounter& value, openpal::WSlice& buff)
 {
-  return Group23Var5::Write(ConvertGroup23Var5::Apply(value), buff);
+    return Group23Var5::Write(ConvertGroup23Var5::Apply(value), buff);
 }
 
 // ------- Group23Var6 -------
 
-Group23Var6::Group23Var6() : flags(0), value(0), time(0)
-{}
+Group23Var6::Group23Var6() : flags(0), value(0), time(0) {}
 
 bool Group23Var6::Read(RSlice& buffer, Group23Var6& output)
 {
-  return Parse::Many(buffer, output.flags, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.value, output.time);
 }
 
 bool Group23Var6::Write(const Group23Var6& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.value, arg.time);
 }
 
 bool Group23Var6::ReadTarget(RSlice& buff, FrozenCounter& output)
 {
-  Group23Var6 value;
-  if(Read(buff, value))
-  {
-    output = FrozenCounterFactory::From(value.flags, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group23Var6 value;
+    if (Read(buff, value))
+    {
+        output = FrozenCounterFactory::From(value.flags, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group23Var6::WriteTarget(const FrozenCounter& value, openpal::WSlice& buff)
 {
-  return Group23Var6::Write(ConvertGroup23Var6::Apply(value), buff);
+    return Group23Var6::Write(ConvertGroup23Var6::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group23.h
+++ b/cpp/libs/src/opendnp3/objects/Group23.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,112 +32,152 @@
 #ifndef OPENDNP3_GROUP23_H
 #define OPENDNP3_GROUP23_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Frozen Counter Event - Any Variation
 struct Group23Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(23,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(23, 0);
+    }
 };
 
 // Frozen Counter Event - 32-bit With Flag
 struct Group23Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(23,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(23, 1);
+    }
 
-  Group23Var1();
+    Group23Var1();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group23Var1&);
-  static bool Write(const Group23Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group23Var1&);
+    static bool Write(const Group23Var1&, openpal::WSlice&);
 
-  typedef uint32_t ValueType;
-  uint8_t flags;
-  uint32_t value;
+    typedef uint32_t ValueType;
+    uint8_t flags;
+    uint32_t value;
 
-  typedef FrozenCounter Target;
-  typedef FrozenCounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
-  static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
-  static DNP3Serializer<FrozenCounter> Inst() { return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef FrozenCounter Target;
+    typedef FrozenCounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
+    static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
+    static DNP3Serializer<FrozenCounter> Inst()
+    {
+        return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Frozen Counter Event - 16-bit With Flag
 struct Group23Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(23,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(23, 2);
+    }
 
-  Group23Var2();
+    Group23Var2();
 
-  static uint32_t Size() { return 3; }
-  static bool Read(openpal::RSlice&, Group23Var2&);
-  static bool Write(const Group23Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 3;
+    }
+    static bool Read(openpal::RSlice&, Group23Var2&);
+    static bool Write(const Group23Var2&, openpal::WSlice&);
 
-  typedef uint16_t ValueType;
-  uint8_t flags;
-  uint16_t value;
+    typedef uint16_t ValueType;
+    uint8_t flags;
+    uint16_t value;
 
-  typedef FrozenCounter Target;
-  typedef FrozenCounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
-  static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
-  static DNP3Serializer<FrozenCounter> Inst() { return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef FrozenCounter Target;
+    typedef FrozenCounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
+    static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
+    static DNP3Serializer<FrozenCounter> Inst()
+    {
+        return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Frozen Counter Event - 32-bit With Flag and Time
 struct Group23Var5
 {
-  static GroupVariationID ID() { return GroupVariationID(23,5); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(23, 5);
+    }
 
-  Group23Var5();
+    Group23Var5();
 
-  static uint32_t Size() { return 11; }
-  static bool Read(openpal::RSlice&, Group23Var5&);
-  static bool Write(const Group23Var5&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 11;
+    }
+    static bool Read(openpal::RSlice&, Group23Var5&);
+    static bool Write(const Group23Var5&, openpal::WSlice&);
 
-  typedef uint32_t ValueType;
-  uint8_t flags;
-  uint32_t value;
-  DNPTime time;
+    typedef uint32_t ValueType;
+    uint8_t flags;
+    uint32_t value;
+    DNPTime time;
 
-  typedef FrozenCounter Target;
-  typedef FrozenCounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
-  static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
-  static DNP3Serializer<FrozenCounter> Inst() { return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef FrozenCounter Target;
+    typedef FrozenCounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
+    static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
+    static DNP3Serializer<FrozenCounter> Inst()
+    {
+        return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Frozen Counter Event - 16-bit With Flag and Time
 struct Group23Var6
 {
-  static GroupVariationID ID() { return GroupVariationID(23,6); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(23, 6);
+    }
 
-  Group23Var6();
+    Group23Var6();
 
-  static uint32_t Size() { return 9; }
-  static bool Read(openpal::RSlice&, Group23Var6&);
-  static bool Write(const Group23Var6&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 9;
+    }
+    static bool Read(openpal::RSlice&, Group23Var6&);
+    static bool Write(const Group23Var6&, openpal::WSlice&);
 
-  typedef uint16_t ValueType;
-  uint8_t flags;
-  uint16_t value;
-  DNPTime time;
+    typedef uint16_t ValueType;
+    uint8_t flags;
+    uint16_t value;
+    DNPTime time;
 
-  typedef FrozenCounter Target;
-  typedef FrozenCounterSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
-  static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
-  static DNP3Serializer<FrozenCounter> Inst() { return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef FrozenCounter Target;
+    typedef FrozenCounterSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, FrozenCounter&);
+    static bool WriteTarget(const FrozenCounter&, openpal::WSlice&);
+    static DNP3Serializer<FrozenCounter> Inst()
+    {
+        return DNP3Serializer<FrozenCounter>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group3.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group3.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,46 +33,46 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group3Var2 -------
 
-Group3Var2::Group3Var2() : flags(0)
-{}
+Group3Var2::Group3Var2() : flags(0) {}
 
 bool Group3Var2::Read(RSlice& buffer, Group3Var2& output)
 {
-  return Parse::Many(buffer, output.flags);
+    return Parse::Many(buffer, output.flags);
 }
 
 bool Group3Var2::Write(const Group3Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags);
+    return Format::Many(buffer, arg.flags);
 }
 
 bool Group3Var2::ReadTarget(RSlice& buff, DoubleBitBinary& output)
 {
-  Group3Var2 value;
-  if(Read(buff, value))
-  {
-    output = DoubleBitBinaryFactory::From(value.flags);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group3Var2 value;
+    if (Read(buff, value))
+    {
+        output = DoubleBitBinaryFactory::From(value.flags);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group3Var2::WriteTarget(const DoubleBitBinary& value, openpal::WSlice& buff)
 {
-  return Group3Var2::Write(ConvertGroup3Var2::Apply(value), buff);
+    return Group3Var2::Write(ConvertGroup3Var2::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group3.h
+++ b/cpp/libs/src/opendnp3/objects/Group3.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,48 +32,64 @@
 #ifndef OPENDNP3_GROUP3_H
 #define OPENDNP3_GROUP3_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Double-bit Binary Input - Any Variation
 struct Group3Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(3,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(3, 0);
+    }
 };
 
 // Double-bit Binary Input - Packed Format
 struct Group3Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(3,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(3, 1);
+    }
 };
 
 // Double-bit Binary Input - With Flags
 struct Group3Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(3,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(3, 2);
+    }
 
-  Group3Var2();
+    Group3Var2();
 
-  static uint32_t Size() { return 1; }
-  static bool Read(openpal::RSlice&, Group3Var2&);
-  static bool Write(const Group3Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 1;
+    }
+    static bool Read(openpal::RSlice&, Group3Var2&);
+    static bool Write(const Group3Var2&, openpal::WSlice&);
 
-  uint8_t flags;
+    uint8_t flags;
 
-  typedef DoubleBitBinary Target;
-  typedef DoubleBitBinarySpec Spec;
-  static bool ReadTarget(openpal::RSlice&, DoubleBitBinary&);
-  static bool WriteTarget(const DoubleBitBinary&, openpal::WSlice&);
-  static DNP3Serializer<DoubleBitBinary> Inst() { return DNP3Serializer<DoubleBitBinary>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef DoubleBitBinary Target;
+    typedef DoubleBitBinarySpec Spec;
+    static bool ReadTarget(openpal::RSlice&, DoubleBitBinary&);
+    static bool WriteTarget(const DoubleBitBinary&, openpal::WSlice&);
+    static DNP3Serializer<DoubleBitBinary> Inst()
+    {
+        return DNP3Serializer<DoubleBitBinary>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group30.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group30.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,216 +33,211 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group30Var1 -------
 
-Group30Var1::Group30Var1() : flags(0), value(0)
-{}
+Group30Var1::Group30Var1() : flags(0), value(0) {}
 
 bool Group30Var1::Read(RSlice& buffer, Group30Var1& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group30Var1::Write(const Group30Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group30Var1::ReadTarget(RSlice& buff, Analog& output)
 {
-  Group30Var1 value;
-  if(Read(buff, value))
-  {
-    output = AnalogFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group30Var1 value;
+    if (Read(buff, value))
+    {
+        output = AnalogFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group30Var1::WriteTarget(const Analog& value, openpal::WSlice& buff)
 {
-  return Group30Var1::Write(ConvertGroup30Var1::Apply(value), buff);
+    return Group30Var1::Write(ConvertGroup30Var1::Apply(value), buff);
 }
 
 // ------- Group30Var2 -------
 
-Group30Var2::Group30Var2() : flags(0), value(0)
-{}
+Group30Var2::Group30Var2() : flags(0), value(0) {}
 
 bool Group30Var2::Read(RSlice& buffer, Group30Var2& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group30Var2::Write(const Group30Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group30Var2::ReadTarget(RSlice& buff, Analog& output)
 {
-  Group30Var2 value;
-  if(Read(buff, value))
-  {
-    output = AnalogFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group30Var2 value;
+    if (Read(buff, value))
+    {
+        output = AnalogFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group30Var2::WriteTarget(const Analog& value, openpal::WSlice& buff)
 {
-  return Group30Var2::Write(ConvertGroup30Var2::Apply(value), buff);
+    return Group30Var2::Write(ConvertGroup30Var2::Apply(value), buff);
 }
 
 // ------- Group30Var3 -------
 
-Group30Var3::Group30Var3() : value(0)
-{}
+Group30Var3::Group30Var3() : value(0) {}
 
 bool Group30Var3::Read(RSlice& buffer, Group30Var3& output)
 {
-  return Parse::Many(buffer, output.value);
+    return Parse::Many(buffer, output.value);
 }
 
 bool Group30Var3::Write(const Group30Var3& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.value);
+    return Format::Many(buffer, arg.value);
 }
 
 bool Group30Var3::ReadTarget(RSlice& buff, Analog& output)
 {
-  Group30Var3 value;
-  if(Read(buff, value))
-  {
-    output = AnalogFactory::From(value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group30Var3 value;
+    if (Read(buff, value))
+    {
+        output = AnalogFactory::From(value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group30Var3::WriteTarget(const Analog& value, openpal::WSlice& buff)
 {
-  return Group30Var3::Write(ConvertGroup30Var3::Apply(value), buff);
+    return Group30Var3::Write(ConvertGroup30Var3::Apply(value), buff);
 }
 
 // ------- Group30Var4 -------
 
-Group30Var4::Group30Var4() : value(0)
-{}
+Group30Var4::Group30Var4() : value(0) {}
 
 bool Group30Var4::Read(RSlice& buffer, Group30Var4& output)
 {
-  return Parse::Many(buffer, output.value);
+    return Parse::Many(buffer, output.value);
 }
 
 bool Group30Var4::Write(const Group30Var4& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.value);
+    return Format::Many(buffer, arg.value);
 }
 
 bool Group30Var4::ReadTarget(RSlice& buff, Analog& output)
 {
-  Group30Var4 value;
-  if(Read(buff, value))
-  {
-    output = AnalogFactory::From(value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group30Var4 value;
+    if (Read(buff, value))
+    {
+        output = AnalogFactory::From(value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group30Var4::WriteTarget(const Analog& value, openpal::WSlice& buff)
 {
-  return Group30Var4::Write(ConvertGroup30Var4::Apply(value), buff);
+    return Group30Var4::Write(ConvertGroup30Var4::Apply(value), buff);
 }
 
 // ------- Group30Var5 -------
 
-Group30Var5::Group30Var5() : flags(0), value(0.0)
-{}
+Group30Var5::Group30Var5() : flags(0), value(0.0) {}
 
 bool Group30Var5::Read(RSlice& buffer, Group30Var5& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group30Var5::Write(const Group30Var5& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group30Var5::ReadTarget(RSlice& buff, Analog& output)
 {
-  Group30Var5 value;
-  if(Read(buff, value))
-  {
-    output = AnalogFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group30Var5 value;
+    if (Read(buff, value))
+    {
+        output = AnalogFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group30Var5::WriteTarget(const Analog& value, openpal::WSlice& buff)
 {
-  return Group30Var5::Write(ConvertGroup30Var5::Apply(value), buff);
+    return Group30Var5::Write(ConvertGroup30Var5::Apply(value), buff);
 }
 
 // ------- Group30Var6 -------
 
-Group30Var6::Group30Var6() : flags(0), value(0.0)
-{}
+Group30Var6::Group30Var6() : flags(0), value(0.0) {}
 
 bool Group30Var6::Read(RSlice& buffer, Group30Var6& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group30Var6::Write(const Group30Var6& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group30Var6::ReadTarget(RSlice& buff, Analog& output)
 {
-  Group30Var6 value;
-  if(Read(buff, value))
-  {
-    output = AnalogFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group30Var6 value;
+    if (Read(buff, value))
+    {
+        output = AnalogFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group30Var6::WriteTarget(const Analog& value, openpal::WSlice& buff)
 {
-  return Group30Var6::Write(ConvertGroup30Var6::Apply(value), buff);
+    return Group30Var6::Write(ConvertGroup30Var6::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group30.h
+++ b/cpp/libs/src/opendnp3/objects/Group30.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,152 +32,210 @@
 #ifndef OPENDNP3_GROUP30_H
 #define OPENDNP3_GROUP30_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Analog Input - Any Variation
 struct Group30Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(30,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(30, 0);
+    }
 };
 
 // Analog Input - 32-bit With Flag
 struct Group30Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(30,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(30, 1);
+    }
 
-  Group30Var1();
+    Group30Var1();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group30Var1&);
-  static bool Write(const Group30Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group30Var1&);
+    static bool Write(const Group30Var1&, openpal::WSlice&);
 
-  typedef int32_t ValueType;
-  uint8_t flags;
-  int32_t value;
+    typedef int32_t ValueType;
+    uint8_t flags;
+    int32_t value;
 
-  typedef Analog Target;
-  typedef AnalogSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Analog&);
-  static bool WriteTarget(const Analog&, openpal::WSlice&);
-  static DNP3Serializer<Analog> Inst() { return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Analog Target;
+    typedef AnalogSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Analog&);
+    static bool WriteTarget(const Analog&, openpal::WSlice&);
+    static DNP3Serializer<Analog> Inst()
+    {
+        return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Input - 16-bit With Flag
 struct Group30Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(30,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(30, 2);
+    }
 
-  Group30Var2();
+    Group30Var2();
 
-  static uint32_t Size() { return 3; }
-  static bool Read(openpal::RSlice&, Group30Var2&);
-  static bool Write(const Group30Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 3;
+    }
+    static bool Read(openpal::RSlice&, Group30Var2&);
+    static bool Write(const Group30Var2&, openpal::WSlice&);
 
-  typedef int16_t ValueType;
-  uint8_t flags;
-  int16_t value;
+    typedef int16_t ValueType;
+    uint8_t flags;
+    int16_t value;
 
-  typedef Analog Target;
-  typedef AnalogSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Analog&);
-  static bool WriteTarget(const Analog&, openpal::WSlice&);
-  static DNP3Serializer<Analog> Inst() { return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Analog Target;
+    typedef AnalogSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Analog&);
+    static bool WriteTarget(const Analog&, openpal::WSlice&);
+    static DNP3Serializer<Analog> Inst()
+    {
+        return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Input - 32-bit Without Flag
 struct Group30Var3
 {
-  static GroupVariationID ID() { return GroupVariationID(30,3); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(30, 3);
+    }
 
-  Group30Var3();
+    Group30Var3();
 
-  static uint32_t Size() { return 4; }
-  static bool Read(openpal::RSlice&, Group30Var3&);
-  static bool Write(const Group30Var3&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 4;
+    }
+    static bool Read(openpal::RSlice&, Group30Var3&);
+    static bool Write(const Group30Var3&, openpal::WSlice&);
 
-  typedef int32_t ValueType;
-  int32_t value;
+    typedef int32_t ValueType;
+    int32_t value;
 
-  typedef Analog Target;
-  typedef AnalogSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Analog&);
-  static bool WriteTarget(const Analog&, openpal::WSlice&);
-  static DNP3Serializer<Analog> Inst() { return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Analog Target;
+    typedef AnalogSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Analog&);
+    static bool WriteTarget(const Analog&, openpal::WSlice&);
+    static DNP3Serializer<Analog> Inst()
+    {
+        return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Input - 16-bit Without Flag
 struct Group30Var4
 {
-  static GroupVariationID ID() { return GroupVariationID(30,4); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(30, 4);
+    }
 
-  Group30Var4();
+    Group30Var4();
 
-  static uint32_t Size() { return 2; }
-  static bool Read(openpal::RSlice&, Group30Var4&);
-  static bool Write(const Group30Var4&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 2;
+    }
+    static bool Read(openpal::RSlice&, Group30Var4&);
+    static bool Write(const Group30Var4&, openpal::WSlice&);
 
-  typedef int16_t ValueType;
-  int16_t value;
+    typedef int16_t ValueType;
+    int16_t value;
 
-  typedef Analog Target;
-  typedef AnalogSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Analog&);
-  static bool WriteTarget(const Analog&, openpal::WSlice&);
-  static DNP3Serializer<Analog> Inst() { return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Analog Target;
+    typedef AnalogSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Analog&);
+    static bool WriteTarget(const Analog&, openpal::WSlice&);
+    static DNP3Serializer<Analog> Inst()
+    {
+        return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Input - Single-precision With Flag
 struct Group30Var5
 {
-  static GroupVariationID ID() { return GroupVariationID(30,5); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(30, 5);
+    }
 
-  Group30Var5();
+    Group30Var5();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group30Var5&);
-  static bool Write(const Group30Var5&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group30Var5&);
+    static bool Write(const Group30Var5&, openpal::WSlice&);
 
-  typedef float ValueType;
-  uint8_t flags;
-  float value;
+    typedef float ValueType;
+    uint8_t flags;
+    float value;
 
-  typedef Analog Target;
-  typedef AnalogSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Analog&);
-  static bool WriteTarget(const Analog&, openpal::WSlice&);
-  static DNP3Serializer<Analog> Inst() { return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Analog Target;
+    typedef AnalogSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Analog&);
+    static bool WriteTarget(const Analog&, openpal::WSlice&);
+    static DNP3Serializer<Analog> Inst()
+    {
+        return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Input - Double-precision With Flag
 struct Group30Var6
 {
-  static GroupVariationID ID() { return GroupVariationID(30,6); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(30, 6);
+    }
 
-  Group30Var6();
+    Group30Var6();
 
-  static uint32_t Size() { return 9; }
-  static bool Read(openpal::RSlice&, Group30Var6&);
-  static bool Write(const Group30Var6&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 9;
+    }
+    static bool Read(openpal::RSlice&, Group30Var6&);
+    static bool Write(const Group30Var6&, openpal::WSlice&);
 
-  typedef double ValueType;
-  uint8_t flags;
-  double value;
+    typedef double ValueType;
+    uint8_t flags;
+    double value;
 
-  typedef Analog Target;
-  typedef AnalogSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Analog&);
-  static bool WriteTarget(const Analog&, openpal::WSlice&);
-  static DNP3Serializer<Analog> Inst() { return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Analog Target;
+    typedef AnalogSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Analog&);
+    static bool WriteTarget(const Analog&, openpal::WSlice&);
+    static DNP3Serializer<Analog> Inst()
+    {
+        return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group32.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group32.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,284 +33,277 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group32Var1 -------
 
-Group32Var1::Group32Var1() : flags(0), value(0)
-{}
+Group32Var1::Group32Var1() : flags(0), value(0) {}
 
 bool Group32Var1::Read(RSlice& buffer, Group32Var1& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group32Var1::Write(const Group32Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group32Var1::ReadTarget(RSlice& buff, Analog& output)
 {
-  Group32Var1 value;
-  if(Read(buff, value))
-  {
-    output = AnalogFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group32Var1 value;
+    if (Read(buff, value))
+    {
+        output = AnalogFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group32Var1::WriteTarget(const Analog& value, openpal::WSlice& buff)
 {
-  return Group32Var1::Write(ConvertGroup32Var1::Apply(value), buff);
+    return Group32Var1::Write(ConvertGroup32Var1::Apply(value), buff);
 }
 
 // ------- Group32Var2 -------
 
-Group32Var2::Group32Var2() : flags(0), value(0)
-{}
+Group32Var2::Group32Var2() : flags(0), value(0) {}
 
 bool Group32Var2::Read(RSlice& buffer, Group32Var2& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group32Var2::Write(const Group32Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group32Var2::ReadTarget(RSlice& buff, Analog& output)
 {
-  Group32Var2 value;
-  if(Read(buff, value))
-  {
-    output = AnalogFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group32Var2 value;
+    if (Read(buff, value))
+    {
+        output = AnalogFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group32Var2::WriteTarget(const Analog& value, openpal::WSlice& buff)
 {
-  return Group32Var2::Write(ConvertGroup32Var2::Apply(value), buff);
+    return Group32Var2::Write(ConvertGroup32Var2::Apply(value), buff);
 }
 
 // ------- Group32Var3 -------
 
-Group32Var3::Group32Var3() : flags(0), value(0), time(0)
-{}
+Group32Var3::Group32Var3() : flags(0), value(0), time(0) {}
 
 bool Group32Var3::Read(RSlice& buffer, Group32Var3& output)
 {
-  return Parse::Many(buffer, output.flags, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.value, output.time);
 }
 
 bool Group32Var3::Write(const Group32Var3& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.value, arg.time);
 }
 
 bool Group32Var3::ReadTarget(RSlice& buff, Analog& output)
 {
-  Group32Var3 value;
-  if(Read(buff, value))
-  {
-    output = AnalogFactory::From(value.flags, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group32Var3 value;
+    if (Read(buff, value))
+    {
+        output = AnalogFactory::From(value.flags, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group32Var3::WriteTarget(const Analog& value, openpal::WSlice& buff)
 {
-  return Group32Var3::Write(ConvertGroup32Var3::Apply(value), buff);
+    return Group32Var3::Write(ConvertGroup32Var3::Apply(value), buff);
 }
 
 // ------- Group32Var4 -------
 
-Group32Var4::Group32Var4() : flags(0), value(0), time(0)
-{}
+Group32Var4::Group32Var4() : flags(0), value(0), time(0) {}
 
 bool Group32Var4::Read(RSlice& buffer, Group32Var4& output)
 {
-  return Parse::Many(buffer, output.flags, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.value, output.time);
 }
 
 bool Group32Var4::Write(const Group32Var4& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.value, arg.time);
 }
 
 bool Group32Var4::ReadTarget(RSlice& buff, Analog& output)
 {
-  Group32Var4 value;
-  if(Read(buff, value))
-  {
-    output = AnalogFactory::From(value.flags, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group32Var4 value;
+    if (Read(buff, value))
+    {
+        output = AnalogFactory::From(value.flags, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group32Var4::WriteTarget(const Analog& value, openpal::WSlice& buff)
 {
-  return Group32Var4::Write(ConvertGroup32Var4::Apply(value), buff);
+    return Group32Var4::Write(ConvertGroup32Var4::Apply(value), buff);
 }
 
 // ------- Group32Var5 -------
 
-Group32Var5::Group32Var5() : flags(0), value(0.0)
-{}
+Group32Var5::Group32Var5() : flags(0), value(0.0) {}
 
 bool Group32Var5::Read(RSlice& buffer, Group32Var5& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group32Var5::Write(const Group32Var5& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group32Var5::ReadTarget(RSlice& buff, Analog& output)
 {
-  Group32Var5 value;
-  if(Read(buff, value))
-  {
-    output = AnalogFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group32Var5 value;
+    if (Read(buff, value))
+    {
+        output = AnalogFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group32Var5::WriteTarget(const Analog& value, openpal::WSlice& buff)
 {
-  return Group32Var5::Write(ConvertGroup32Var5::Apply(value), buff);
+    return Group32Var5::Write(ConvertGroup32Var5::Apply(value), buff);
 }
 
 // ------- Group32Var6 -------
 
-Group32Var6::Group32Var6() : flags(0), value(0.0)
-{}
+Group32Var6::Group32Var6() : flags(0), value(0.0) {}
 
 bool Group32Var6::Read(RSlice& buffer, Group32Var6& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group32Var6::Write(const Group32Var6& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group32Var6::ReadTarget(RSlice& buff, Analog& output)
 {
-  Group32Var6 value;
-  if(Read(buff, value))
-  {
-    output = AnalogFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group32Var6 value;
+    if (Read(buff, value))
+    {
+        output = AnalogFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group32Var6::WriteTarget(const Analog& value, openpal::WSlice& buff)
 {
-  return Group32Var6::Write(ConvertGroup32Var6::Apply(value), buff);
+    return Group32Var6::Write(ConvertGroup32Var6::Apply(value), buff);
 }
 
 // ------- Group32Var7 -------
 
-Group32Var7::Group32Var7() : flags(0), value(0.0), time(0)
-{}
+Group32Var7::Group32Var7() : flags(0), value(0.0), time(0) {}
 
 bool Group32Var7::Read(RSlice& buffer, Group32Var7& output)
 {
-  return Parse::Many(buffer, output.flags, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.value, output.time);
 }
 
 bool Group32Var7::Write(const Group32Var7& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.value, arg.time);
 }
 
 bool Group32Var7::ReadTarget(RSlice& buff, Analog& output)
 {
-  Group32Var7 value;
-  if(Read(buff, value))
-  {
-    output = AnalogFactory::From(value.flags, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group32Var7 value;
+    if (Read(buff, value))
+    {
+        output = AnalogFactory::From(value.flags, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group32Var7::WriteTarget(const Analog& value, openpal::WSlice& buff)
 {
-  return Group32Var7::Write(ConvertGroup32Var7::Apply(value), buff);
+    return Group32Var7::Write(ConvertGroup32Var7::Apply(value), buff);
 }
 
 // ------- Group32Var8 -------
 
-Group32Var8::Group32Var8() : flags(0), value(0.0), time(0)
-{}
+Group32Var8::Group32Var8() : flags(0), value(0.0), time(0) {}
 
 bool Group32Var8::Read(RSlice& buffer, Group32Var8& output)
 {
-  return Parse::Many(buffer, output.flags, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.value, output.time);
 }
 
 bool Group32Var8::Write(const Group32Var8& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.value, arg.time);
 }
 
 bool Group32Var8::ReadTarget(RSlice& buff, Analog& output)
 {
-  Group32Var8 value;
-  if(Read(buff, value))
-  {
-    output = AnalogFactory::From(value.flags, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group32Var8 value;
+    if (Read(buff, value))
+    {
+        output = AnalogFactory::From(value.flags, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group32Var8::WriteTarget(const Analog& value, openpal::WSlice& buff)
 {
-  return Group32Var8::Write(ConvertGroup32Var8::Apply(value), buff);
+    return Group32Var8::Write(ConvertGroup32Var8::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group32.h
+++ b/cpp/libs/src/opendnp3/objects/Group32.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,202 +32,278 @@
 #ifndef OPENDNP3_GROUP32_H
 #define OPENDNP3_GROUP32_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Analog Input Event - Any Variation
 struct Group32Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(32,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(32, 0);
+    }
 };
 
 // Analog Input Event - 32-bit With Flag
 struct Group32Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(32,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(32, 1);
+    }
 
-  Group32Var1();
+    Group32Var1();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group32Var1&);
-  static bool Write(const Group32Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group32Var1&);
+    static bool Write(const Group32Var1&, openpal::WSlice&);
 
-  typedef int32_t ValueType;
-  uint8_t flags;
-  int32_t value;
+    typedef int32_t ValueType;
+    uint8_t flags;
+    int32_t value;
 
-  typedef Analog Target;
-  typedef AnalogSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Analog&);
-  static bool WriteTarget(const Analog&, openpal::WSlice&);
-  static DNP3Serializer<Analog> Inst() { return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Analog Target;
+    typedef AnalogSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Analog&);
+    static bool WriteTarget(const Analog&, openpal::WSlice&);
+    static DNP3Serializer<Analog> Inst()
+    {
+        return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Input Event - 16-bit With Flag
 struct Group32Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(32,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(32, 2);
+    }
 
-  Group32Var2();
+    Group32Var2();
 
-  static uint32_t Size() { return 3; }
-  static bool Read(openpal::RSlice&, Group32Var2&);
-  static bool Write(const Group32Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 3;
+    }
+    static bool Read(openpal::RSlice&, Group32Var2&);
+    static bool Write(const Group32Var2&, openpal::WSlice&);
 
-  typedef int16_t ValueType;
-  uint8_t flags;
-  int16_t value;
+    typedef int16_t ValueType;
+    uint8_t flags;
+    int16_t value;
 
-  typedef Analog Target;
-  typedef AnalogSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Analog&);
-  static bool WriteTarget(const Analog&, openpal::WSlice&);
-  static DNP3Serializer<Analog> Inst() { return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Analog Target;
+    typedef AnalogSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Analog&);
+    static bool WriteTarget(const Analog&, openpal::WSlice&);
+    static DNP3Serializer<Analog> Inst()
+    {
+        return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Input Event - 32-bit With Flag and Time
 struct Group32Var3
 {
-  static GroupVariationID ID() { return GroupVariationID(32,3); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(32, 3);
+    }
 
-  Group32Var3();
+    Group32Var3();
 
-  static uint32_t Size() { return 11; }
-  static bool Read(openpal::RSlice&, Group32Var3&);
-  static bool Write(const Group32Var3&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 11;
+    }
+    static bool Read(openpal::RSlice&, Group32Var3&);
+    static bool Write(const Group32Var3&, openpal::WSlice&);
 
-  typedef int32_t ValueType;
-  uint8_t flags;
-  int32_t value;
-  DNPTime time;
+    typedef int32_t ValueType;
+    uint8_t flags;
+    int32_t value;
+    DNPTime time;
 
-  typedef Analog Target;
-  typedef AnalogSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Analog&);
-  static bool WriteTarget(const Analog&, openpal::WSlice&);
-  static DNP3Serializer<Analog> Inst() { return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Analog Target;
+    typedef AnalogSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Analog&);
+    static bool WriteTarget(const Analog&, openpal::WSlice&);
+    static DNP3Serializer<Analog> Inst()
+    {
+        return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Input Event - 16-bit With Flag and Time
 struct Group32Var4
 {
-  static GroupVariationID ID() { return GroupVariationID(32,4); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(32, 4);
+    }
 
-  Group32Var4();
+    Group32Var4();
 
-  static uint32_t Size() { return 9; }
-  static bool Read(openpal::RSlice&, Group32Var4&);
-  static bool Write(const Group32Var4&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 9;
+    }
+    static bool Read(openpal::RSlice&, Group32Var4&);
+    static bool Write(const Group32Var4&, openpal::WSlice&);
 
-  typedef int16_t ValueType;
-  uint8_t flags;
-  int16_t value;
-  DNPTime time;
+    typedef int16_t ValueType;
+    uint8_t flags;
+    int16_t value;
+    DNPTime time;
 
-  typedef Analog Target;
-  typedef AnalogSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Analog&);
-  static bool WriteTarget(const Analog&, openpal::WSlice&);
-  static DNP3Serializer<Analog> Inst() { return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Analog Target;
+    typedef AnalogSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Analog&);
+    static bool WriteTarget(const Analog&, openpal::WSlice&);
+    static DNP3Serializer<Analog> Inst()
+    {
+        return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Input Event - Single-precision With Flag
 struct Group32Var5
 {
-  static GroupVariationID ID() { return GroupVariationID(32,5); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(32, 5);
+    }
 
-  Group32Var5();
+    Group32Var5();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group32Var5&);
-  static bool Write(const Group32Var5&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group32Var5&);
+    static bool Write(const Group32Var5&, openpal::WSlice&);
 
-  typedef float ValueType;
-  uint8_t flags;
-  float value;
+    typedef float ValueType;
+    uint8_t flags;
+    float value;
 
-  typedef Analog Target;
-  typedef AnalogSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Analog&);
-  static bool WriteTarget(const Analog&, openpal::WSlice&);
-  static DNP3Serializer<Analog> Inst() { return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Analog Target;
+    typedef AnalogSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Analog&);
+    static bool WriteTarget(const Analog&, openpal::WSlice&);
+    static DNP3Serializer<Analog> Inst()
+    {
+        return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Input Event - Double-precision With Flag
 struct Group32Var6
 {
-  static GroupVariationID ID() { return GroupVariationID(32,6); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(32, 6);
+    }
 
-  Group32Var6();
+    Group32Var6();
 
-  static uint32_t Size() { return 9; }
-  static bool Read(openpal::RSlice&, Group32Var6&);
-  static bool Write(const Group32Var6&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 9;
+    }
+    static bool Read(openpal::RSlice&, Group32Var6&);
+    static bool Write(const Group32Var6&, openpal::WSlice&);
 
-  typedef double ValueType;
-  uint8_t flags;
-  double value;
+    typedef double ValueType;
+    uint8_t flags;
+    double value;
 
-  typedef Analog Target;
-  typedef AnalogSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Analog&);
-  static bool WriteTarget(const Analog&, openpal::WSlice&);
-  static DNP3Serializer<Analog> Inst() { return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Analog Target;
+    typedef AnalogSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Analog&);
+    static bool WriteTarget(const Analog&, openpal::WSlice&);
+    static DNP3Serializer<Analog> Inst()
+    {
+        return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Input Event - Single-precision With Flag and Time
 struct Group32Var7
 {
-  static GroupVariationID ID() { return GroupVariationID(32,7); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(32, 7);
+    }
 
-  Group32Var7();
+    Group32Var7();
 
-  static uint32_t Size() { return 11; }
-  static bool Read(openpal::RSlice&, Group32Var7&);
-  static bool Write(const Group32Var7&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 11;
+    }
+    static bool Read(openpal::RSlice&, Group32Var7&);
+    static bool Write(const Group32Var7&, openpal::WSlice&);
 
-  typedef float ValueType;
-  uint8_t flags;
-  float value;
-  DNPTime time;
+    typedef float ValueType;
+    uint8_t flags;
+    float value;
+    DNPTime time;
 
-  typedef Analog Target;
-  typedef AnalogSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Analog&);
-  static bool WriteTarget(const Analog&, openpal::WSlice&);
-  static DNP3Serializer<Analog> Inst() { return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Analog Target;
+    typedef AnalogSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Analog&);
+    static bool WriteTarget(const Analog&, openpal::WSlice&);
+    static DNP3Serializer<Analog> Inst()
+    {
+        return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Input Event - Double-precision With Flag and Time
 struct Group32Var8
 {
-  static GroupVariationID ID() { return GroupVariationID(32,8); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(32, 8);
+    }
 
-  Group32Var8();
+    Group32Var8();
 
-  static uint32_t Size() { return 15; }
-  static bool Read(openpal::RSlice&, Group32Var8&);
-  static bool Write(const Group32Var8&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 15;
+    }
+    static bool Read(openpal::RSlice&, Group32Var8&);
+    static bool Write(const Group32Var8&, openpal::WSlice&);
 
-  typedef double ValueType;
-  uint8_t flags;
-  double value;
-  DNPTime time;
+    typedef double ValueType;
+    uint8_t flags;
+    double value;
+    DNPTime time;
 
-  typedef Analog Target;
-  typedef AnalogSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, Analog&);
-  static bool WriteTarget(const Analog&, openpal::WSlice&);
-  static DNP3Serializer<Analog> Inst() { return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef Analog Target;
+    typedef AnalogSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, Analog&);
+    static bool WriteTarget(const Analog&, openpal::WSlice&);
+    static DNP3Serializer<Analog> Inst()
+    {
+        return DNP3Serializer<Analog>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group4.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group4.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,114 +33,112 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group4Var1 -------
 
-Group4Var1::Group4Var1() : flags(0)
-{}
+Group4Var1::Group4Var1() : flags(0) {}
 
 bool Group4Var1::Read(RSlice& buffer, Group4Var1& output)
 {
-  return Parse::Many(buffer, output.flags);
+    return Parse::Many(buffer, output.flags);
 }
 
 bool Group4Var1::Write(const Group4Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags);
+    return Format::Many(buffer, arg.flags);
 }
 
 bool Group4Var1::ReadTarget(RSlice& buff, DoubleBitBinary& output)
 {
-  Group4Var1 value;
-  if(Read(buff, value))
-  {
-    output = DoubleBitBinaryFactory::From(value.flags);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group4Var1 value;
+    if (Read(buff, value))
+    {
+        output = DoubleBitBinaryFactory::From(value.flags);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group4Var1::WriteTarget(const DoubleBitBinary& value, openpal::WSlice& buff)
 {
-  return Group4Var1::Write(ConvertGroup4Var1::Apply(value), buff);
+    return Group4Var1::Write(ConvertGroup4Var1::Apply(value), buff);
 }
 
 // ------- Group4Var2 -------
 
-Group4Var2::Group4Var2() : flags(0), time(0)
-{}
+Group4Var2::Group4Var2() : flags(0), time(0) {}
 
 bool Group4Var2::Read(RSlice& buffer, Group4Var2& output)
 {
-  return Parse::Many(buffer, output.flags, output.time);
+    return Parse::Many(buffer, output.flags, output.time);
 }
 
 bool Group4Var2::Write(const Group4Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.time);
+    return Format::Many(buffer, arg.flags, arg.time);
 }
 
 bool Group4Var2::ReadTarget(RSlice& buff, DoubleBitBinary& output)
 {
-  Group4Var2 value;
-  if(Read(buff, value))
-  {
-    output = DoubleBitBinaryFactory::From(value.flags, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group4Var2 value;
+    if (Read(buff, value))
+    {
+        output = DoubleBitBinaryFactory::From(value.flags, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group4Var2::WriteTarget(const DoubleBitBinary& value, openpal::WSlice& buff)
 {
-  return Group4Var2::Write(ConvertGroup4Var2::Apply(value), buff);
+    return Group4Var2::Write(ConvertGroup4Var2::Apply(value), buff);
 }
 
 // ------- Group4Var3 -------
 
-Group4Var3::Group4Var3() : flags(0), time(0)
-{}
+Group4Var3::Group4Var3() : flags(0), time(0) {}
 
 bool Group4Var3::Read(RSlice& buffer, Group4Var3& output)
 {
-  return Parse::Many(buffer, output.flags, output.time);
+    return Parse::Many(buffer, output.flags, output.time);
 }
 
 bool Group4Var3::Write(const Group4Var3& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.time);
+    return Format::Many(buffer, arg.flags, arg.time);
 }
 
 bool Group4Var3::ReadTarget(RSlice& buff, DoubleBitBinary& output)
 {
-  Group4Var3 value;
-  if(Read(buff, value))
-  {
-    output = DoubleBitBinaryFactory::From(value.flags, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group4Var3 value;
+    if (Read(buff, value))
+    {
+        output = DoubleBitBinaryFactory::From(value.flags, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group4Var3::WriteTarget(const DoubleBitBinary& value, openpal::WSlice& buff)
 {
-  return Group4Var3::Write(ConvertGroup4Var3::Apply(value), buff);
+    return Group4Var3::Write(ConvertGroup4Var3::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group4.h
+++ b/cpp/libs/src/opendnp3/objects/Group4.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,84 +32,115 @@
 #ifndef OPENDNP3_GROUP4_H
 #define OPENDNP3_GROUP4_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Double-bit Binary Input Event - Any Variation
 struct Group4Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(4,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(4, 0);
+    }
 };
 
 // Double-bit Binary Input Event - Without Time
 struct Group4Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(4,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(4, 1);
+    }
 
-  Group4Var1();
+    Group4Var1();
 
-  static uint32_t Size() { return 1; }
-  static bool Read(openpal::RSlice&, Group4Var1&);
-  static bool Write(const Group4Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 1;
+    }
+    static bool Read(openpal::RSlice&, Group4Var1&);
+    static bool Write(const Group4Var1&, openpal::WSlice&);
 
-  uint8_t flags;
+    uint8_t flags;
 
-  typedef DoubleBitBinary Target;
-  typedef DoubleBitBinarySpec Spec;
-  static bool ReadTarget(openpal::RSlice&, DoubleBitBinary&);
-  static bool WriteTarget(const DoubleBitBinary&, openpal::WSlice&);
-  static DNP3Serializer<DoubleBitBinary> Inst() { return DNP3Serializer<DoubleBitBinary>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef DoubleBitBinary Target;
+    typedef DoubleBitBinarySpec Spec;
+    static bool ReadTarget(openpal::RSlice&, DoubleBitBinary&);
+    static bool WriteTarget(const DoubleBitBinary&, openpal::WSlice&);
+    static DNP3Serializer<DoubleBitBinary> Inst()
+    {
+        return DNP3Serializer<DoubleBitBinary>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Double-bit Binary Input Event - With Absolute Time
 struct Group4Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(4,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(4, 2);
+    }
 
-  Group4Var2();
+    Group4Var2();
 
-  static uint32_t Size() { return 7; }
-  static bool Read(openpal::RSlice&, Group4Var2&);
-  static bool Write(const Group4Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 7;
+    }
+    static bool Read(openpal::RSlice&, Group4Var2&);
+    static bool Write(const Group4Var2&, openpal::WSlice&);
 
-  uint8_t flags;
-  DNPTime time;
+    uint8_t flags;
+    DNPTime time;
 
-  typedef DoubleBitBinary Target;
-  typedef DoubleBitBinarySpec Spec;
-  static bool ReadTarget(openpal::RSlice&, DoubleBitBinary&);
-  static bool WriteTarget(const DoubleBitBinary&, openpal::WSlice&);
-  static DNP3Serializer<DoubleBitBinary> Inst() { return DNP3Serializer<DoubleBitBinary>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef DoubleBitBinary Target;
+    typedef DoubleBitBinarySpec Spec;
+    static bool ReadTarget(openpal::RSlice&, DoubleBitBinary&);
+    static bool WriteTarget(const DoubleBitBinary&, openpal::WSlice&);
+    static DNP3Serializer<DoubleBitBinary> Inst()
+    {
+        return DNP3Serializer<DoubleBitBinary>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Double-bit Binary Input Event - With Relative Time
 struct Group4Var3
 {
-  static GroupVariationID ID() { return GroupVariationID(4,3); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(4, 3);
+    }
 
-  Group4Var3();
+    Group4Var3();
 
-  static uint32_t Size() { return 3; }
-  static bool Read(openpal::RSlice&, Group4Var3&);
-  static bool Write(const Group4Var3&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 3;
+    }
+    static bool Read(openpal::RSlice&, Group4Var3&);
+    static bool Write(const Group4Var3&, openpal::WSlice&);
 
-  uint8_t flags;
-  uint16_t time;
+    uint8_t flags;
+    uint16_t time;
 
-  typedef DoubleBitBinary Target;
-  typedef DoubleBitBinarySpec Spec;
-  static bool ReadTarget(openpal::RSlice&, DoubleBitBinary&);
-  static bool WriteTarget(const DoubleBitBinary&, openpal::WSlice&);
-  static DNP3Serializer<DoubleBitBinary> Inst() { return DNP3Serializer<DoubleBitBinary>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef DoubleBitBinary Target;
+    typedef DoubleBitBinarySpec Spec;
+    static bool ReadTarget(openpal::RSlice&, DoubleBitBinary&);
+    static bool WriteTarget(const DoubleBitBinary&, openpal::WSlice&);
+    static DNP3Serializer<DoubleBitBinary> Inst()
+    {
+        return DNP3Serializer<DoubleBitBinary>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group40.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group40.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,148 +33,145 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group40Var1 -------
 
-Group40Var1::Group40Var1() : flags(0), value(0)
-{}
+Group40Var1::Group40Var1() : flags(0), value(0) {}
 
 bool Group40Var1::Read(RSlice& buffer, Group40Var1& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group40Var1::Write(const Group40Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group40Var1::ReadTarget(RSlice& buff, AnalogOutputStatus& output)
 {
-  Group40Var1 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputStatusFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group40Var1 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputStatusFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group40Var1::WriteTarget(const AnalogOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group40Var1::Write(ConvertGroup40Var1::Apply(value), buff);
+    return Group40Var1::Write(ConvertGroup40Var1::Apply(value), buff);
 }
 
 // ------- Group40Var2 -------
 
-Group40Var2::Group40Var2() : flags(0), value(0)
-{}
+Group40Var2::Group40Var2() : flags(0), value(0) {}
 
 bool Group40Var2::Read(RSlice& buffer, Group40Var2& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group40Var2::Write(const Group40Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group40Var2::ReadTarget(RSlice& buff, AnalogOutputStatus& output)
 {
-  Group40Var2 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputStatusFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group40Var2 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputStatusFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group40Var2::WriteTarget(const AnalogOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group40Var2::Write(ConvertGroup40Var2::Apply(value), buff);
+    return Group40Var2::Write(ConvertGroup40Var2::Apply(value), buff);
 }
 
 // ------- Group40Var3 -------
 
-Group40Var3::Group40Var3() : flags(0), value(0.0)
-{}
+Group40Var3::Group40Var3() : flags(0), value(0.0) {}
 
 bool Group40Var3::Read(RSlice& buffer, Group40Var3& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group40Var3::Write(const Group40Var3& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group40Var3::ReadTarget(RSlice& buff, AnalogOutputStatus& output)
 {
-  Group40Var3 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputStatusFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group40Var3 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputStatusFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group40Var3::WriteTarget(const AnalogOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group40Var3::Write(ConvertGroup40Var3::Apply(value), buff);
+    return Group40Var3::Write(ConvertGroup40Var3::Apply(value), buff);
 }
 
 // ------- Group40Var4 -------
 
-Group40Var4::Group40Var4() : flags(0), value(0.0)
-{}
+Group40Var4::Group40Var4() : flags(0), value(0.0) {}
 
 bool Group40Var4::Read(RSlice& buffer, Group40Var4& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group40Var4::Write(const Group40Var4& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group40Var4::ReadTarget(RSlice& buff, AnalogOutputStatus& output)
 {
-  Group40Var4 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputStatusFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group40Var4 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputStatusFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group40Var4::WriteTarget(const AnalogOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group40Var4::Write(ConvertGroup40Var4::Apply(value), buff);
+    return Group40Var4::Write(ConvertGroup40Var4::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group40.h
+++ b/cpp/libs/src/opendnp3/objects/Group40.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,110 +32,150 @@
 #ifndef OPENDNP3_GROUP40_H
 #define OPENDNP3_GROUP40_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Analog Output Status - Any Variation
 struct Group40Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(40,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(40, 0);
+    }
 };
 
 // Analog Output Status - 32-bit With Flag
 struct Group40Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(40,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(40, 1);
+    }
 
-  Group40Var1();
+    Group40Var1();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group40Var1&);
-  static bool Write(const Group40Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group40Var1&);
+    static bool Write(const Group40Var1&, openpal::WSlice&);
 
-  typedef int32_t ValueType;
-  uint8_t flags;
-  int32_t value;
+    typedef int32_t ValueType;
+    uint8_t flags;
+    int32_t value;
 
-  typedef AnalogOutputStatus Target;
-  typedef AnalogOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
-  static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputStatus> Inst() { return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputStatus Target;
+    typedef AnalogOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
+    static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputStatus> Inst()
+    {
+        return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Output Status - 16-bit With Flag
 struct Group40Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(40,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(40, 2);
+    }
 
-  Group40Var2();
+    Group40Var2();
 
-  static uint32_t Size() { return 3; }
-  static bool Read(openpal::RSlice&, Group40Var2&);
-  static bool Write(const Group40Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 3;
+    }
+    static bool Read(openpal::RSlice&, Group40Var2&);
+    static bool Write(const Group40Var2&, openpal::WSlice&);
 
-  typedef int16_t ValueType;
-  uint8_t flags;
-  int16_t value;
+    typedef int16_t ValueType;
+    uint8_t flags;
+    int16_t value;
 
-  typedef AnalogOutputStatus Target;
-  typedef AnalogOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
-  static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputStatus> Inst() { return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputStatus Target;
+    typedef AnalogOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
+    static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputStatus> Inst()
+    {
+        return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Output Status - Single-precision With Flag
 struct Group40Var3
 {
-  static GroupVariationID ID() { return GroupVariationID(40,3); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(40, 3);
+    }
 
-  Group40Var3();
+    Group40Var3();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group40Var3&);
-  static bool Write(const Group40Var3&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group40Var3&);
+    static bool Write(const Group40Var3&, openpal::WSlice&);
 
-  typedef float ValueType;
-  uint8_t flags;
-  float value;
+    typedef float ValueType;
+    uint8_t flags;
+    float value;
 
-  typedef AnalogOutputStatus Target;
-  typedef AnalogOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
-  static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputStatus> Inst() { return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputStatus Target;
+    typedef AnalogOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
+    static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputStatus> Inst()
+    {
+        return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Output Status - Double-precision With Flag
 struct Group40Var4
 {
-  static GroupVariationID ID() { return GroupVariationID(40,4); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(40, 4);
+    }
 
-  Group40Var4();
+    Group40Var4();
 
-  static uint32_t Size() { return 9; }
-  static bool Read(openpal::RSlice&, Group40Var4&);
-  static bool Write(const Group40Var4&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 9;
+    }
+    static bool Read(openpal::RSlice&, Group40Var4&);
+    static bool Write(const Group40Var4&, openpal::WSlice&);
 
-  typedef double ValueType;
-  uint8_t flags;
-  double value;
+    typedef double ValueType;
+    uint8_t flags;
+    double value;
 
-  typedef AnalogOutputStatus Target;
-  typedef AnalogOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
-  static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputStatus> Inst() { return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputStatus Target;
+    typedef AnalogOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
+    static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputStatus> Inst()
+    {
+        return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group41.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group41.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,148 +33,145 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group41Var1 -------
 
-Group41Var1::Group41Var1() : value(0), status(0)
-{}
+Group41Var1::Group41Var1() : value(0), status(0) {}
 
 bool Group41Var1::Read(RSlice& buffer, Group41Var1& output)
 {
-  return Parse::Many(buffer, output.value, output.status);
+    return Parse::Many(buffer, output.value, output.status);
 }
 
 bool Group41Var1::Write(const Group41Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.value, arg.status);
+    return Format::Many(buffer, arg.value, arg.status);
 }
 
 bool Group41Var1::ReadTarget(RSlice& buff, AnalogOutputInt32& output)
 {
-  Group41Var1 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputInt32Factory::From(value.value, value.status);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group41Var1 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputInt32Factory::From(value.value, value.status);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group41Var1::WriteTarget(const AnalogOutputInt32& value, openpal::WSlice& buff)
 {
-  return Group41Var1::Write(ConvertGroup41Var1::Apply(value), buff);
+    return Group41Var1::Write(ConvertGroup41Var1::Apply(value), buff);
 }
 
 // ------- Group41Var2 -------
 
-Group41Var2::Group41Var2() : value(0), status(0)
-{}
+Group41Var2::Group41Var2() : value(0), status(0) {}
 
 bool Group41Var2::Read(RSlice& buffer, Group41Var2& output)
 {
-  return Parse::Many(buffer, output.value, output.status);
+    return Parse::Many(buffer, output.value, output.status);
 }
 
 bool Group41Var2::Write(const Group41Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.value, arg.status);
+    return Format::Many(buffer, arg.value, arg.status);
 }
 
 bool Group41Var2::ReadTarget(RSlice& buff, AnalogOutputInt16& output)
 {
-  Group41Var2 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputInt16Factory::From(value.value, value.status);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group41Var2 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputInt16Factory::From(value.value, value.status);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group41Var2::WriteTarget(const AnalogOutputInt16& value, openpal::WSlice& buff)
 {
-  return Group41Var2::Write(ConvertGroup41Var2::Apply(value), buff);
+    return Group41Var2::Write(ConvertGroup41Var2::Apply(value), buff);
 }
 
 // ------- Group41Var3 -------
 
-Group41Var3::Group41Var3() : value(0.0), status(0)
-{}
+Group41Var3::Group41Var3() : value(0.0), status(0) {}
 
 bool Group41Var3::Read(RSlice& buffer, Group41Var3& output)
 {
-  return Parse::Many(buffer, output.value, output.status);
+    return Parse::Many(buffer, output.value, output.status);
 }
 
 bool Group41Var3::Write(const Group41Var3& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.value, arg.status);
+    return Format::Many(buffer, arg.value, arg.status);
 }
 
 bool Group41Var3::ReadTarget(RSlice& buff, AnalogOutputFloat32& output)
 {
-  Group41Var3 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputFloat32Factory::From(value.value, value.status);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group41Var3 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputFloat32Factory::From(value.value, value.status);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group41Var3::WriteTarget(const AnalogOutputFloat32& value, openpal::WSlice& buff)
 {
-  return Group41Var3::Write(ConvertGroup41Var3::Apply(value), buff);
+    return Group41Var3::Write(ConvertGroup41Var3::Apply(value), buff);
 }
 
 // ------- Group41Var4 -------
 
-Group41Var4::Group41Var4() : value(0.0), status(0)
-{}
+Group41Var4::Group41Var4() : value(0.0), status(0) {}
 
 bool Group41Var4::Read(RSlice& buffer, Group41Var4& output)
 {
-  return Parse::Many(buffer, output.value, output.status);
+    return Parse::Many(buffer, output.value, output.status);
 }
 
 bool Group41Var4::Write(const Group41Var4& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.value, arg.status);
+    return Format::Many(buffer, arg.value, arg.status);
 }
 
 bool Group41Var4::ReadTarget(RSlice& buff, AnalogOutputDouble64& output)
 {
-  Group41Var4 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputDouble64Factory::From(value.value, value.status);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group41Var4 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputDouble64Factory::From(value.value, value.status);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group41Var4::WriteTarget(const AnalogOutputDouble64& value, openpal::WSlice& buff)
 {
-  return Group41Var4::Write(ConvertGroup41Var4::Apply(value), buff);
+    return Group41Var4::Write(ConvertGroup41Var4::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group41.h
+++ b/cpp/libs/src/opendnp3/objects/Group41.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,106 +32,146 @@
 #ifndef OPENDNP3_GROUP41_H
 #define OPENDNP3_GROUP41_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
-#include "opendnp3/app/DNP3Serializer.h"
-#include "opendnp3/app/AnalogOutput.h"
 
-namespace opendnp3 {
+#include "opendnp3/app/AnalogOutput.h"
+#include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
+
+namespace opendnp3
+{
 
 // Analog Output - Any Variation
 struct Group41Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(41,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(41, 0);
+    }
 };
 
 // Analog Output - 32-bit With Flag
 struct Group41Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(41,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(41, 1);
+    }
 
-  Group41Var1();
+    Group41Var1();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group41Var1&);
-  static bool Write(const Group41Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group41Var1&);
+    static bool Write(const Group41Var1&, openpal::WSlice&);
 
-  typedef int32_t ValueType;
-  int32_t value;
-  uint8_t status;
+    typedef int32_t ValueType;
+    int32_t value;
+    uint8_t status;
 
-  typedef AnalogOutputInt32 Target;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputInt32&);
-  static bool WriteTarget(const AnalogOutputInt32&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputInt32> Inst() { return DNP3Serializer<AnalogOutputInt32>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputInt32 Target;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputInt32&);
+    static bool WriteTarget(const AnalogOutputInt32&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputInt32> Inst()
+    {
+        return DNP3Serializer<AnalogOutputInt32>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Output - 16-bit With Flag
 struct Group41Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(41,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(41, 2);
+    }
 
-  Group41Var2();
+    Group41Var2();
 
-  static uint32_t Size() { return 3; }
-  static bool Read(openpal::RSlice&, Group41Var2&);
-  static bool Write(const Group41Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 3;
+    }
+    static bool Read(openpal::RSlice&, Group41Var2&);
+    static bool Write(const Group41Var2&, openpal::WSlice&);
 
-  typedef int16_t ValueType;
-  int16_t value;
-  uint8_t status;
+    typedef int16_t ValueType;
+    int16_t value;
+    uint8_t status;
 
-  typedef AnalogOutputInt16 Target;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputInt16&);
-  static bool WriteTarget(const AnalogOutputInt16&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputInt16> Inst() { return DNP3Serializer<AnalogOutputInt16>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputInt16 Target;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputInt16&);
+    static bool WriteTarget(const AnalogOutputInt16&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputInt16> Inst()
+    {
+        return DNP3Serializer<AnalogOutputInt16>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Output - Single-precision
 struct Group41Var3
 {
-  static GroupVariationID ID() { return GroupVariationID(41,3); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(41, 3);
+    }
 
-  Group41Var3();
+    Group41Var3();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group41Var3&);
-  static bool Write(const Group41Var3&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group41Var3&);
+    static bool Write(const Group41Var3&, openpal::WSlice&);
 
-  typedef float ValueType;
-  float value;
-  uint8_t status;
+    typedef float ValueType;
+    float value;
+    uint8_t status;
 
-  typedef AnalogOutputFloat32 Target;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputFloat32&);
-  static bool WriteTarget(const AnalogOutputFloat32&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputFloat32> Inst() { return DNP3Serializer<AnalogOutputFloat32>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputFloat32 Target;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputFloat32&);
+    static bool WriteTarget(const AnalogOutputFloat32&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputFloat32> Inst()
+    {
+        return DNP3Serializer<AnalogOutputFloat32>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Output - Double-precision
 struct Group41Var4
 {
-  static GroupVariationID ID() { return GroupVariationID(41,4); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(41, 4);
+    }
 
-  Group41Var4();
+    Group41Var4();
 
-  static uint32_t Size() { return 9; }
-  static bool Read(openpal::RSlice&, Group41Var4&);
-  static bool Write(const Group41Var4&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 9;
+    }
+    static bool Read(openpal::RSlice&, Group41Var4&);
+    static bool Write(const Group41Var4&, openpal::WSlice&);
 
-  typedef double ValueType;
-  double value;
-  uint8_t status;
+    typedef double ValueType;
+    double value;
+    uint8_t status;
 
-  typedef AnalogOutputDouble64 Target;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputDouble64&);
-  static bool WriteTarget(const AnalogOutputDouble64&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputDouble64> Inst() { return DNP3Serializer<AnalogOutputDouble64>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputDouble64 Target;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputDouble64&);
+    static bool WriteTarget(const AnalogOutputDouble64&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputDouble64> Inst()
+    {
+        return DNP3Serializer<AnalogOutputDouble64>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group42.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group42.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,284 +33,277 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group42Var1 -------
 
-Group42Var1::Group42Var1() : flags(0), value(0)
-{}
+Group42Var1::Group42Var1() : flags(0), value(0) {}
 
 bool Group42Var1::Read(RSlice& buffer, Group42Var1& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group42Var1::Write(const Group42Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group42Var1::ReadTarget(RSlice& buff, AnalogOutputStatus& output)
 {
-  Group42Var1 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputStatusFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group42Var1 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputStatusFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group42Var1::WriteTarget(const AnalogOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group42Var1::Write(ConvertGroup42Var1::Apply(value), buff);
+    return Group42Var1::Write(ConvertGroup42Var1::Apply(value), buff);
 }
 
 // ------- Group42Var2 -------
 
-Group42Var2::Group42Var2() : flags(0), value(0)
-{}
+Group42Var2::Group42Var2() : flags(0), value(0) {}
 
 bool Group42Var2::Read(RSlice& buffer, Group42Var2& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group42Var2::Write(const Group42Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group42Var2::ReadTarget(RSlice& buff, AnalogOutputStatus& output)
 {
-  Group42Var2 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputStatusFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group42Var2 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputStatusFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group42Var2::WriteTarget(const AnalogOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group42Var2::Write(ConvertGroup42Var2::Apply(value), buff);
+    return Group42Var2::Write(ConvertGroup42Var2::Apply(value), buff);
 }
 
 // ------- Group42Var3 -------
 
-Group42Var3::Group42Var3() : flags(0), value(0), time(0)
-{}
+Group42Var3::Group42Var3() : flags(0), value(0), time(0) {}
 
 bool Group42Var3::Read(RSlice& buffer, Group42Var3& output)
 {
-  return Parse::Many(buffer, output.flags, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.value, output.time);
 }
 
 bool Group42Var3::Write(const Group42Var3& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.value, arg.time);
 }
 
 bool Group42Var3::ReadTarget(RSlice& buff, AnalogOutputStatus& output)
 {
-  Group42Var3 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputStatusFactory::From(value.flags, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group42Var3 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputStatusFactory::From(value.flags, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group42Var3::WriteTarget(const AnalogOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group42Var3::Write(ConvertGroup42Var3::Apply(value), buff);
+    return Group42Var3::Write(ConvertGroup42Var3::Apply(value), buff);
 }
 
 // ------- Group42Var4 -------
 
-Group42Var4::Group42Var4() : flags(0), value(0), time(0)
-{}
+Group42Var4::Group42Var4() : flags(0), value(0), time(0) {}
 
 bool Group42Var4::Read(RSlice& buffer, Group42Var4& output)
 {
-  return Parse::Many(buffer, output.flags, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.value, output.time);
 }
 
 bool Group42Var4::Write(const Group42Var4& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.value, arg.time);
 }
 
 bool Group42Var4::ReadTarget(RSlice& buff, AnalogOutputStatus& output)
 {
-  Group42Var4 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputStatusFactory::From(value.flags, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group42Var4 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputStatusFactory::From(value.flags, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group42Var4::WriteTarget(const AnalogOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group42Var4::Write(ConvertGroup42Var4::Apply(value), buff);
+    return Group42Var4::Write(ConvertGroup42Var4::Apply(value), buff);
 }
 
 // ------- Group42Var5 -------
 
-Group42Var5::Group42Var5() : flags(0), value(0.0)
-{}
+Group42Var5::Group42Var5() : flags(0), value(0.0) {}
 
 bool Group42Var5::Read(RSlice& buffer, Group42Var5& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group42Var5::Write(const Group42Var5& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group42Var5::ReadTarget(RSlice& buff, AnalogOutputStatus& output)
 {
-  Group42Var5 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputStatusFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group42Var5 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputStatusFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group42Var5::WriteTarget(const AnalogOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group42Var5::Write(ConvertGroup42Var5::Apply(value), buff);
+    return Group42Var5::Write(ConvertGroup42Var5::Apply(value), buff);
 }
 
 // ------- Group42Var6 -------
 
-Group42Var6::Group42Var6() : flags(0), value(0.0)
-{}
+Group42Var6::Group42Var6() : flags(0), value(0.0) {}
 
 bool Group42Var6::Read(RSlice& buffer, Group42Var6& output)
 {
-  return Parse::Many(buffer, output.flags, output.value);
+    return Parse::Many(buffer, output.flags, output.value);
 }
 
 bool Group42Var6::Write(const Group42Var6& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value);
+    return Format::Many(buffer, arg.flags, arg.value);
 }
 
 bool Group42Var6::ReadTarget(RSlice& buff, AnalogOutputStatus& output)
 {
-  Group42Var6 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputStatusFactory::From(value.flags, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group42Var6 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputStatusFactory::From(value.flags, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group42Var6::WriteTarget(const AnalogOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group42Var6::Write(ConvertGroup42Var6::Apply(value), buff);
+    return Group42Var6::Write(ConvertGroup42Var6::Apply(value), buff);
 }
 
 // ------- Group42Var7 -------
 
-Group42Var7::Group42Var7() : flags(0), value(0.0), time(0)
-{}
+Group42Var7::Group42Var7() : flags(0), value(0.0), time(0) {}
 
 bool Group42Var7::Read(RSlice& buffer, Group42Var7& output)
 {
-  return Parse::Many(buffer, output.flags, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.value, output.time);
 }
 
 bool Group42Var7::Write(const Group42Var7& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.value, arg.time);
 }
 
 bool Group42Var7::ReadTarget(RSlice& buff, AnalogOutputStatus& output)
 {
-  Group42Var7 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputStatusFactory::From(value.flags, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group42Var7 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputStatusFactory::From(value.flags, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group42Var7::WriteTarget(const AnalogOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group42Var7::Write(ConvertGroup42Var7::Apply(value), buff);
+    return Group42Var7::Write(ConvertGroup42Var7::Apply(value), buff);
 }
 
 // ------- Group42Var8 -------
 
-Group42Var8::Group42Var8() : flags(0), value(0.0), time(0)
-{}
+Group42Var8::Group42Var8() : flags(0), value(0.0), time(0) {}
 
 bool Group42Var8::Read(RSlice& buffer, Group42Var8& output)
 {
-  return Parse::Many(buffer, output.flags, output.value, output.time);
+    return Parse::Many(buffer, output.flags, output.value, output.time);
 }
 
 bool Group42Var8::Write(const Group42Var8& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.flags, arg.value, arg.time);
+    return Format::Many(buffer, arg.flags, arg.value, arg.time);
 }
 
 bool Group42Var8::ReadTarget(RSlice& buff, AnalogOutputStatus& output)
 {
-  Group42Var8 value;
-  if(Read(buff, value))
-  {
-    output = AnalogOutputStatusFactory::From(value.flags, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group42Var8 value;
+    if (Read(buff, value))
+    {
+        output = AnalogOutputStatusFactory::From(value.flags, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group42Var8::WriteTarget(const AnalogOutputStatus& value, openpal::WSlice& buff)
 {
-  return Group42Var8::Write(ConvertGroup42Var8::Apply(value), buff);
+    return Group42Var8::Write(ConvertGroup42Var8::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group42.h
+++ b/cpp/libs/src/opendnp3/objects/Group42.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,202 +32,278 @@
 #ifndef OPENDNP3_GROUP42_H
 #define OPENDNP3_GROUP42_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Analog Output Event - Any Variation
 struct Group42Var0
 {
-  static GroupVariationID ID() { return GroupVariationID(42,0); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(42, 0);
+    }
 };
 
 // Analog Output Event - 32-bit With Flag
 struct Group42Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(42,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(42, 1);
+    }
 
-  Group42Var1();
+    Group42Var1();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group42Var1&);
-  static bool Write(const Group42Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group42Var1&);
+    static bool Write(const Group42Var1&, openpal::WSlice&);
 
-  typedef int32_t ValueType;
-  uint8_t flags;
-  int32_t value;
+    typedef int32_t ValueType;
+    uint8_t flags;
+    int32_t value;
 
-  typedef AnalogOutputStatus Target;
-  typedef AnalogOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
-  static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputStatus> Inst() { return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputStatus Target;
+    typedef AnalogOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
+    static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputStatus> Inst()
+    {
+        return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Output Event - 16-bit With Flag
 struct Group42Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(42,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(42, 2);
+    }
 
-  Group42Var2();
+    Group42Var2();
 
-  static uint32_t Size() { return 3; }
-  static bool Read(openpal::RSlice&, Group42Var2&);
-  static bool Write(const Group42Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 3;
+    }
+    static bool Read(openpal::RSlice&, Group42Var2&);
+    static bool Write(const Group42Var2&, openpal::WSlice&);
 
-  typedef int16_t ValueType;
-  uint8_t flags;
-  int16_t value;
+    typedef int16_t ValueType;
+    uint8_t flags;
+    int16_t value;
 
-  typedef AnalogOutputStatus Target;
-  typedef AnalogOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
-  static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputStatus> Inst() { return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputStatus Target;
+    typedef AnalogOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
+    static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputStatus> Inst()
+    {
+        return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Output Event - 32-bit With Flag and Time
 struct Group42Var3
 {
-  static GroupVariationID ID() { return GroupVariationID(42,3); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(42, 3);
+    }
 
-  Group42Var3();
+    Group42Var3();
 
-  static uint32_t Size() { return 11; }
-  static bool Read(openpal::RSlice&, Group42Var3&);
-  static bool Write(const Group42Var3&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 11;
+    }
+    static bool Read(openpal::RSlice&, Group42Var3&);
+    static bool Write(const Group42Var3&, openpal::WSlice&);
 
-  typedef int32_t ValueType;
-  uint8_t flags;
-  int32_t value;
-  DNPTime time;
+    typedef int32_t ValueType;
+    uint8_t flags;
+    int32_t value;
+    DNPTime time;
 
-  typedef AnalogOutputStatus Target;
-  typedef AnalogOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
-  static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputStatus> Inst() { return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputStatus Target;
+    typedef AnalogOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
+    static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputStatus> Inst()
+    {
+        return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Output Event - 16-bit With Flag and Time
 struct Group42Var4
 {
-  static GroupVariationID ID() { return GroupVariationID(42,4); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(42, 4);
+    }
 
-  Group42Var4();
+    Group42Var4();
 
-  static uint32_t Size() { return 9; }
-  static bool Read(openpal::RSlice&, Group42Var4&);
-  static bool Write(const Group42Var4&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 9;
+    }
+    static bool Read(openpal::RSlice&, Group42Var4&);
+    static bool Write(const Group42Var4&, openpal::WSlice&);
 
-  typedef int16_t ValueType;
-  uint8_t flags;
-  int16_t value;
-  DNPTime time;
+    typedef int16_t ValueType;
+    uint8_t flags;
+    int16_t value;
+    DNPTime time;
 
-  typedef AnalogOutputStatus Target;
-  typedef AnalogOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
-  static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputStatus> Inst() { return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputStatus Target;
+    typedef AnalogOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
+    static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputStatus> Inst()
+    {
+        return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Output Event - Single-precision With Flag
 struct Group42Var5
 {
-  static GroupVariationID ID() { return GroupVariationID(42,5); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(42, 5);
+    }
 
-  Group42Var5();
+    Group42Var5();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group42Var5&);
-  static bool Write(const Group42Var5&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group42Var5&);
+    static bool Write(const Group42Var5&, openpal::WSlice&);
 
-  typedef float ValueType;
-  uint8_t flags;
-  float value;
+    typedef float ValueType;
+    uint8_t flags;
+    float value;
 
-  typedef AnalogOutputStatus Target;
-  typedef AnalogOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
-  static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputStatus> Inst() { return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputStatus Target;
+    typedef AnalogOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
+    static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputStatus> Inst()
+    {
+        return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Output Event - Double-precision With Flag
 struct Group42Var6
 {
-  static GroupVariationID ID() { return GroupVariationID(42,6); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(42, 6);
+    }
 
-  Group42Var6();
+    Group42Var6();
 
-  static uint32_t Size() { return 9; }
-  static bool Read(openpal::RSlice&, Group42Var6&);
-  static bool Write(const Group42Var6&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 9;
+    }
+    static bool Read(openpal::RSlice&, Group42Var6&);
+    static bool Write(const Group42Var6&, openpal::WSlice&);
 
-  typedef double ValueType;
-  uint8_t flags;
-  double value;
+    typedef double ValueType;
+    uint8_t flags;
+    double value;
 
-  typedef AnalogOutputStatus Target;
-  typedef AnalogOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
-  static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputStatus> Inst() { return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputStatus Target;
+    typedef AnalogOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
+    static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputStatus> Inst()
+    {
+        return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Output Event - Single-precision With Flag and Time
 struct Group42Var7
 {
-  static GroupVariationID ID() { return GroupVariationID(42,7); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(42, 7);
+    }
 
-  Group42Var7();
+    Group42Var7();
 
-  static uint32_t Size() { return 11; }
-  static bool Read(openpal::RSlice&, Group42Var7&);
-  static bool Write(const Group42Var7&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 11;
+    }
+    static bool Read(openpal::RSlice&, Group42Var7&);
+    static bool Write(const Group42Var7&, openpal::WSlice&);
 
-  typedef float ValueType;
-  uint8_t flags;
-  float value;
-  DNPTime time;
+    typedef float ValueType;
+    uint8_t flags;
+    float value;
+    DNPTime time;
 
-  typedef AnalogOutputStatus Target;
-  typedef AnalogOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
-  static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputStatus> Inst() { return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputStatus Target;
+    typedef AnalogOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
+    static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputStatus> Inst()
+    {
+        return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Output Event - Double-precision With Flag and Time
 struct Group42Var8
 {
-  static GroupVariationID ID() { return GroupVariationID(42,8); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(42, 8);
+    }
 
-  Group42Var8();
+    Group42Var8();
 
-  static uint32_t Size() { return 15; }
-  static bool Read(openpal::RSlice&, Group42Var8&);
-  static bool Write(const Group42Var8&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 15;
+    }
+    static bool Read(openpal::RSlice&, Group42Var8&);
+    static bool Write(const Group42Var8&, openpal::WSlice&);
 
-  typedef double ValueType;
-  uint8_t flags;
-  double value;
-  DNPTime time;
+    typedef double ValueType;
+    uint8_t flags;
+    double value;
+    DNPTime time;
 
-  typedef AnalogOutputStatus Target;
-  typedef AnalogOutputStatusSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
-  static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
-  static DNP3Serializer<AnalogOutputStatus> Inst() { return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogOutputStatus Target;
+    typedef AnalogOutputStatusSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, AnalogOutputStatus&);
+    static bool WriteTarget(const AnalogOutputStatus&, openpal::WSlice&);
+    static DNP3Serializer<AnalogOutputStatus> Inst()
+    {
+        return DNP3Serializer<AnalogOutputStatus>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group43.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group43.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,284 +33,277 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group43Var1 -------
 
-Group43Var1::Group43Var1() : status(0), value(0)
-{}
+Group43Var1::Group43Var1() : status(0), value(0) {}
 
 bool Group43Var1::Read(RSlice& buffer, Group43Var1& output)
 {
-  return Parse::Many(buffer, output.status, output.value);
+    return Parse::Many(buffer, output.status, output.value);
 }
 
 bool Group43Var1::Write(const Group43Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.status, arg.value);
+    return Format::Many(buffer, arg.status, arg.value);
 }
 
 bool Group43Var1::ReadTarget(RSlice& buff, AnalogCommandEvent& output)
 {
-  Group43Var1 value;
-  if(Read(buff, value))
-  {
-    output = AnalogCommandEventFactory::From(value.status, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group43Var1 value;
+    if (Read(buff, value))
+    {
+        output = AnalogCommandEventFactory::From(value.status, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group43Var1::WriteTarget(const AnalogCommandEvent& value, openpal::WSlice& buff)
 {
-  return Group43Var1::Write(ConvertGroup43Var1::Apply(value), buff);
+    return Group43Var1::Write(ConvertGroup43Var1::Apply(value), buff);
 }
 
 // ------- Group43Var2 -------
 
-Group43Var2::Group43Var2() : status(0), value(0)
-{}
+Group43Var2::Group43Var2() : status(0), value(0) {}
 
 bool Group43Var2::Read(RSlice& buffer, Group43Var2& output)
 {
-  return Parse::Many(buffer, output.status, output.value);
+    return Parse::Many(buffer, output.status, output.value);
 }
 
 bool Group43Var2::Write(const Group43Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.status, arg.value);
+    return Format::Many(buffer, arg.status, arg.value);
 }
 
 bool Group43Var2::ReadTarget(RSlice& buff, AnalogCommandEvent& output)
 {
-  Group43Var2 value;
-  if(Read(buff, value))
-  {
-    output = AnalogCommandEventFactory::From(value.status, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group43Var2 value;
+    if (Read(buff, value))
+    {
+        output = AnalogCommandEventFactory::From(value.status, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group43Var2::WriteTarget(const AnalogCommandEvent& value, openpal::WSlice& buff)
 {
-  return Group43Var2::Write(ConvertGroup43Var2::Apply(value), buff);
+    return Group43Var2::Write(ConvertGroup43Var2::Apply(value), buff);
 }
 
 // ------- Group43Var3 -------
 
-Group43Var3::Group43Var3() : status(0), value(0), time(0)
-{}
+Group43Var3::Group43Var3() : status(0), value(0), time(0) {}
 
 bool Group43Var3::Read(RSlice& buffer, Group43Var3& output)
 {
-  return Parse::Many(buffer, output.status, output.value, output.time);
+    return Parse::Many(buffer, output.status, output.value, output.time);
 }
 
 bool Group43Var3::Write(const Group43Var3& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.status, arg.value, arg.time);
+    return Format::Many(buffer, arg.status, arg.value, arg.time);
 }
 
 bool Group43Var3::ReadTarget(RSlice& buff, AnalogCommandEvent& output)
 {
-  Group43Var3 value;
-  if(Read(buff, value))
-  {
-    output = AnalogCommandEventFactory::From(value.status, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group43Var3 value;
+    if (Read(buff, value))
+    {
+        output = AnalogCommandEventFactory::From(value.status, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group43Var3::WriteTarget(const AnalogCommandEvent& value, openpal::WSlice& buff)
 {
-  return Group43Var3::Write(ConvertGroup43Var3::Apply(value), buff);
+    return Group43Var3::Write(ConvertGroup43Var3::Apply(value), buff);
 }
 
 // ------- Group43Var4 -------
 
-Group43Var4::Group43Var4() : status(0), value(0), time(0)
-{}
+Group43Var4::Group43Var4() : status(0), value(0), time(0) {}
 
 bool Group43Var4::Read(RSlice& buffer, Group43Var4& output)
 {
-  return Parse::Many(buffer, output.status, output.value, output.time);
+    return Parse::Many(buffer, output.status, output.value, output.time);
 }
 
 bool Group43Var4::Write(const Group43Var4& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.status, arg.value, arg.time);
+    return Format::Many(buffer, arg.status, arg.value, arg.time);
 }
 
 bool Group43Var4::ReadTarget(RSlice& buff, AnalogCommandEvent& output)
 {
-  Group43Var4 value;
-  if(Read(buff, value))
-  {
-    output = AnalogCommandEventFactory::From(value.status, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group43Var4 value;
+    if (Read(buff, value))
+    {
+        output = AnalogCommandEventFactory::From(value.status, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group43Var4::WriteTarget(const AnalogCommandEvent& value, openpal::WSlice& buff)
 {
-  return Group43Var4::Write(ConvertGroup43Var4::Apply(value), buff);
+    return Group43Var4::Write(ConvertGroup43Var4::Apply(value), buff);
 }
 
 // ------- Group43Var5 -------
 
-Group43Var5::Group43Var5() : status(0), value(0.0)
-{}
+Group43Var5::Group43Var5() : status(0), value(0.0) {}
 
 bool Group43Var5::Read(RSlice& buffer, Group43Var5& output)
 {
-  return Parse::Many(buffer, output.status, output.value);
+    return Parse::Many(buffer, output.status, output.value);
 }
 
 bool Group43Var5::Write(const Group43Var5& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.status, arg.value);
+    return Format::Many(buffer, arg.status, arg.value);
 }
 
 bool Group43Var5::ReadTarget(RSlice& buff, AnalogCommandEvent& output)
 {
-  Group43Var5 value;
-  if(Read(buff, value))
-  {
-    output = AnalogCommandEventFactory::From(value.status, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group43Var5 value;
+    if (Read(buff, value))
+    {
+        output = AnalogCommandEventFactory::From(value.status, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group43Var5::WriteTarget(const AnalogCommandEvent& value, openpal::WSlice& buff)
 {
-  return Group43Var5::Write(ConvertGroup43Var5::Apply(value), buff);
+    return Group43Var5::Write(ConvertGroup43Var5::Apply(value), buff);
 }
 
 // ------- Group43Var6 -------
 
-Group43Var6::Group43Var6() : status(0), value(0.0)
-{}
+Group43Var6::Group43Var6() : status(0), value(0.0) {}
 
 bool Group43Var6::Read(RSlice& buffer, Group43Var6& output)
 {
-  return Parse::Many(buffer, output.status, output.value);
+    return Parse::Many(buffer, output.status, output.value);
 }
 
 bool Group43Var6::Write(const Group43Var6& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.status, arg.value);
+    return Format::Many(buffer, arg.status, arg.value);
 }
 
 bool Group43Var6::ReadTarget(RSlice& buff, AnalogCommandEvent& output)
 {
-  Group43Var6 value;
-  if(Read(buff, value))
-  {
-    output = AnalogCommandEventFactory::From(value.status, value.value);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group43Var6 value;
+    if (Read(buff, value))
+    {
+        output = AnalogCommandEventFactory::From(value.status, value.value);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group43Var6::WriteTarget(const AnalogCommandEvent& value, openpal::WSlice& buff)
 {
-  return Group43Var6::Write(ConvertGroup43Var6::Apply(value), buff);
+    return Group43Var6::Write(ConvertGroup43Var6::Apply(value), buff);
 }
 
 // ------- Group43Var7 -------
 
-Group43Var7::Group43Var7() : status(0), value(0.0), time(0)
-{}
+Group43Var7::Group43Var7() : status(0), value(0.0), time(0) {}
 
 bool Group43Var7::Read(RSlice& buffer, Group43Var7& output)
 {
-  return Parse::Many(buffer, output.status, output.value, output.time);
+    return Parse::Many(buffer, output.status, output.value, output.time);
 }
 
 bool Group43Var7::Write(const Group43Var7& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.status, arg.value, arg.time);
+    return Format::Many(buffer, arg.status, arg.value, arg.time);
 }
 
 bool Group43Var7::ReadTarget(RSlice& buff, AnalogCommandEvent& output)
 {
-  Group43Var7 value;
-  if(Read(buff, value))
-  {
-    output = AnalogCommandEventFactory::From(value.status, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group43Var7 value;
+    if (Read(buff, value))
+    {
+        output = AnalogCommandEventFactory::From(value.status, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group43Var7::WriteTarget(const AnalogCommandEvent& value, openpal::WSlice& buff)
 {
-  return Group43Var7::Write(ConvertGroup43Var7::Apply(value), buff);
+    return Group43Var7::Write(ConvertGroup43Var7::Apply(value), buff);
 }
 
 // ------- Group43Var8 -------
 
-Group43Var8::Group43Var8() : status(0), value(0.0), time(0)
-{}
+Group43Var8::Group43Var8() : status(0), value(0.0), time(0) {}
 
 bool Group43Var8::Read(RSlice& buffer, Group43Var8& output)
 {
-  return Parse::Many(buffer, output.status, output.value, output.time);
+    return Parse::Many(buffer, output.status, output.value, output.time);
 }
 
 bool Group43Var8::Write(const Group43Var8& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.status, arg.value, arg.time);
+    return Format::Many(buffer, arg.status, arg.value, arg.time);
 }
 
 bool Group43Var8::ReadTarget(RSlice& buff, AnalogCommandEvent& output)
 {
-  Group43Var8 value;
-  if(Read(buff, value))
-  {
-    output = AnalogCommandEventFactory::From(value.status, value.value, value.time);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group43Var8 value;
+    if (Read(buff, value))
+    {
+        output = AnalogCommandEventFactory::From(value.status, value.value, value.time);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group43Var8::WriteTarget(const AnalogCommandEvent& value, openpal::WSlice& buff)
 {
-  return Group43Var8::Write(ConvertGroup43Var8::Apply(value), buff);
+    return Group43Var8::Write(ConvertGroup43Var8::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group43.h
+++ b/cpp/libs/src/opendnp3/objects/Group43.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,188 +32,261 @@
 #ifndef OPENDNP3_GROUP43_H
 #define OPENDNP3_GROUP43_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
-#include "opendnp3/app/DNP3Serializer.h"
-#include "opendnp3/app/AnalogCommandEvent.h"
 
-namespace opendnp3 {
+#include "opendnp3/app/AnalogCommandEvent.h"
+#include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
+
+namespace opendnp3
+{
 
 // Analog Command Event - 32-bit
 struct Group43Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(43,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(43, 1);
+    }
 
-  Group43Var1();
+    Group43Var1();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group43Var1&);
-  static bool Write(const Group43Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group43Var1&);
+    static bool Write(const Group43Var1&, openpal::WSlice&);
 
-  typedef int32_t ValueType;
-  uint8_t status;
-  int32_t value;
+    typedef int32_t ValueType;
+    uint8_t status;
+    int32_t value;
 
-  typedef AnalogCommandEvent Target;
-  static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
-  static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
-  static DNP3Serializer<AnalogCommandEvent> Inst() { return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogCommandEvent Target;
+    static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
+    static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
+    static DNP3Serializer<AnalogCommandEvent> Inst()
+    {
+        return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Command Event - 16-bit
 struct Group43Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(43,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(43, 2);
+    }
 
-  Group43Var2();
+    Group43Var2();
 
-  static uint32_t Size() { return 3; }
-  static bool Read(openpal::RSlice&, Group43Var2&);
-  static bool Write(const Group43Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 3;
+    }
+    static bool Read(openpal::RSlice&, Group43Var2&);
+    static bool Write(const Group43Var2&, openpal::WSlice&);
 
-  typedef int16_t ValueType;
-  uint8_t status;
-  int16_t value;
+    typedef int16_t ValueType;
+    uint8_t status;
+    int16_t value;
 
-  typedef AnalogCommandEvent Target;
-  static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
-  static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
-  static DNP3Serializer<AnalogCommandEvent> Inst() { return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogCommandEvent Target;
+    static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
+    static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
+    static DNP3Serializer<AnalogCommandEvent> Inst()
+    {
+        return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Command Event - 32-bit With Time
 struct Group43Var3
 {
-  static GroupVariationID ID() { return GroupVariationID(43,3); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(43, 3);
+    }
 
-  Group43Var3();
+    Group43Var3();
 
-  static uint32_t Size() { return 11; }
-  static bool Read(openpal::RSlice&, Group43Var3&);
-  static bool Write(const Group43Var3&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 11;
+    }
+    static bool Read(openpal::RSlice&, Group43Var3&);
+    static bool Write(const Group43Var3&, openpal::WSlice&);
 
-  typedef int32_t ValueType;
-  uint8_t status;
-  int32_t value;
-  DNPTime time;
+    typedef int32_t ValueType;
+    uint8_t status;
+    int32_t value;
+    DNPTime time;
 
-  typedef AnalogCommandEvent Target;
-  static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
-  static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
-  static DNP3Serializer<AnalogCommandEvent> Inst() { return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogCommandEvent Target;
+    static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
+    static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
+    static DNP3Serializer<AnalogCommandEvent> Inst()
+    {
+        return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Command Event - 16-bit With Time
 struct Group43Var4
 {
-  static GroupVariationID ID() { return GroupVariationID(43,4); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(43, 4);
+    }
 
-  Group43Var4();
+    Group43Var4();
 
-  static uint32_t Size() { return 9; }
-  static bool Read(openpal::RSlice&, Group43Var4&);
-  static bool Write(const Group43Var4&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 9;
+    }
+    static bool Read(openpal::RSlice&, Group43Var4&);
+    static bool Write(const Group43Var4&, openpal::WSlice&);
 
-  typedef int16_t ValueType;
-  uint8_t status;
-  int16_t value;
-  DNPTime time;
+    typedef int16_t ValueType;
+    uint8_t status;
+    int16_t value;
+    DNPTime time;
 
-  typedef AnalogCommandEvent Target;
-  static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
-  static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
-  static DNP3Serializer<AnalogCommandEvent> Inst() { return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogCommandEvent Target;
+    static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
+    static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
+    static DNP3Serializer<AnalogCommandEvent> Inst()
+    {
+        return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Command Event - Single-precision
 struct Group43Var5
 {
-  static GroupVariationID ID() { return GroupVariationID(43,5); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(43, 5);
+    }
 
-  Group43Var5();
+    Group43Var5();
 
-  static uint32_t Size() { return 5; }
-  static bool Read(openpal::RSlice&, Group43Var5&);
-  static bool Write(const Group43Var5&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 5;
+    }
+    static bool Read(openpal::RSlice&, Group43Var5&);
+    static bool Write(const Group43Var5&, openpal::WSlice&);
 
-  typedef float ValueType;
-  uint8_t status;
-  float value;
+    typedef float ValueType;
+    uint8_t status;
+    float value;
 
-  typedef AnalogCommandEvent Target;
-  static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
-  static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
-  static DNP3Serializer<AnalogCommandEvent> Inst() { return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogCommandEvent Target;
+    static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
+    static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
+    static DNP3Serializer<AnalogCommandEvent> Inst()
+    {
+        return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Command Event - Double-precision
 struct Group43Var6
 {
-  static GroupVariationID ID() { return GroupVariationID(43,6); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(43, 6);
+    }
 
-  Group43Var6();
+    Group43Var6();
 
-  static uint32_t Size() { return 9; }
-  static bool Read(openpal::RSlice&, Group43Var6&);
-  static bool Write(const Group43Var6&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 9;
+    }
+    static bool Read(openpal::RSlice&, Group43Var6&);
+    static bool Write(const Group43Var6&, openpal::WSlice&);
 
-  typedef double ValueType;
-  uint8_t status;
-  double value;
+    typedef double ValueType;
+    uint8_t status;
+    double value;
 
-  typedef AnalogCommandEvent Target;
-  static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
-  static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
-  static DNP3Serializer<AnalogCommandEvent> Inst() { return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogCommandEvent Target;
+    static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
+    static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
+    static DNP3Serializer<AnalogCommandEvent> Inst()
+    {
+        return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Command Event - Single-precision With Time
 struct Group43Var7
 {
-  static GroupVariationID ID() { return GroupVariationID(43,7); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(43, 7);
+    }
 
-  Group43Var7();
+    Group43Var7();
 
-  static uint32_t Size() { return 11; }
-  static bool Read(openpal::RSlice&, Group43Var7&);
-  static bool Write(const Group43Var7&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 11;
+    }
+    static bool Read(openpal::RSlice&, Group43Var7&);
+    static bool Write(const Group43Var7&, openpal::WSlice&);
 
-  typedef float ValueType;
-  uint8_t status;
-  float value;
-  DNPTime time;
+    typedef float ValueType;
+    uint8_t status;
+    float value;
+    DNPTime time;
 
-  typedef AnalogCommandEvent Target;
-  static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
-  static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
-  static DNP3Serializer<AnalogCommandEvent> Inst() { return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogCommandEvent Target;
+    static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
+    static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
+    static DNP3Serializer<AnalogCommandEvent> Inst()
+    {
+        return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
 // Analog Command Event - Double-precision With Time
 struct Group43Var8
 {
-  static GroupVariationID ID() { return GroupVariationID(43,8); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(43, 8);
+    }
 
-  Group43Var8();
+    Group43Var8();
 
-  static uint32_t Size() { return 15; }
-  static bool Read(openpal::RSlice&, Group43Var8&);
-  static bool Write(const Group43Var8&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 15;
+    }
+    static bool Read(openpal::RSlice&, Group43Var8&);
+    static bool Write(const Group43Var8&, openpal::WSlice&);
 
-  typedef double ValueType;
-  uint8_t status;
-  double value;
-  DNPTime time;
+    typedef double ValueType;
+    uint8_t status;
+    double value;
+    DNPTime time;
 
-  typedef AnalogCommandEvent Target;
-  static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
-  static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
-  static DNP3Serializer<AnalogCommandEvent> Inst() { return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef AnalogCommandEvent Target;
+    static bool ReadTarget(openpal::RSlice&, AnalogCommandEvent&);
+    static bool WriteTarget(const AnalogCommandEvent&, openpal::WSlice&);
+    static DNP3Serializer<AnalogCommandEvent> Inst()
+    {
+        return DNP3Serializer<AnalogCommandEvent>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group50.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group50.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,76 +33,74 @@
 
 #include <openpal/serialization/Format.h>
 #include <openpal/serialization/Parse.h>
+
 #include "opendnp3/app/MeasurementFactory.h"
 #include "opendnp3/app/WriteConversions.h"
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group50Var1 -------
 
-Group50Var1::Group50Var1() : time(0)
-{}
+Group50Var1::Group50Var1() : time(0) {}
 
 bool Group50Var1::Read(RSlice& buffer, Group50Var1& output)
 {
-  return Parse::Many(buffer, output.time);
+    return Parse::Many(buffer, output.time);
 }
 
 bool Group50Var1::Write(const Group50Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.time);
+    return Format::Many(buffer, arg.time);
 }
 
 // ------- Group50Var3 -------
 
-Group50Var3::Group50Var3() : time(0)
-{}
+Group50Var3::Group50Var3() : time(0) {}
 
 bool Group50Var3::Read(RSlice& buffer, Group50Var3& output)
 {
-  return Parse::Many(buffer, output.time);
+    return Parse::Many(buffer, output.time);
 }
 
 bool Group50Var3::Write(const Group50Var3& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.time);
+    return Format::Many(buffer, arg.time);
 }
 
 // ------- Group50Var4 -------
 
-Group50Var4::Group50Var4() : time(0), interval(0), units(0)
-{}
+Group50Var4::Group50Var4() : time(0), interval(0), units(0) {}
 
 bool Group50Var4::Read(RSlice& buffer, Group50Var4& output)
 {
-  return Parse::Many(buffer, output.time, output.interval, output.units);
+    return Parse::Many(buffer, output.time, output.interval, output.units);
 }
 
 bool Group50Var4::Write(const Group50Var4& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.time, arg.interval, arg.units);
+    return Format::Many(buffer, arg.time, arg.interval, arg.units);
 }
 
 bool Group50Var4::ReadTarget(RSlice& buff, TimeAndInterval& output)
 {
-  Group50Var4 value;
-  if(Read(buff, value))
-  {
-    output = TimeAndIntervalFactory::From(value.time, value.interval, value.units);
-    return true;
-  }
-  else
-  {
-    return false;
-  }
+    Group50Var4 value;
+    if (Read(buff, value))
+    {
+        output = TimeAndIntervalFactory::From(value.time, value.interval, value.units);
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool Group50Var4::WriteTarget(const TimeAndInterval& value, openpal::WSlice& buff)
 {
-  return Group50Var4::Write(ConvertGroup50Var4::Apply(value), buff);
+    return Group50Var4::Write(ConvertGroup50Var4::Apply(value), buff);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group50.h
+++ b/cpp/libs/src/opendnp3/objects/Group50.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,66 +32,88 @@
 #ifndef OPENDNP3_GROUP50_H
 #define OPENDNP3_GROUP50_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
+
 #include "opendnp3/app/DNP3Serializer.h"
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
 #include "opendnp3/app/MeasurementTypeSpecs.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Time and Date - Absolute Time
 struct Group50Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(50,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(50, 1);
+    }
 
-  Group50Var1();
+    Group50Var1();
 
-  static uint32_t Size() { return 6; }
-  static bool Read(openpal::RSlice&, Group50Var1&);
-  static bool Write(const Group50Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 6;
+    }
+    static bool Read(openpal::RSlice&, Group50Var1&);
+    static bool Write(const Group50Var1&, openpal::WSlice&);
 
-  DNPTime time;
+    DNPTime time;
 };
 
 // Time and Date - Absolute Time at last recorded time
 struct Group50Var3
 {
-  static GroupVariationID ID() { return GroupVariationID(50,3); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(50, 3);
+    }
 
-  Group50Var3();
+    Group50Var3();
 
-  static uint32_t Size() { return 6; }
-  static bool Read(openpal::RSlice&, Group50Var3&);
-  static bool Write(const Group50Var3&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 6;
+    }
+    static bool Read(openpal::RSlice&, Group50Var3&);
+    static bool Write(const Group50Var3&, openpal::WSlice&);
 
-  DNPTime time;
+    DNPTime time;
 };
 
 // Time and Date - Indexed absolute time and long interval
 struct Group50Var4
 {
-  static GroupVariationID ID() { return GroupVariationID(50,4); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(50, 4);
+    }
 
-  Group50Var4();
+    Group50Var4();
 
-  static uint32_t Size() { return 11; }
-  static bool Read(openpal::RSlice&, Group50Var4&);
-  static bool Write(const Group50Var4&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 11;
+    }
+    static bool Read(openpal::RSlice&, Group50Var4&);
+    static bool Write(const Group50Var4&, openpal::WSlice&);
 
-  DNPTime time;
-  uint32_t interval;
-  uint8_t units;
+    DNPTime time;
+    uint32_t interval;
+    uint8_t units;
 
-  typedef TimeAndInterval Target;
-  typedef TimeAndIntervalSpec Spec;
-  static bool ReadTarget(openpal::RSlice&, TimeAndInterval&);
-  static bool WriteTarget(const TimeAndInterval&, openpal::WSlice&);
-  static DNP3Serializer<TimeAndInterval> Inst() { return DNP3Serializer<TimeAndInterval>(ID(), Size(), &ReadTarget, &WriteTarget); }
+    typedef TimeAndInterval Target;
+    typedef TimeAndIntervalSpec Spec;
+    static bool ReadTarget(openpal::RSlice&, TimeAndInterval&);
+    static bool WriteTarget(const TimeAndInterval&, openpal::WSlice&);
+    static DNP3Serializer<TimeAndInterval> Inst()
+    {
+        return DNP3Serializer<TimeAndInterval>(ID(), Size(), &ReadTarget, &WriteTarget);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group51.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group51.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,37 +36,35 @@
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group51Var1 -------
 
-Group51Var1::Group51Var1() : time(0)
-{}
+Group51Var1::Group51Var1() : time(0) {}
 
 bool Group51Var1::Read(RSlice& buffer, Group51Var1& output)
 {
-  return Parse::Many(buffer, output.time);
+    return Parse::Many(buffer, output.time);
 }
 
 bool Group51Var1::Write(const Group51Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.time);
+    return Format::Many(buffer, arg.time);
 }
 
 // ------- Group51Var2 -------
 
-Group51Var2::Group51Var2() : time(0)
-{}
+Group51Var2::Group51Var2() : time(0) {}
 
 bool Group51Var2::Read(RSlice& buffer, Group51Var2& output)
 {
-  return Parse::Many(buffer, output.time);
+    return Parse::Many(buffer, output.time);
 }
 
 bool Group51Var2::Write(const Group51Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.time);
+    return Format::Many(buffer, arg.time);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group51.h
+++ b/cpp/libs/src/opendnp3/objects/Group51.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,42 +32,55 @@
 #ifndef OPENDNP3_GROUP51_H
 #define OPENDNP3_GROUP51_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
 
-namespace opendnp3 {
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
+
+namespace opendnp3
+{
 
 // Time and Date CTO - Absolute time, synchronized
 struct Group51Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(51,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(51, 1);
+    }
 
-  Group51Var1();
+    Group51Var1();
 
-  static uint32_t Size() { return 6; }
-  static bool Read(openpal::RSlice&, Group51Var1&);
-  static bool Write(const Group51Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 6;
+    }
+    static bool Read(openpal::RSlice&, Group51Var1&);
+    static bool Write(const Group51Var1&, openpal::WSlice&);
 
-  DNPTime time;
+    DNPTime time;
 };
 
 // Time and Date CTO - Absolute time, unsynchronized
 struct Group51Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(51,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(51, 2);
+    }
 
-  Group51Var2();
+    Group51Var2();
 
-  static uint32_t Size() { return 6; }
-  static bool Read(openpal::RSlice&, Group51Var2&);
-  static bool Write(const Group51Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 6;
+    }
+    static bool Read(openpal::RSlice&, Group51Var2&);
+    static bool Write(const Group51Var2&, openpal::WSlice&);
 
-  DNPTime time;
+    DNPTime time;
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group52.cpp
+++ b/cpp/libs/src/opendnp3/objects/Group52.cpp
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,37 +36,35 @@
 
 using namespace openpal;
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // ------- Group52Var1 -------
 
-Group52Var1::Group52Var1() : time(0)
-{}
+Group52Var1::Group52Var1() : time(0) {}
 
 bool Group52Var1::Read(RSlice& buffer, Group52Var1& output)
 {
-  return Parse::Many(buffer, output.time);
+    return Parse::Many(buffer, output.time);
 }
 
 bool Group52Var1::Write(const Group52Var1& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.time);
+    return Format::Many(buffer, arg.time);
 }
 
 // ------- Group52Var2 -------
 
-Group52Var2::Group52Var2() : time(0)
-{}
+Group52Var2::Group52Var2() : time(0) {}
 
 bool Group52Var2::Read(RSlice& buffer, Group52Var2& output)
 {
-  return Parse::Many(buffer, output.time);
+    return Parse::Many(buffer, output.time);
 }
 
 bool Group52Var2::Write(const Group52Var2& arg, openpal::WSlice& buffer)
 {
-  return Format::Many(buffer, arg.time);
+    return Format::Many(buffer, arg.time);
 }
 
-
-}
+} // namespace opendnp3

--- a/cpp/libs/src/opendnp3/objects/Group52.h
+++ b/cpp/libs/src/opendnp3/objects/Group52.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,42 +32,55 @@
 #ifndef OPENDNP3_GROUP52_H
 #define OPENDNP3_GROUP52_H
 
-#include "opendnp3/app/GroupVariationID.h"
 #include <openpal/container/RSlice.h>
 #include <openpal/container/WSlice.h>
-#include "opendnp3/app/DNPTime.h"
 
-namespace opendnp3 {
+#include "opendnp3/app/DNPTime.h"
+#include "opendnp3/app/GroupVariationID.h"
+
+namespace opendnp3
+{
 
 // Time Delay - Coarse
 struct Group52Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(52,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(52, 1);
+    }
 
-  Group52Var1();
+    Group52Var1();
 
-  static uint32_t Size() { return 2; }
-  static bool Read(openpal::RSlice&, Group52Var1&);
-  static bool Write(const Group52Var1&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 2;
+    }
+    static bool Read(openpal::RSlice&, Group52Var1&);
+    static bool Write(const Group52Var1&, openpal::WSlice&);
 
-  uint16_t time;
+    uint16_t time;
 };
 
 // Time Delay - Fine
 struct Group52Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(52,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(52, 2);
+    }
 
-  Group52Var2();
+    Group52Var2();
 
-  static uint32_t Size() { return 2; }
-  static bool Read(openpal::RSlice&, Group52Var2&);
-  static bool Write(const Group52Var2&, openpal::WSlice&);
+    static uint32_t Size()
+    {
+        return 2;
+    }
+    static bool Read(openpal::RSlice&, Group52Var2&);
+    static bool Write(const Group52Var2&, openpal::WSlice&);
 
-  uint16_t time;
+    uint16_t time;
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group60.h
+++ b/cpp/libs/src/opendnp3/objects/Group60.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,33 +34,45 @@
 
 #include "opendnp3/app/GroupVariationID.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Class Data - Class 0
 struct Group60Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(60,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(60, 1);
+    }
 };
 
 // Class Data - Class 1
 struct Group60Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(60,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(60, 2);
+    }
 };
 
 // Class Data - Class 2
 struct Group60Var3
 {
-  static GroupVariationID ID() { return GroupVariationID(60,3); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(60, 3);
+    }
 };
 
 // Class Data - Class 3
 struct Group60Var4
 {
-  static GroupVariationID ID() { return GroupVariationID(60,4); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(60, 4);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group70.h
+++ b/cpp/libs/src/opendnp3/objects/Group70.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,57 +34,81 @@
 
 #include "opendnp3/app/GroupVariationID.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // File-control - File identifier
 struct Group70Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(70,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(70, 1);
+    }
 };
 
 // File-control - Authentication
 struct Group70Var2
 {
-  static GroupVariationID ID() { return GroupVariationID(70,2); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(70, 2);
+    }
 };
 
 // File-control - File command
 struct Group70Var3
 {
-  static GroupVariationID ID() { return GroupVariationID(70,3); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(70, 3);
+    }
 };
 
 // File-control - File command status
 struct Group70Var4
 {
-  static GroupVariationID ID() { return GroupVariationID(70,4); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(70, 4);
+    }
 };
 
 // File-control - File transport
 struct Group70Var5
 {
-  static GroupVariationID ID() { return GroupVariationID(70,5); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(70, 5);
+    }
 };
 
 // File-control - File transport status
 struct Group70Var6
 {
-  static GroupVariationID ID() { return GroupVariationID(70,6); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(70, 6);
+    }
 };
 
 // File-control - File descriptor
 struct Group70Var7
 {
-  static GroupVariationID ID() { return GroupVariationID(70,7); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(70, 7);
+    }
 };
 
 // File-control - File specification string
 struct Group70Var8
 {
-  static GroupVariationID ID() { return GroupVariationID(70,8); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(70, 8);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/objects/Group80.h
+++ b/cpp/libs/src/opendnp3/objects/Group80.h
@@ -7,11 +7,11 @@
 // |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
 //                                           __/ |
 //                                          |___/
-// 
+//
 // This file is auto-generated. Do not edit manually
-// 
+//
 // Copyright 2013-2019 Automatak, LLC
-// 
+//
 // Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
 // LLC (www.automatak.com) under one or more contributor license agreements.
 // See the NOTICE file distributed with this work for additional information
@@ -19,9 +19,9 @@
 // this file to you under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License. You may obtain
 // a copy of the License at:
-// 
+//
 //   http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,15 +34,18 @@
 
 #include "opendnp3/app/GroupVariationID.h"
 
-namespace opendnp3 {
+namespace opendnp3
+{
 
 // Internal Indications - Packed Format
 struct Group80Var1
 {
-  static GroupVariationID ID() { return GroupVariationID(80,1); }
+    static GroupVariationID ID()
+    {
+        return GroupVariationID(80, 1);
+    }
 };
 
-
-}
+} // namespace opendnp3
 
 #endif

--- a/cpp/libs/src/opendnp3/outstation/ApplicationIIN.cpp
+++ b/cpp/libs/src/opendnp3/outstation/ApplicationIIN.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/AssignClassHandler.cpp
+++ b/cpp/libs/src/opendnp3/outstation/AssignClassHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -97,17 +97,15 @@ IINField AssignClassHandler::ProcessHeader(const RangeHeader& header)
 
 bool AssignClassHandler::IsExpectingAssignment()
 {
-    int32_t current = static_cast<int32_t>(this->GetCurrentHeader());
+    auto current = static_cast<int32_t>(this->GetCurrentHeader());
 
     if (current > 0 && ((current - 1) == this->classHeader))
     {
         this->classHeader = -1;
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 IINField AssignClassHandler::ProcessAssignRange(AssignClassType type, PointClass clazz, const Range& range)
@@ -131,7 +129,7 @@ IINField AssignClassHandler::ProcessAssignAll(AssignClassType type, PointClass c
 
 void AssignClassHandler::NotifyApplicationOfAssignment(AssignClassType type, PointClass clazz, const Range& range)
 {
-    if (range.IsValid() && pApplication)
+    if (range.IsValid() && (pApplication != nullptr))
     {
         auto pApplication = this->pApplication;
         auto callback = [pApplication, range, clazz, type]() {

--- a/cpp/libs/src/opendnp3/outstation/AssignClassHandler.h
+++ b/cpp/libs/src/opendnp3/outstation/AssignClassHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/ClassBasedRequestHandler.cpp
+++ b/cpp/libs/src/opendnp3/outstation/ClassBasedRequestHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/ClassBasedRequestHandler.h
+++ b/cpp/libs/src/opendnp3/outstation/ClassBasedRequestHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/CommandActionAdapter.cpp
+++ b/cpp/libs/src/opendnp3/outstation/CommandActionAdapter.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/CommandActionAdapter.h
+++ b/cpp/libs/src/opendnp3/outstation/CommandActionAdapter.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/CommandResponseHandler.cpp
+++ b/cpp/libs/src/opendnp3/outstation/CommandResponseHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -34,7 +34,7 @@ CommandResponseHandler::CommandResponseHandler(uint8_t maxCommands_,
 {
 }
 
-bool CommandResponseHandler::IsAllowed(uint32_t headerCount, GroupVariation gv, QualifierCode qc)
+bool CommandResponseHandler::IsAllowed(uint32_t /*headerCount*/, GroupVariation gv, QualifierCode qc)
 {
     if (!(qc == QualifierCode::UINT8_CNT_UINT8_INDEX || qc == QualifierCode::UINT16_CNT_UINT16_INDEX))
     {
@@ -84,70 +84,70 @@ IINField CommandResponseHandler::ProcessHeader(const PrefixHeader& header,
     return this->ProcessAny(header, meas);
 }
 
-IINField CommandResponseHandler::ProcessIndexPrefixTwoByte(const HeaderRecord&,
+IINField CommandResponseHandler::ProcessIndexPrefixTwoByte(const HeaderRecord& /*unused*/,
                                                            const ICollection<Indexed<ControlRelayOutputBlock>>& meas)
 {
     return this->RespondToHeader<ControlRelayOutputBlock, openpal::UInt16>(QualifierCode::UINT16_CNT_UINT16_INDEX,
                                                                            Group12Var1::Inst(), meas);
 }
 
-IINField CommandResponseHandler::ProcessIndexPrefixTwoByte(const HeaderRecord&,
+IINField CommandResponseHandler::ProcessIndexPrefixTwoByte(const HeaderRecord& /*unused*/,
                                                            const ICollection<Indexed<AnalogOutputInt16>>& meas)
 {
     return this->RespondToHeader<AnalogOutputInt16, openpal::UInt16>(QualifierCode::UINT16_CNT_UINT16_INDEX,
                                                                      Group41Var2::Inst(), meas);
 }
 
-IINField CommandResponseHandler::ProcessIndexPrefixTwoByte(const HeaderRecord&,
+IINField CommandResponseHandler::ProcessIndexPrefixTwoByte(const HeaderRecord& /*unused*/,
                                                            const ICollection<Indexed<AnalogOutputInt32>>& meas)
 {
     return this->RespondToHeader<AnalogOutputInt32, openpal::UInt16>(QualifierCode::UINT16_CNT_UINT16_INDEX,
                                                                      Group41Var1::Inst(), meas);
 }
 
-IINField CommandResponseHandler::ProcessIndexPrefixTwoByte(const HeaderRecord&,
+IINField CommandResponseHandler::ProcessIndexPrefixTwoByte(const HeaderRecord& /*unused*/,
                                                            const ICollection<Indexed<AnalogOutputFloat32>>& meas)
 {
     return this->RespondToHeader<AnalogOutputFloat32, openpal::UInt16>(QualifierCode::UINT16_CNT_UINT16_INDEX,
                                                                        Group41Var3::Inst(), meas);
 }
 
-IINField CommandResponseHandler::ProcessIndexPrefixTwoByte(const HeaderRecord&,
+IINField CommandResponseHandler::ProcessIndexPrefixTwoByte(const HeaderRecord& /*unused*/,
                                                            const ICollection<Indexed<AnalogOutputDouble64>>& meas)
 {
     return this->RespondToHeader<AnalogOutputDouble64, openpal::UInt16>(QualifierCode::UINT16_CNT_UINT16_INDEX,
                                                                         Group41Var4::Inst(), meas);
 }
 
-IINField CommandResponseHandler::ProcessIndexPrefixOneByte(const HeaderRecord&,
+IINField CommandResponseHandler::ProcessIndexPrefixOneByte(const HeaderRecord& /*unused*/,
                                                            const ICollection<Indexed<ControlRelayOutputBlock>>& meas)
 {
     return this->RespondToHeader<ControlRelayOutputBlock, openpal::UInt8>(QualifierCode::UINT8_CNT_UINT8_INDEX,
                                                                           Group12Var1::Inst(), meas);
 }
 
-IINField CommandResponseHandler::ProcessIndexPrefixOneByte(const HeaderRecord&,
+IINField CommandResponseHandler::ProcessIndexPrefixOneByte(const HeaderRecord& /*unused*/,
                                                            const ICollection<Indexed<AnalogOutputInt16>>& meas)
 {
     return this->RespondToHeader<AnalogOutputInt16, openpal::UInt8>(QualifierCode::UINT8_CNT_UINT8_INDEX,
                                                                     Group41Var2::Inst(), meas);
 }
 
-IINField CommandResponseHandler::ProcessIndexPrefixOneByte(const HeaderRecord&,
+IINField CommandResponseHandler::ProcessIndexPrefixOneByte(const HeaderRecord& /*unused*/,
                                                            const ICollection<Indexed<AnalogOutputInt32>>& meas)
 {
     return this->RespondToHeader<AnalogOutputInt32, openpal::UInt8>(QualifierCode::UINT8_CNT_UINT8_INDEX,
                                                                     Group41Var1::Inst(), meas);
 }
 
-IINField CommandResponseHandler::ProcessIndexPrefixOneByte(const HeaderRecord&,
+IINField CommandResponseHandler::ProcessIndexPrefixOneByte(const HeaderRecord& /*unused*/,
                                                            const ICollection<Indexed<AnalogOutputFloat32>>& meas)
 {
     return this->RespondToHeader<AnalogOutputFloat32, openpal::UInt8>(QualifierCode::UINT8_CNT_UINT8_INDEX,
                                                                       Group41Var3::Inst(), meas);
 }
 
-IINField CommandResponseHandler::ProcessIndexPrefixOneByte(const HeaderRecord&,
+IINField CommandResponseHandler::ProcessIndexPrefixOneByte(const HeaderRecord& /*unused*/,
                                                            const ICollection<Indexed<AnalogOutputDouble64>>& meas)
 {
     return this->RespondToHeader<AnalogOutputDouble64, openpal::UInt8>(QualifierCode::UINT8_CNT_UINT8_INDEX,

--- a/cpp/libs/src/opendnp3/outstation/CommandResponseHandler.h
+++ b/cpp/libs/src/opendnp3/outstation/CommandResponseHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/ConstantCommandAction.h
+++ b/cpp/libs/src/opendnp3/outstation/ConstantCommandAction.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/ControlState.h
+++ b/cpp/libs/src/opendnp3/outstation/ControlState.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/Database.cpp
+++ b/cpp/libs/src/opendnp3/outstation/Database.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -21,7 +21,7 @@
 
 #include <openpal/logging/LogMacros.h>
 
-#include <assert.h>
+#include <cassert>
 
 using namespace openpal;
 
@@ -86,10 +86,8 @@ bool Database::Update(const TimeAndInterval& value, uint16_t index)
         view[rawIndex].value = value;
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 bool Database::Modify(FlagsType type, uint16_t start, uint16_t stop, uint8_t flags)
@@ -139,12 +137,10 @@ template<class Spec> uint16_t Database::GetRawIndex(uint16_t index)
     {
         return index;
     }
-    else
-    {
-        auto view = buffers.buffers.GetArrayView<Spec>();
-        auto result = IndexSearch::FindClosestRawIndex(view, index);
-        return result.match ? result.index : openpal::MaxValue<uint16_t>();
-    }
+
+    auto view = buffers.buffers.GetArrayView<Spec>();
+    auto result = IndexSearch::FindClosestRawIndex(view, index);
+    return result.match ? result.index : openpal::MaxValue<uint16_t>();
 }
 
 template<class Spec> bool Database::UpdateEvent(const typename Spec::meas_t& value, uint16_t index, EventMode mode)
@@ -158,10 +154,8 @@ template<class Spec> bool Database::UpdateEvent(const typename Spec::meas_t& val
         this->UpdateAny(view[rawIndex], value, mode);
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 template<class Spec> bool Database::UpdateAny(Cell<Spec>& cell, const typename Spec::meas_t& value, EventMode mode)
@@ -220,10 +214,8 @@ template<class Spec> bool Database::Modify(uint16_t start, uint16_t stop, uint8_
 
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 } // namespace opendnp3

--- a/cpp/libs/src/opendnp3/outstation/Database.h
+++ b/cpp/libs/src/opendnp3/outstation/Database.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -49,7 +49,7 @@ public:
     virtual bool Update(const FrozenCounter&, uint16_t, EventMode = EventMode::Detect) override;
     virtual bool Update(const BinaryOutputStatus&, uint16_t, EventMode = EventMode::Detect) override;
     virtual bool Update(const AnalogOutputStatus&, uint16_t, EventMode = EventMode::Detect) override;
-    virtual bool Update(const OctetString& meas, uint16_t index, EventMode mode = EventMode::Detect) override;
+    virtual bool Update(const OctetString& value, uint16_t index, EventMode mode = EventMode::Detect) override;
     virtual bool Update(const TimeAndInterval&, uint16_t) override;
     virtual bool Modify(FlagsType type, uint16_t start, uint16_t stop, uint8_t flags) override;
 

--- a/cpp/libs/src/opendnp3/outstation/DatabaseBuffers.cpp
+++ b/cpp/libs/src/opendnp3/outstation/DatabaseBuffers.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -21,7 +21,7 @@
 
 #include "openpal/logging/LogMacros.h"
 
-#include <assert.h>
+#include <cassert>
 
 using namespace openpal;
 
@@ -63,88 +63,86 @@ IINField DatabaseBuffers::SelectAll(GroupVariation gv)
 
         return IINField::Empty();
     }
-    else
+
+    switch (gv)
     {
-        switch (gv)
-        {
-        case (GroupVariation::Group1Var0):
-            return this->SelectAll<BinarySpec>();
-        case (GroupVariation::Group1Var1):
-            return this->SelectAllUsing<BinarySpec>(StaticBinaryVariation::Group1Var1);
-        case (GroupVariation::Group1Var2):
-            return this->SelectAllUsing<BinarySpec>(StaticBinaryVariation::Group1Var2);
+    case (GroupVariation::Group1Var0):
+        return this->SelectAll<BinarySpec>();
+    case (GroupVariation::Group1Var1):
+        return this->SelectAllUsing<BinarySpec>(StaticBinaryVariation::Group1Var1);
+    case (GroupVariation::Group1Var2):
+        return this->SelectAllUsing<BinarySpec>(StaticBinaryVariation::Group1Var2);
 
-        case (GroupVariation::Group3Var0):
-            return this->SelectAll<DoubleBitBinarySpec>();
-        case (GroupVariation::Group3Var2):
-            return this->SelectAllUsing<DoubleBitBinarySpec>(StaticDoubleBinaryVariation::Group3Var2);
+    case (GroupVariation::Group3Var0):
+        return this->SelectAll<DoubleBitBinarySpec>();
+    case (GroupVariation::Group3Var2):
+        return this->SelectAllUsing<DoubleBitBinarySpec>(StaticDoubleBinaryVariation::Group3Var2);
 
-        case (GroupVariation::Group10Var0):
-            return this->SelectAll<BinaryOutputStatusSpec>();
-        case (GroupVariation::Group10Var2):
-            return this->SelectAllUsing<BinaryOutputStatusSpec>(StaticBinaryOutputStatusVariation::Group10Var2);
+    case (GroupVariation::Group10Var0):
+        return this->SelectAll<BinaryOutputStatusSpec>();
+    case (GroupVariation::Group10Var2):
+        return this->SelectAllUsing<BinaryOutputStatusSpec>(StaticBinaryOutputStatusVariation::Group10Var2);
 
-        case (GroupVariation::Group20Var0):
-            return this->SelectAll<CounterSpec>();
-        case (GroupVariation::Group20Var1):
-            return this->SelectAllUsing<CounterSpec>(StaticCounterVariation::Group20Var1);
-        case (GroupVariation::Group20Var2):
-            return this->SelectAllUsing<CounterSpec>(StaticCounterVariation::Group20Var2);
-        case (GroupVariation::Group20Var5):
-            return this->SelectAllUsing<CounterSpec>(StaticCounterVariation::Group20Var5);
-        case (GroupVariation::Group20Var6):
-            return this->SelectAllUsing<CounterSpec>(StaticCounterVariation::Group20Var6);
+    case (GroupVariation::Group20Var0):
+        return this->SelectAll<CounterSpec>();
+    case (GroupVariation::Group20Var1):
+        return this->SelectAllUsing<CounterSpec>(StaticCounterVariation::Group20Var1);
+    case (GroupVariation::Group20Var2):
+        return this->SelectAllUsing<CounterSpec>(StaticCounterVariation::Group20Var2);
+    case (GroupVariation::Group20Var5):
+        return this->SelectAllUsing<CounterSpec>(StaticCounterVariation::Group20Var5);
+    case (GroupVariation::Group20Var6):
+        return this->SelectAllUsing<CounterSpec>(StaticCounterVariation::Group20Var6);
 
-        case (GroupVariation::Group21Var0):
-            return this->SelectAll<FrozenCounterSpec>();
-        case (GroupVariation::Group21Var1):
-            return this->SelectAllUsing<FrozenCounterSpec>(StaticFrozenCounterVariation::Group21Var1);
-        case (GroupVariation::Group21Var2):
-            return this->SelectAllUsing<FrozenCounterSpec>(StaticFrozenCounterVariation::Group21Var2);
-        case (GroupVariation::Group21Var5):
-            return this->SelectAllUsing<FrozenCounterSpec>(StaticFrozenCounterVariation::Group21Var5);
-        case (GroupVariation::Group21Var6):
-            return this->SelectAllUsing<FrozenCounterSpec>(StaticFrozenCounterVariation::Group21Var6);
-        case (GroupVariation::Group21Var9):
-            return this->SelectAllUsing<FrozenCounterSpec>(StaticFrozenCounterVariation::Group21Var9);
-        case (GroupVariation::Group21Var10):
-            return this->SelectAllUsing<FrozenCounterSpec>(StaticFrozenCounterVariation::Group21Var10);
+    case (GroupVariation::Group21Var0):
+        return this->SelectAll<FrozenCounterSpec>();
+    case (GroupVariation::Group21Var1):
+        return this->SelectAllUsing<FrozenCounterSpec>(StaticFrozenCounterVariation::Group21Var1);
+    case (GroupVariation::Group21Var2):
+        return this->SelectAllUsing<FrozenCounterSpec>(StaticFrozenCounterVariation::Group21Var2);
+    case (GroupVariation::Group21Var5):
+        return this->SelectAllUsing<FrozenCounterSpec>(StaticFrozenCounterVariation::Group21Var5);
+    case (GroupVariation::Group21Var6):
+        return this->SelectAllUsing<FrozenCounterSpec>(StaticFrozenCounterVariation::Group21Var6);
+    case (GroupVariation::Group21Var9):
+        return this->SelectAllUsing<FrozenCounterSpec>(StaticFrozenCounterVariation::Group21Var9);
+    case (GroupVariation::Group21Var10):
+        return this->SelectAllUsing<FrozenCounterSpec>(StaticFrozenCounterVariation::Group21Var10);
 
-        case (GroupVariation::Group30Var0):
-            return this->SelectAll<AnalogSpec>();
-        case (GroupVariation::Group30Var1):
-            return this->SelectAllUsing<AnalogSpec>(StaticAnalogVariation::Group30Var1);
-        case (GroupVariation::Group30Var2):
-            return this->SelectAllUsing<AnalogSpec>(StaticAnalogVariation::Group30Var2);
-        case (GroupVariation::Group30Var3):
-            return this->SelectAllUsing<AnalogSpec>(StaticAnalogVariation::Group30Var3);
-        case (GroupVariation::Group30Var4):
-            return this->SelectAllUsing<AnalogSpec>(StaticAnalogVariation::Group30Var4);
-        case (GroupVariation::Group30Var5):
-            return this->SelectAllUsing<AnalogSpec>(StaticAnalogVariation::Group30Var5);
-        case (GroupVariation::Group30Var6):
-            return this->SelectAllUsing<AnalogSpec>(StaticAnalogVariation::Group30Var6);
+    case (GroupVariation::Group30Var0):
+        return this->SelectAll<AnalogSpec>();
+    case (GroupVariation::Group30Var1):
+        return this->SelectAllUsing<AnalogSpec>(StaticAnalogVariation::Group30Var1);
+    case (GroupVariation::Group30Var2):
+        return this->SelectAllUsing<AnalogSpec>(StaticAnalogVariation::Group30Var2);
+    case (GroupVariation::Group30Var3):
+        return this->SelectAllUsing<AnalogSpec>(StaticAnalogVariation::Group30Var3);
+    case (GroupVariation::Group30Var4):
+        return this->SelectAllUsing<AnalogSpec>(StaticAnalogVariation::Group30Var4);
+    case (GroupVariation::Group30Var5):
+        return this->SelectAllUsing<AnalogSpec>(StaticAnalogVariation::Group30Var5);
+    case (GroupVariation::Group30Var6):
+        return this->SelectAllUsing<AnalogSpec>(StaticAnalogVariation::Group30Var6);
 
-        case (GroupVariation::Group40Var0):
-            return this->SelectAll<AnalogOutputStatusSpec>();
-        case (GroupVariation::Group40Var1):
-            return this->SelectAllUsing<AnalogOutputStatusSpec>(StaticAnalogOutputStatusVariation::Group40Var1);
-        case (GroupVariation::Group40Var2):
-            return this->SelectAllUsing<AnalogOutputStatusSpec>(StaticAnalogOutputStatusVariation::Group40Var2);
-        case (GroupVariation::Group40Var3):
-            return this->SelectAllUsing<AnalogOutputStatusSpec>(StaticAnalogOutputStatusVariation::Group40Var3);
-        case (GroupVariation::Group40Var4):
-            return this->SelectAllUsing<AnalogOutputStatusSpec>(StaticAnalogOutputStatusVariation::Group40Var4);
+    case (GroupVariation::Group40Var0):
+        return this->SelectAll<AnalogOutputStatusSpec>();
+    case (GroupVariation::Group40Var1):
+        return this->SelectAllUsing<AnalogOutputStatusSpec>(StaticAnalogOutputStatusVariation::Group40Var1);
+    case (GroupVariation::Group40Var2):
+        return this->SelectAllUsing<AnalogOutputStatusSpec>(StaticAnalogOutputStatusVariation::Group40Var2);
+    case (GroupVariation::Group40Var3):
+        return this->SelectAllUsing<AnalogOutputStatusSpec>(StaticAnalogOutputStatusVariation::Group40Var3);
+    case (GroupVariation::Group40Var4):
+        return this->SelectAllUsing<AnalogOutputStatusSpec>(StaticAnalogOutputStatusVariation::Group40Var4);
 
-        case (GroupVariation::Group50Var4):
-            return this->SelectAllUsing<TimeAndIntervalSpec>(StaticTimeAndIntervalVariation::Group50Var4);
+    case (GroupVariation::Group50Var4):
+        return this->SelectAllUsing<TimeAndIntervalSpec>(StaticTimeAndIntervalVariation::Group50Var4);
 
-        case (GroupVariation::Group110Var0):
-            return this->SelectAll<OctetStringSpec>();
+    case (GroupVariation::Group110Var0):
+        return this->SelectAll<OctetStringSpec>();
 
-        default:
-            return IINField(IINBit::FUNC_NOT_SUPPORTED);
-        }
+    default:
+        return IINField(IINBit::FUNC_NOT_SUPPORTED);
     }
 }
 
@@ -248,9 +246,9 @@ bool DatabaseBuffers::Load(HeaderWriter& writer)
                                    &DatabaseBuffers::LoadType<TimeAndIntervalSpec>,
                                    &DatabaseBuffers::LoadType<OctetStringSpec>};
 
-    for (int i = 0; i < NUM_TYPE; ++i)
+    for (auto& function : functions)
     {
-        if (!(this->*functions[i])(writer))
+        if (!(this->*function)(writer))
         {
             // return early because the APDU is full
             return false;
@@ -314,10 +312,8 @@ StaticBinaryVariation DatabaseBuffers::CheckForPromotion<BinarySpec>(const Binar
     {
         return BinarySpec::IsQualityOnlineOnly(value) ? variation : StaticBinaryVariation::Group1Var2;
     }
-    else
-    {
-        return variation;
-    }
+
+    return variation;
 }
 
 Range DatabaseBuffers::RangeOf(uint16_t size)

--- a/cpp/libs/src/opendnp3/outstation/DatabaseBuffers.h
+++ b/cpp/libs/src/opendnp3/outstation/DatabaseBuffers.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/DatabaseConfigView.cpp
+++ b/cpp/libs/src/opendnp3/outstation/DatabaseConfigView.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/DatabaseConfigView.h
+++ b/cpp/libs/src/opendnp3/outstation/DatabaseConfigView.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/DeferredRequest.cpp
+++ b/cpp/libs/src/opendnp3/outstation/DeferredRequest.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/DeferredRequest.h
+++ b/cpp/libs/src/opendnp3/outstation/DeferredRequest.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/Event.h
+++ b/cpp/libs/src/opendnp3/outstation/Event.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/EventBufferConfig.cpp
+++ b/cpp/libs/src/opendnp3/outstation/EventBufferConfig.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/IClassAssigner.h
+++ b/cpp/libs/src/opendnp3/outstation/IClassAssigner.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/ICommandAction.h
+++ b/cpp/libs/src/opendnp3/outstation/ICommandAction.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/IDatabase.h
+++ b/cpp/libs/src/opendnp3/outstation/IDatabase.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/IEventReceiver.h
+++ b/cpp/libs/src/opendnp3/outstation/IEventReceiver.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/IEventRecorder.h
+++ b/cpp/libs/src/opendnp3/outstation/IEventRecorder.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/IEventSelector.h
+++ b/cpp/libs/src/opendnp3/outstation/IEventSelector.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/IINHelpers.cpp
+++ b/cpp/libs/src/opendnp3/outstation/IINHelpers.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/IINHelpers.h
+++ b/cpp/libs/src/opendnp3/outstation/IINHelpers.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/IOutstationApplication.cpp
+++ b/cpp/libs/src/opendnp3/outstation/IOutstationApplication.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -18,7 +18,3 @@
  * limitations under the License.
  */
 #include "opendnp3/outstation/IOutstationApplication.h"
-
-namespace opendnp3
-{
-}

--- a/cpp/libs/src/opendnp3/outstation/IResponseLoader.h
+++ b/cpp/libs/src/opendnp3/outstation/IResponseLoader.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/IStaticSelector.h
+++ b/cpp/libs/src/opendnp3/outstation/IStaticSelector.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/IndexSearch.h
+++ b/cpp/libs/src/opendnp3/outstation/IndexSearch.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/OctetStringSerializer.cpp
+++ b/cpp/libs/src/opendnp3/outstation/OctetStringSerializer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/OctetStringSerializer.h
+++ b/cpp/libs/src/opendnp3/outstation/OctetStringSerializer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/OutstationChannelStates.h
+++ b/cpp/libs/src/opendnp3/outstation/OutstationChannelStates.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/OutstationContext.h
+++ b/cpp/libs/src/opendnp3/outstation/OutstationContext.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -60,9 +60,9 @@ public:
              const DatabaseSizes& dbSizes,
              const openpal::Logger& logger,
              const std::shared_ptr<openpal::IExecutor>& executor,
-             const std::shared_ptr<ILowerLayer>& lower,
-             const std::shared_ptr<ICommandHandler>& commandHandler,
-             const std::shared_ptr<IOutstationApplication>& application);
+             std::shared_ptr<ILowerLayer> lower,
+             std::shared_ptr<ICommandHandler> commandHandler,
+             std::shared_ptr<IOutstationApplication> application);
 
     /// ----- Implement IUpperLayer ------
 
@@ -113,7 +113,7 @@ private:
 
     void BeginResponseTx(uint16_t destination, const openpal::RSlice& data, const AppControlField& control);
 
-    void BeginUnsolTx(const AppControlField& control, const openpal::RSlice& unsol);
+    void BeginUnsolTx(const AppControlField& control, const openpal::RSlice& response);
 
     void BeginTx(uint16_t destination, const openpal::RSlice& message);
 

--- a/cpp/libs/src/opendnp3/outstation/OutstationSeqNum.h
+++ b/cpp/libs/src/opendnp3/outstation/OutstationSeqNum.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/OutstationStates.cpp
+++ b/cpp/libs/src/opendnp3/outstation/OutstationStates.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -97,10 +97,8 @@ OutstationState& StateSolicitedConfirmWait::OnConfirm(OContext& ctx, const Parse
     {
         return ctx.ContinueMultiFragResponse(request.addresses, AppSeqNum(request.header.control.SEQ).Next());
     }
-    else
-    {
-        return StateIdle::Inst();
-    }
+
+    return StateIdle::Inst();
 }
 
 OutstationState& StateSolicitedConfirmWait::OnConfirmTimeout(OContext& ctx)

--- a/cpp/libs/src/opendnp3/outstation/OutstationStates.h
+++ b/cpp/libs/src/opendnp3/outstation/OutstationStates.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/ParsedRequest.h
+++ b/cpp/libs/src/opendnp3/outstation/ParsedRequest.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/ReadHandler.cpp
+++ b/cpp/libs/src/opendnp3/outstation/ReadHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/ReadHandler.h
+++ b/cpp/libs/src/opendnp3/outstation/ReadHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/RequestHistory.cpp
+++ b/cpp/libs/src/opendnp3/outstation/RequestHistory.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/RequestHistory.h
+++ b/cpp/libs/src/opendnp3/outstation/RequestHistory.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/ResponseContext.cpp
+++ b/cpp/libs/src/opendnp3/outstation/ResponseContext.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -52,10 +52,8 @@ AppControlField ResponseContext::LoadResponse(HeaderWriter& writer)
         auto con = !fin || someEventsWritten;
         return AppControlField(fir, fin, con, false);
     }
-    else
-    {
-        return AppControlField(fir, false, true, false);
-    }
+
+    return AppControlField(fir, false, true, false);
 }
 
 } // namespace opendnp3

--- a/cpp/libs/src/opendnp3/outstation/ResponseContext.h
+++ b/cpp/libs/src/opendnp3/outstation/ResponseContext.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/SelectedRanges.cpp
+++ b/cpp/libs/src/opendnp3/outstation/SelectedRanges.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/SelectedRanges.h
+++ b/cpp/libs/src/opendnp3/outstation/SelectedRanges.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/SimpleCommandHandler.cpp
+++ b/cpp/libs/src/opendnp3/outstation/SimpleCommandHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/StaticBuffers.cpp
+++ b/cpp/libs/src/opendnp3/outstation/StaticBuffers.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/StaticBuffers.h
+++ b/cpp/libs/src/opendnp3/outstation/StaticBuffers.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/StaticWriters.cpp
+++ b/cpp/libs/src/opendnp3/outstation/StaticWriters.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -104,12 +104,10 @@ bool WriteSingleBitfield(openpal::ArrayView<Cell<Spec>, uint16_t>& view, HeaderW
                                                                      static_cast<uint8_t>(mapped.start));
         return LoadWithBitfieldIterator<Spec, openpal::UInt8>(view, iter, range);
     }
-    else
-    {
-        auto iter = writer.IterateOverSingleBitfield<openpal::UInt16>(GV::ID(), QualifierCode::UINT16_START_STOP,
-                                                                      mapped.start);
-        return LoadWithBitfieldIterator<Spec, openpal::UInt16>(view, iter, range);
-    }
+
+    auto iter
+        = writer.IterateOverSingleBitfield<openpal::UInt16>(GV::ID(), QualifierCode::UINT16_START_STOP, mapped.start);
+    return LoadWithBitfieldIterator<Spec, openpal::UInt16>(view, iter, range);
 }
 
 template<class Spec, class Serializer>
@@ -125,12 +123,10 @@ bool WriteWithSerializer(openpal::ArrayView<Cell<Spec>, uint16_t>& view, HeaderW
             QualifierCode::UINT8_START_STOP, Serializer::Inst(), static_cast<uint8_t>(mapped.start));
         return LoadWithRangeIterator<Spec, openpal::UInt8>(view, iter, range);
     }
-    else
-    {
-        auto iter = writer.IterateOverRange<openpal::UInt16, typename Serializer::Target>(
-            QualifierCode::UINT16_START_STOP, Serializer::Inst(), mapped.start);
-        return LoadWithRangeIterator<Spec, openpal::UInt16>(view, iter, range);
-    }
+
+    auto iter = writer.IterateOverRange<openpal::UInt16, typename Serializer::Target>(QualifierCode::UINT16_START_STOP,
+                                                                                      Serializer::Inst(), mapped.start);
+    return LoadWithRangeIterator<Spec, openpal::UInt16>(view, iter, range);
 }
 
 StaticWrite<BinarySpec>::func_t StaticWriters::Get(StaticBinaryVariation variation)
@@ -242,13 +238,13 @@ StaticWrite<AnalogOutputStatusSpec>::func_t StaticWriters::Get(StaticAnalogOutpu
     }
 }
 
-StaticWrite<OctetStringSpec>::func_t StaticWriters::Get(StaticOctetStringVariation variation)
+StaticWrite<OctetStringSpec>::func_t StaticWriters::Get(StaticOctetStringVariation /*variation*/)
 {
     // variation is always the same
     return &Write;
 }
 
-StaticWrite<TimeAndIntervalSpec>::func_t StaticWriters::Get(StaticTimeAndIntervalVariation variation)
+StaticWrite<TimeAndIntervalSpec>::func_t StaticWriters::Get(StaticTimeAndIntervalVariation /*variation*/)
 {
     return &WriteWithSerializer<TimeAndIntervalSpec, Group50Var4>;
 }

--- a/cpp/libs/src/opendnp3/outstation/StaticWriters.h
+++ b/cpp/libs/src/opendnp3/outstation/StaticWriters.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/TimeSyncState.h
+++ b/cpp/libs/src/opendnp3/outstation/TimeSyncState.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/WriteHandler.cpp
+++ b/cpp/libs/src/opendnp3/outstation/WriteHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -35,7 +35,7 @@ WriteHandler::WriteHandler(IOutstationApplication& application,
 {
 }
 
-IINField WriteHandler::ProcessHeader(const RangeHeader& header, const ICollection<Indexed<IINValue>>& values)
+IINField WriteHandler::ProcessHeader(const RangeHeader& /*header*/, const ICollection<Indexed<IINValue>>& values)
 {
     Indexed<IINValue> pair;
 
@@ -64,7 +64,7 @@ IINField WriteHandler::ProcessHeader(const RangeHeader& header, const ICollectio
     return IINField();
 }
 
-IINField WriteHandler::ProcessHeader(const CountHeader& header, const ICollection<Group50Var1>& values)
+IINField WriteHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group50Var1>& values)
 {
     if (this->wroteTime)
         return IINBit::PARAM_ERROR;
@@ -80,7 +80,7 @@ IINField WriteHandler::ProcessHeader(const CountHeader& header, const ICollectio
     return application->WriteAbsoluteTime(UTCTimestamp(value.time)) ? IINField::Empty() : IINBit::PARAM_ERROR;
 }
 
-IINField WriteHandler::ProcessHeader(const CountHeader& header, const ICollection<Group50Var3>& values)
+IINField WriteHandler::ProcessHeader(const CountHeader& /*header*/, const ICollection<Group50Var3>& values)
 {
     if (this->wroteTime)
         return IINBit::PARAM_ERROR;
@@ -101,7 +101,8 @@ IINField WriteHandler::ProcessHeader(const CountHeader& header, const ICollectio
     return application->WriteAbsoluteTime(time) ? IINField::Empty() : IINBit::PARAM_ERROR;
 }
 
-IINField WriteHandler::ProcessHeader(const PrefixHeader& header, const ICollection<Indexed<TimeAndInterval>>& values)
+IINField WriteHandler::ProcessHeader(const PrefixHeader& /*header*/,
+                                     const ICollection<Indexed<TimeAndInterval>>& values)
 {
     if (!application->SupportsWriteTimeAndInterval())
     {

--- a/cpp/libs/src/opendnp3/outstation/WriteHandler.h
+++ b/cpp/libs/src/opendnp3/outstation/WriteHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -48,9 +48,9 @@ public:
 private:
     virtual IINField ProcessHeader(const RangeHeader& header, const ICollection<Indexed<IINValue>>& values) override;
 
-    virtual IINField ProcessHeader(const CountHeader& header, const ICollection<Group50Var1>& times) override;
+    virtual IINField ProcessHeader(const CountHeader& header, const ICollection<Group50Var1>& values) override;
 
-    virtual IINField ProcessHeader(const CountHeader& header, const ICollection<Group50Var3>& times) override;
+    virtual IINField ProcessHeader(const CountHeader& header, const ICollection<Group50Var3>& values) override;
 
     virtual IINField ProcessHeader(const PrefixHeader& header,
                                    const ICollection<Indexed<TimeAndInterval>>& values) override;

--- a/cpp/libs/src/opendnp3/outstation/event/ASDUEventWriteHandler.cpp
+++ b/cpp/libs/src/opendnp3/outstation/event/ASDUEventWriteHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -67,7 +67,7 @@ uint16_t ASDUEventWriteHandler::Write(EventDoubleBinaryVariation variation,
 }
 
 uint16_t ASDUEventWriteHandler::Write(EventCounterVariation variation,
-                                      const Counter& first,
+                                      const Counter& /*first*/,
                                       IEventCollection<Counter>& items)
 {
     switch (variation)
@@ -86,7 +86,7 @@ uint16_t ASDUEventWriteHandler::Write(EventCounterVariation variation,
 }
 
 uint16_t ASDUEventWriteHandler::Write(EventFrozenCounterVariation variation,
-                                      const FrozenCounter& first,
+                                      const FrozenCounter& /*first*/,
                                       IEventCollection<FrozenCounter>& items)
 {
     switch (variation)
@@ -105,7 +105,7 @@ uint16_t ASDUEventWriteHandler::Write(EventFrozenCounterVariation variation,
 }
 
 uint16_t ASDUEventWriteHandler::Write(EventAnalogVariation variation,
-                                      const Analog& first,
+                                      const Analog& /*first*/,
                                       IEventCollection<Analog>& items)
 {
     switch (variation)
@@ -132,7 +132,7 @@ uint16_t ASDUEventWriteHandler::Write(EventAnalogVariation variation,
 }
 
 uint16_t ASDUEventWriteHandler::Write(EventBinaryOutputStatusVariation variation,
-                                      const BinaryOutputStatus& first,
+                                      const BinaryOutputStatus& /*first*/,
                                       IEventCollection<BinaryOutputStatus>& items)
 {
     switch (variation)
@@ -147,7 +147,7 @@ uint16_t ASDUEventWriteHandler::Write(EventBinaryOutputStatusVariation variation
 }
 
 uint16_t ASDUEventWriteHandler::Write(EventAnalogOutputStatusVariation variation,
-                                      const AnalogOutputStatus& first,
+                                      const AnalogOutputStatus& /*first*/,
                                       IEventCollection<AnalogOutputStatus>& items)
 {
     switch (variation)
@@ -173,7 +173,7 @@ uint16_t ASDUEventWriteHandler::Write(EventAnalogOutputStatusVariation variation
     }
 }
 
-uint16_t ASDUEventWriteHandler::Write(EventOctetStringVariation variation,
+uint16_t ASDUEventWriteHandler::Write(EventOctetStringVariation /*variation*/,
                                       const OctetString& first,
                                       IEventCollection<OctetString>& items)
 {

--- a/cpp/libs/src/opendnp3/outstation/event/ASDUEventWriteHandler.h
+++ b/cpp/libs/src/opendnp3/outstation/event/ASDUEventWriteHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/ClazzCount.h
+++ b/cpp/libs/src/opendnp3/outstation/event/ClazzCount.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventBuffer.cpp
+++ b/cpp/libs/src/opendnp3/outstation/event/EventBuffer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventBuffer.h
+++ b/cpp/libs/src/opendnp3/outstation/event/EventBuffer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventCollection.h
+++ b/cpp/libs/src/opendnp3/outstation/event/EventCollection.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventLists.cpp
+++ b/cpp/libs/src/opendnp3/outstation/event/EventLists.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventLists.h
+++ b/cpp/libs/src/opendnp3/outstation/event/EventLists.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventRecord.cpp
+++ b/cpp/libs/src/opendnp3/outstation/event/EventRecord.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventRecord.h
+++ b/cpp/libs/src/opendnp3/outstation/event/EventRecord.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventSelection.cpp
+++ b/cpp/libs/src/opendnp3/outstation/event/EventSelection.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventSelection.h
+++ b/cpp/libs/src/opendnp3/outstation/event/EventSelection.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventState.h
+++ b/cpp/libs/src/opendnp3/outstation/event/EventState.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventStorage.cpp
+++ b/cpp/libs/src/opendnp3/outstation/event/EventStorage.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -184,10 +184,8 @@ uint32_t EventStorage::ClearWritten()
             this->state.counters.OnRemove(record.clazz, record.state);
             return true;
         }
-        else
-        {
-            return false;
-        }
+
+        return false;
     };
 
     return this->state.events.RemoveAll(written);

--- a/cpp/libs/src/opendnp3/outstation/event/EventStorage.h
+++ b/cpp/libs/src/opendnp3/outstation/event/EventStorage.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventTypeImpl.h
+++ b/cpp/libs/src/opendnp3/outstation/event/EventTypeImpl.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventUpdate.h
+++ b/cpp/libs/src/opendnp3/outstation/event/EventUpdate.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventWriters.cpp
+++ b/cpp/libs/src/opendnp3/outstation/event/EventWriters.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -38,7 +38,7 @@ public:
     {
     }
 
-    virtual bool Write(const OctetString& meas, uint16_t index) override
+    bool Write(const OctetString& meas, uint16_t index) override
     {
         if (meas.Size() != this->serializer.Size())
             return false;

--- a/cpp/libs/src/opendnp3/outstation/event/EventWriters.h
+++ b/cpp/libs/src/opendnp3/outstation/event/EventWriters.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/EventWriting.cpp
+++ b/cpp/libs/src/opendnp3/outstation/event/EventWriting.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -41,10 +41,8 @@ uint32_t EventWriting::Write(EventLists& lists, IEventWriteHandler& handler)
         {
             return total_num_written;
         }
-        else
-        {
-            total_num_written += num_written;
-        }
+
+        total_num_written += num_written;
     }
 }
 
@@ -53,7 +51,7 @@ EventRecord* EventWriting::FindNextSelected(event_iter_t& iter, EventType type)
     while (true)
     {
         auto current = iter.CurrentValue();
-        if (!current)
+        if (current == nullptr)
             return nullptr;
 
         if (current->state == EventState::selected)
@@ -61,10 +59,8 @@ EventRecord* EventWriting::FindNextSelected(event_iter_t& iter, EventType type)
             // we terminate here since the type has changed
             return current->type->IsEqual(type) ? current : nullptr;
         }
-        else
-        {
-            iter.Next();
-        }
+
+        iter.Next();
     }
 }
 
@@ -76,7 +72,7 @@ uint16_t EventWriting::WriteSome(event_iter_t& iterator, EventLists& lists, IEve
 
     const auto value = iterator.Find([](const EventRecord& record) { return record.state == EventState::selected; });
 
-    if (!value)
+    if (value == nullptr)
         return 0; // no match
 
     return value->type->WriteSome(iterator, lists, handler);

--- a/cpp/libs/src/opendnp3/outstation/event/EventWriting.h
+++ b/cpp/libs/src/opendnp3/outstation/event/EventWriting.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/IEventType.h
+++ b/cpp/libs/src/opendnp3/outstation/event/IEventType.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/IEventWriteHandler.h
+++ b/cpp/libs/src/opendnp3/outstation/event/IEventWriteHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/List.h
+++ b/cpp/libs/src/opendnp3/outstation/event/List.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/TypedEventRecord.h
+++ b/cpp/libs/src/opendnp3/outstation/event/TypedEventRecord.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/outstation/event/TypedStorage.h
+++ b/cpp/libs/src/opendnp3/outstation/event/TypedStorage.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/transport/TransportConstants.h
+++ b/cpp/libs/src/opendnp3/transport/TransportConstants.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/transport/TransportHeader.cpp
+++ b/cpp/libs/src/opendnp3/transport/TransportHeader.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/transport/TransportHeader.h
+++ b/cpp/libs/src/opendnp3/transport/TransportHeader.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/transport/TransportLayer.cpp
+++ b/cpp/libs/src/opendnp3/transport/TransportLayer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -25,7 +25,7 @@
 
 #include "opendnp3/LogLevels.h"
 
-#include <assert.h>
+#include <cassert>
 
 using namespace std;
 using namespace openpal;
@@ -62,7 +62,7 @@ bool TransportLayer::BeginTransmit(const Message& message)
         return false;
     }
 
-    if (!lower)
+    if (lower == nullptr)
     {
         SIMPLE_LOG_BLOCK(logger, flags::ERR, "Can't send without an attached link layer");
         return false;
@@ -84,17 +84,15 @@ bool TransportLayer::OnReceive(const Message& message)
     if (isOnline)
     {
         const auto asdu = receiver.ProcessReceive(message);
-        if (asdu.payload.IsNotEmpty() && upper)
+        if (asdu.payload.IsNotEmpty() && (upper != nullptr))
         {
             upper->OnReceive(asdu);
         }
         return true;
     }
-    else
-    {
-        SIMPLE_LOG_BLOCK(logger, flags::ERR, "Layer offline");
-        return false;
-    }
+
+    SIMPLE_LOG_BLOCK(logger, flags::ERR, "Layer offline");
+    return false;
 }
 
 bool TransportLayer::OnTxReady()
@@ -113,7 +111,7 @@ bool TransportLayer::OnTxReady()
 
     isSending = false;
 
-    if (upper)
+    if (upper != nullptr)
     {
         upper->OnTxReady();
     }
@@ -147,7 +145,7 @@ bool TransportLayer::OnLowerLayerUp()
     }
 
     isOnline = true;
-    if (upper)
+    if (upper != nullptr)
     {
         upper->OnLowerLayerUp();
     }
@@ -166,7 +164,7 @@ bool TransportLayer::OnLowerLayerDown()
     isSending = false;
     receiver.Reset();
 
-    if (upper)
+    if (upper != nullptr)
     {
         upper->OnLowerLayerDown();
     }

--- a/cpp/libs/src/opendnp3/transport/TransportLayer.h
+++ b/cpp/libs/src/opendnp3/transport/TransportLayer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/transport/TransportRx.cpp
+++ b/cpp/libs/src/opendnp3/transport/TransportRx.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -134,10 +134,8 @@ Message TransportRx::ProcessReceive(const Message& segment)
         this->numBytesRead = 0;
         return Message(segment.addresses, ret);
     }
-    else
-    {
-        return Message();
-    }
+
+    return Message();
 }
 
 } // namespace opendnp3

--- a/cpp/libs/src/opendnp3/transport/TransportRx.h
+++ b/cpp/libs/src/opendnp3/transport/TransportRx.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/transport/TransportSeqNum.h
+++ b/cpp/libs/src/opendnp3/transport/TransportSeqNum.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/transport/TransportStack.cpp
+++ b/cpp/libs/src/opendnp3/transport/TransportStack.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/transport/TransportStack.h
+++ b/cpp/libs/src/opendnp3/transport/TransportStack.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/opendnp3/transport/TransportTx.cpp
+++ b/cpp/libs/src/opendnp3/transport/TransportTx.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -25,7 +25,7 @@
 
 #include "opendnp3/LogLevels.h"
 
-#include <assert.h>
+#include <cassert>
 
 using namespace std;
 using namespace openpal;
@@ -54,27 +54,25 @@ openpal::RSlice TransportTx::GetSegment()
     {
         return txSegment.Get();
     }
-    else
-    {
-        const uint32_t numToSend
-            = (this->message.payload.Size() < MAX_TPDU_PAYLOAD) ? this->message.payload.Size() : MAX_TPDU_PAYLOAD;
 
-        auto dest = tpduBuffer.GetWSlice().Skip(1);
-        this->message.payload.Take(numToSend).CopyTo(dest);
+    const uint32_t numToSend
+        = (this->message.payload.Size() < MAX_TPDU_PAYLOAD) ? this->message.payload.Size() : MAX_TPDU_PAYLOAD;
 
-        bool fir = (tpduCount == 0);
-        bool fin = (numToSend == this->message.payload.Size());
-        tpduBuffer()[0] = TransportHeader::ToByte(fir, fin, sequence);
+    auto dest = tpduBuffer.GetWSlice().Skip(1);
+    this->message.payload.Take(numToSend).CopyTo(dest);
 
-        FORMAT_LOG_BLOCK(logger, flags::TRANSPORT_TX, "FIR: %d FIN: %d SEQ: %u LEN: %u", fir, fin, sequence.Get(),
-                         numToSend);
+    bool fir = (tpduCount == 0);
+    bool fin = (numToSend == this->message.payload.Size());
+    tpduBuffer()[0] = TransportHeader::ToByte(fir, fin, sequence);
 
-        ++statistics.numTransportTx;
+    FORMAT_LOG_BLOCK(logger, flags::TRANSPORT_TX, "FIR: %d FIN: %d SEQ: %u LEN: %u", fir, fin, sequence.Get(),
+                     numToSend);
 
-        auto segment = tpduBuffer.ToRSlice(numToSend + 1);
-        txSegment.Set(segment);
-        return segment;
-    }
+    ++statistics.numTransportTx;
+
+    auto segment = tpduBuffer.ToRSlice(numToSend + 1);
+    txSegment.Set(segment);
+    return segment;
 }
 
 bool TransportTx::Advance()

--- a/cpp/libs/src/opendnp3/transport/TransportTx.h
+++ b/cpp/libs/src/opendnp3/transport/TransportTx.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/openpal/container/Buffer.cpp
+++ b/cpp/libs/src/openpal/container/Buffer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -47,9 +47,7 @@ WSlice Buffer::GetWSlice(uint32_t maxSize)
     {
         return WSlice(this->buffer, maxSize);
     }
-    else
-    {
-        return GetWSlice();
-    }
+
+    return GetWSlice();
 }
 } // namespace openpal

--- a/cpp/libs/src/openpal/container/RSlice.cpp
+++ b/cpp/libs/src/openpal/container/RSlice.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -42,13 +42,11 @@ RSlice RSlice::CopyTo(WSlice& dest) const
     {
         return RSlice::Empty();
     }
-    else
-    {
-        WSlice copy(dest);
-        memcpy(dest, pBuffer, size);
-        dest.Advance(size);
-        return copy.ToRSlice().Take(size);
-    }
+
+    WSlice copy(dest);
+    memcpy(dest, pBuffer, size);
+    dest.Advance(size);
+    return copy.ToRSlice().Take(size);
 }
 
 RSlice RSlice::Take(uint32_t count) const
@@ -74,10 +72,8 @@ bool RSlice::Equals(const RSlice& rhs) const
     {
         return memcmp(pBuffer, rhs.pBuffer, Size()) == 0;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 void RSlice::Advance(uint32_t count)

--- a/cpp/libs/src/openpal/container/WSlice.cpp
+++ b/cpp/libs/src/openpal/container/WSlice.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/openpal/executor/MonotonicTimestamp.cpp
+++ b/cpp/libs/src/openpal/executor/MonotonicTimestamp.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -19,7 +19,7 @@
  */
 #include "openpal/executor/MonotonicTimestamp.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace openpal
 {

--- a/cpp/libs/src/openpal/executor/TimeDuration.cpp
+++ b/cpp/libs/src/openpal/executor/TimeDuration.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/openpal/executor/TimerRef.cpp
+++ b/cpp/libs/src/openpal/executor/TimerRef.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -36,52 +36,46 @@ bool TimerRef::IsActive() const
 
 MonotonicTimestamp TimerRef::ExpiresAt() const
 {
-    return pTimer ? pTimer->ExpiresAt() : MonotonicTimestamp::Max();
+    return pTimer != nullptr ? pTimer->ExpiresAt() : MonotonicTimestamp::Max();
 }
 
 bool TimerRef::Cancel()
 {
-    if (pTimer)
+    if (pTimer != nullptr)
     {
         pTimer->Cancel();
         pTimer = nullptr;
         return true;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 bool TimerRef::StartAction(const TimeDuration& timeout, const action_t& action)
 {
-    if (pTimer)
+    if (pTimer != nullptr)
     {
         return false;
     }
-    else
-    {
-        pTimer = pExecutor->Start(timeout, action);
-        return true;
-    }
+
+    pTimer = pExecutor->Start(timeout, action);
+    return true;
 }
 
 bool TimerRef::StartAction(const MonotonicTimestamp& expiration, const action_t& action)
 {
-    if (pTimer)
+    if (pTimer != nullptr)
     {
         return false;
     }
-    else
-    {
-        pTimer = pExecutor->Start(expiration, action);
-        return true;
-    }
+
+    pTimer = pExecutor->Start(expiration, action);
+    return true;
 }
 
 void TimerRef::RestartAction(const TimeDuration& timeout, const action_t& action)
 {
-    if (pTimer)
+    if (pTimer != nullptr)
     {
         pTimer->Cancel();
     }
@@ -91,7 +85,7 @@ void TimerRef::RestartAction(const TimeDuration& timeout, const action_t& action
 
 void TimerRef::RestartAction(const MonotonicTimestamp& expiration, const action_t& action)
 {
-    if (pTimer)
+    if (pTimer != nullptr)
     {
         pTimer->Cancel();
     }

--- a/cpp/libs/src/openpal/logging/Logger.cpp
+++ b/cpp/libs/src/openpal/logging/Logger.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -20,11 +20,13 @@
 
 #include "openpal/logging/Logger.h"
 
+#include <utility>
+
 namespace openpal
 {
 
-Logger::Logger(const std::shared_ptr<ILogHandler>& backend, const std::string& id, openpal::LogFilters levels)
-    : backend(backend), settings(std::make_shared<Settings>(id, levels))
+Logger::Logger(std::shared_ptr<ILogHandler> backend, const std::string& id, openpal::LogFilters levels)
+    : backend(std::move(backend)), settings(std::make_shared<Settings>(id, levels))
 {
 }
 

--- a/cpp/libs/src/openpal/logging/StringFormatting.cpp
+++ b/cpp/libs/src/openpal/logging/StringFormatting.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/openpal/serialization/ByteSerialization.cpp
+++ b/cpp/libs/src/openpal/serialization/ByteSerialization.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/openpal/serialization/DoubleFloat.cpp
+++ b/cpp/libs/src/openpal/serialization/DoubleFloat.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -55,11 +55,9 @@ double DoubleFloat::Read(const uint8_t* data)
         DoubleFloatUnion x = {{data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]}};
         return x.value;
     }
-    else
-    {
-        DoubleFloatUnion x = {{data[7], data[6], data[5], data[4], data[3], data[2], data[1], data[0]}};
-        return x.value;
-    }
+
+    DoubleFloatUnion x = {{data[7], data[6], data[5], data[4], data[3], data[2], data[1], data[0]}};
+    return x.value;
 }
 
 void DoubleFloat::Write(uint8_t* dest, double value)

--- a/cpp/libs/src/openpal/serialization/FloatByteOrder.cpp
+++ b/cpp/libs/src/openpal/serialization/FloatByteOrder.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -50,7 +50,7 @@ FloatByteOrder::Value FloatByteOrder::GetByteOrder()
     {
         return FloatByteOrder::Value::NORMAL;
     }
-    else if (IsReverseByteOrder())
+    if (IsReverseByteOrder())
     {
         return FloatByteOrder::Value::REVERSE;
     }

--- a/cpp/libs/src/openpal/serialization/Format.cpp
+++ b/cpp/libs/src/openpal/serialization/Format.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -29,11 +29,9 @@ template<class Serializer> bool WriteType(WSlice& dest, const typename Serialize
     {
         return false;
     }
-    else
-    {
-        Serializer::WriteBuffer(dest, value);
-        return true;
-    }
+
+    Serializer::WriteBuffer(dest, value);
+    return true;
 }
 
 bool Format::Write(WSlice& dest, const uint8_t& value)

--- a/cpp/libs/src/openpal/serialization/Parse.cpp
+++ b/cpp/libs/src/openpal/serialization/Parse.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -29,11 +29,9 @@ template<class Serializer> bool ParseType(RSlice& input, typename Serializer::Ty
     {
         return false;
     }
-    else
-    {
-        output = Serializer::ReadBuffer(input);
-        return true;
-    }
+
+    output = Serializer::ReadBuffer(input);
+    return true;
 }
 
 bool Parse::Read(RSlice& input, uint8_t& output)

--- a/cpp/libs/src/openpal/serialization/SingleFloat.cpp
+++ b/cpp/libs/src/openpal/serialization/SingleFloat.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -55,11 +55,9 @@ float SingleFloat::Read(const uint8_t* data)
         SingleFloatUnion x = {{data[0], data[1], data[2], data[3]}};
         return x.value;
     }
-    else
-    {
-        SingleFloatUnion x = {{data[3], data[2], data[1], data[0]}};
-        return x.value;
-    }
+
+    SingleFloatUnion x = {{data[3], data[2], data[1], data[0]}};
+    return x.value;
 }
 
 void SingleFloat::Write(uint8_t* dest, float value)

--- a/cpp/libs/src/openpal/serialization/UInt48LE.cpp
+++ b/cpp/libs/src/openpal/serialization/UInt48LE.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/libs/src/openpal/util/Limits.cpp
+++ b/cpp/libs/src/openpal/util/Limits.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -19,8 +19,7 @@
  */
 #include "openpal/util/Limits.h"
 
-#include <float.h>
-
+#include <cfloat>
 #include <cstdint>
 
 /// these are implemented in terms of cstdint

--- a/cpp/libs/src/openpal/util/ToHex.cpp
+++ b/cpp/libs/src/openpal/util/ToHex.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiodnp3/src/CatchTestStart.cpp
+++ b/cpp/tests/asiodnp3/src/CatchTestStart.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiodnp3/src/TestDNP3Manager.cpp
+++ b/cpp/tests/asiodnp3/src/TestDNP3Manager.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -46,7 +46,7 @@ const int ITERATIONS = 100;
 
 struct Channels
 {
-    Channels(DNP3Manager& manager)
+    explicit Channels(DNP3Manager& manager)
         : client(manager.AddTCPClient("client", levels::ALL, ChannelRetry::Default(), "127.0.0.1", "", 20000, nullptr)),
           server(
               manager.AddTCPServer("server", levels::ALL, ServerAcceptMode::CloseExisting, "0.0.0.0", 20000, nullptr))
@@ -59,7 +59,7 @@ struct Channels
 
 struct Components : Channels
 {
-    Components(DNP3Manager& manager)
+    explicit Components(DNP3Manager& manager)
         : Channels(manager),
           outstation(server->AddOutstation("outstation",
                                            SuccessCommandHandler::Create(),

--- a/cpp/tests/asiodnp3/src/TestDeadlock.cpp
+++ b/cpp/tests/asiodnp3/src/TestDeadlock.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiodnp3/src/TestEventIntegration.cpp
+++ b/cpp/tests/asiodnp3/src/TestEventIntegration.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiodnp3/src/TestIPEndpointsList.cpp
+++ b/cpp/tests/asiodnp3/src/TestIPEndpointsList.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiodnp3/src/TestMasterServerSmoke.cpp
+++ b/cpp/tests/asiodnp3/src/TestMasterServerSmoke.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -102,12 +102,12 @@ class DoubleShutdownListenCallbacks final : public IListenCallbacks
 public:
     DoubleShutdownListenCallbacks() : hasDoubleShutdown(false) {}
 
-    bool AcceptConnection(uint64_t sessionid, const std::string& ipaddress) override
+    bool AcceptConnection(uint64_t /*sessionid*/, const std::string& /*ipaddress*/) override
     {
         return true;
     }
 
-    bool AcceptCertificate(uint64_t sessionid, const X509Info& info) override
+    bool AcceptCertificate(uint64_t /*sessionid*/, const X509Info& /*info*/) override
     {
         return true;
     }

--- a/cpp/tests/asiodnp3/src/TestPerfomance.cpp
+++ b/cpp/tests/asiodnp3/src/TestPerfomance.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiodnp3/src/TestUpdateBuilder.cpp
+++ b/cpp/tests/asiodnp3/src/TestUpdateBuilder.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiodnp3/src/mocks/CountingSOEHandler.h
+++ b/cpp/tests/asiodnp3/src/mocks/CountingSOEHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiodnp3/src/mocks/ExpectedValue.h
+++ b/cpp/tests/asiodnp3/src/mocks/ExpectedValue.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiodnp3/src/mocks/PerformanceStackPair.cpp
+++ b/cpp/tests/asiodnp3/src/mocks/PerformanceStackPair.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -27,6 +27,7 @@
 #include <exception>
 #include <iostream>
 #include <sstream>
+#include <utility>
 
 using namespace opendnp3;
 
@@ -144,10 +145,10 @@ std::shared_ptr<IMaster> PerformanceStackPair::CreateMaster(uint32_t levels,
                                                             std::shared_ptr<ISOEHandler> soehandler,
                                                             std::shared_ptr<IChannelListener> listener)
 {
-    auto channel = manager.AddTCPClient(GetId("client", port).c_str(), levels, asiopal::ChannelRetry::Default(),
-                                        "127.0.0.1", "127.0.0.1", port, listener);
+    auto channel = manager.AddTCPClient(GetId("client", port), levels, asiopal::ChannelRetry::Default(), "127.0.0.1",
+                                        "127.0.0.1", port, std::move(listener));
 
-    return channel->AddMaster(GetId("master", port).c_str(), soehandler, DefaultMasterApplication::Create(),
+    return channel->AddMaster(GetId("master", port), std::move(soehandler), DefaultMasterApplication::Create(),
                               GetMasterStackConfig(timeout));
 }
 
@@ -159,10 +160,10 @@ std::shared_ptr<IOutstation> PerformanceStackPair::CreateOutstation(uint32_t lev
                                                                     uint16_t eventBufferSize,
                                                                     std::shared_ptr<IChannelListener> listener)
 {
-    auto channel = manager.AddTCPServer(GetId("server", port).c_str(), levels, ServerAcceptMode::CloseExisting,
-                                        "127.0.0.1", port, listener);
+    auto channel = manager.AddTCPServer(GetId("server", port), levels, ServerAcceptMode::CloseExisting, "127.0.0.1",
+                                        port, std::move(listener));
 
-    return channel->AddOutstation(GetId("outstation", port).c_str(), SuccessCommandHandler::Create(),
+    return channel->AddOutstation(GetId("outstation", port), SuccessCommandHandler::Create(),
                                   DefaultOutstationApplication::Create(),
                                   GetOutstationStackConfig(numPointsPerType, eventBufferSize, timeout));
 }

--- a/cpp/tests/asiodnp3/src/mocks/PerformanceStackPair.h
+++ b/cpp/tests/asiodnp3/src/mocks/PerformanceStackPair.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiodnp3/src/mocks/QueuedChannelListener.h
+++ b/cpp/tests/asiodnp3/src/mocks/QueuedChannelListener.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiodnp3/src/mocks/QueuingSOEHandler.h
+++ b/cpp/tests/asiodnp3/src/mocks/QueuingSOEHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiodnp3/src/mocks/StackPair.cpp
+++ b/cpp/tests/asiodnp3/src/mocks/StackPair.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -27,6 +27,7 @@
 #include <exception>
 #include <iostream>
 #include <sstream>
+#include <utility>
 
 using namespace opendnp3;
 
@@ -204,10 +205,10 @@ std::shared_ptr<IMaster> StackPair::CreateMaster(uint32_t levels,
                                                  std::shared_ptr<opendnp3::ISOEHandler> soehandler,
                                                  std::shared_ptr<IChannelListener> listener)
 {
-    auto channel = manager.AddTCPClient(GetId("client", port).c_str(), levels, asiopal::ChannelRetry::Default(),
-                                        "127.0.0.1", "127.0.0.1", port, listener);
+    auto channel = manager.AddTCPClient(GetId("client", port), levels, asiopal::ChannelRetry::Default(), "127.0.0.1",
+                                        "127.0.0.1", port, std::move(listener));
 
-    return channel->AddMaster(GetId("master", port).c_str(), soehandler, DefaultMasterApplication::Create(),
+    return channel->AddMaster(GetId("master", port), std::move(soehandler), DefaultMasterApplication::Create(),
                               GetMasterStackConfig(timeout));
 }
 
@@ -219,10 +220,10 @@ std::shared_ptr<IOutstation> StackPair::CreateOutstation(uint32_t levels,
                                                          uint16_t eventBufferSize,
                                                          std::shared_ptr<IChannelListener> listener)
 {
-    auto channel = manager.AddTCPServer(GetId("server", port).c_str(), levels, ServerAcceptMode::CloseExisting,
-                                        "127.0.0.1", port, listener);
+    auto channel = manager.AddTCPServer(GetId("server", port), levels, ServerAcceptMode::CloseExisting, "127.0.0.1",
+                                        port, std::move(listener));
 
-    return channel->AddOutstation(GetId("outstation", port).c_str(), opendnp3::SuccessCommandHandler::Create(),
+    return channel->AddOutstation(GetId("outstation", port), opendnp3::SuccessCommandHandler::Create(),
                                   opendnp3::DefaultOutstationApplication::Create(),
                                   GetOutstationStackConfig(numPointsPerType, eventBufferSize, timeout));
 }

--- a/cpp/tests/asiodnp3/src/mocks/StackPair.h
+++ b/cpp/tests/asiodnp3/src/mocks/StackPair.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiodnp3/src/mocks/SynchronizedQueue.h
+++ b/cpp/tests/asiodnp3/src/mocks/SynchronizedQueue.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiodnp3/src/mocks/TestTypedefs.h
+++ b/cpp/tests/asiodnp3/src/mocks/TestTypedefs.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiopal/src/CatchTestStart.cpp
+++ b/cpp/tests/asiopal/src/CatchTestStart.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiopal/src/TestASIO.cpp
+++ b/cpp/tests/asiopal/src/TestASIO.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -29,8 +29,8 @@ using namespace asio;
 
 namespace asio
 {
-typedef asio::basic_waitable_timer<std::chrono::steady_clock> steady_timer;
-}
+using steady_timer = asio::basic_waitable_timer<std::chrono::steady_clock>;
+} // namespace asio
 
 void AssertCanceled(bool* apFlag, const std::error_code& ec)
 {

--- a/cpp/tests/asiopal/src/TestStrandExecutor.cpp
+++ b/cpp/tests/asiopal/src/TestStrandExecutor.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -54,16 +54,16 @@ TEST_CASE(SUITE("Test automatic resource reclaimation"))
         }
     };
 
-    for (int i = 0; i < NUM_STRAND; ++i)
+    for (unsigned int& i : counter)
     {
-        setup(counter[i]);
+        setup(i);
     }
 
     pool.Shutdown();
 
-    for (int i = 0; i < NUM_STRAND; ++i)
+    for (unsigned int i : counter)
     {
-        REQUIRE(counter[i] == 2 * NUM_OPS);
+        REQUIRE(i == 2 * NUM_OPS);
     }
 }
 

--- a/cpp/tests/asiopal/src/TestTCPClientServer.cpp
+++ b/cpp/tests/asiopal/src/TestTCPClientServer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiopal/src/mocks/MockIO.cpp
+++ b/cpp/tests/asiopal/src/mocks/MockIO.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiopal/src/mocks/MockIO.h
+++ b/cpp/tests/asiopal/src/mocks/MockIO.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiopal/src/mocks/MockTCPClientHandler.cpp
+++ b/cpp/tests/asiopal/src/mocks/MockTCPClientHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -34,10 +34,8 @@ void MockTCPClientHandler::OnConnect(const std::shared_ptr<Executor>& executor,
         ++this->num_error;
         throw std::logic_error(ec.message());
     }
-    else
-    {
-        this->channels.push_back(SocketChannel::Create(executor, std::move(socket)));
-    }
+
+    this->channels.push_back(SocketChannel::Create(executor, std::move(socket)));
 }
 
 MockTCPClientHandler::~MockTCPClientHandler()

--- a/cpp/tests/asiopal/src/mocks/MockTCPClientHandler.h
+++ b/cpp/tests/asiopal/src/mocks/MockTCPClientHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiopal/src/mocks/MockTCPPair.cpp
+++ b/cpp/tests/asiopal/src/mocks/MockTCPPair.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -23,9 +23,8 @@
 namespace asiopal
 {
 
-MockTCPPair::MockTCPPair(std::shared_ptr<MockIO> io, uint16_t port, std::error_code ec)
-    : log(),
-      io(io),
+MockTCPPair::MockTCPPair(const std::shared_ptr<MockIO>& io, uint16_t port, std::error_code ec)
+    : io(io),
       port(port),
       chandler(std::make_shared<MockTCPClientHandler>()),
       client(TCPClient::Create(log.logger, io->GetExecutor(), "127.0.0.1")),

--- a/cpp/tests/asiopal/src/mocks/MockTCPPair.h
+++ b/cpp/tests/asiopal/src/mocks/MockTCPPair.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -36,7 +36,7 @@ class MockTCPPair
 {
 
 public:
-    MockTCPPair(std::shared_ptr<MockIO> io, uint16_t port, std::error_code ec = std::error_code());
+    MockTCPPair(const std::shared_ptr<MockIO>& io, uint16_t port, std::error_code ec = std::error_code());
 
     ~MockTCPPair();
 

--- a/cpp/tests/asiopal/src/mocks/MockTCPServer.h
+++ b/cpp/tests/asiopal/src/mocks/MockTCPServer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiopal/src/tls/TestTLSClientServer.cpp
+++ b/cpp/tests/asiopal/src/tls/TestTLSClientServer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiopal/src/tls/mocks/MockTLSClientHandler.h
+++ b/cpp/tests/asiopal/src/tls/mocks/MockTLSClientHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/asiopal/src/tls/mocks/MockTLSPair.cpp
+++ b/cpp/tests/asiopal/src/tls/mocks/MockTLSPair.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -23,10 +23,12 @@
 namespace asiopal
 {
 
-MockTLSPair::MockTLSPair(
-    std::shared_ptr<MockIO> io, uint16_t port, const TLSConfig& client, const TLSConfig& server, std::error_code ec)
-    : log(),
-      io(io),
+MockTLSPair::MockTLSPair(const std::shared_ptr<MockIO>& io,
+                         uint16_t port,
+                         const TLSConfig& client,
+                         const TLSConfig& server,
+                         std::error_code ec)
+    : io(io),
       port(port),
       chandler(std::make_shared<MockTLSClientHandler>()),
       client(TLSClient::Create(log.logger, io->GetExecutor(), "127.0.0.1", client, ec)),

--- a/cpp/tests/asiopal/src/tls/mocks/MockTLSPair.h
+++ b/cpp/tests/asiopal/src/tls/mocks/MockTLSPair.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -36,7 +36,7 @@ class MockTLSPair
 {
 
 public:
-    MockTLSPair(std::shared_ptr<MockIO> io,
+    MockTLSPair(const std::shared_ptr<MockIO>& io,
                 uint16_t port,
                 const TLSConfig& client,
                 const TLSConfig& server,

--- a/cpp/tests/asiopal/src/tls/mocks/MockTLSServer.h
+++ b/cpp/tests/asiopal/src/tls/mocks/MockTLSServer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/fuzz/fuzzdecoder.cpp
+++ b/cpp/tests/fuzz/fuzzdecoder.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/fuzz/fuzzmaster.cpp
+++ b/cpp/tests/fuzz/fuzzmaster.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/fuzz/fuzzoutstation.cpp
+++ b/cpp/tests/fuzz/fuzzoutstation.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/fuzz/onefile.cpp
+++ b/cpp/tests/fuzz/onefile.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/dnp3mocks/APDUHexBuilders.cpp
+++ b/cpp/tests/libs/src/dnp3mocks/APDUHexBuilders.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -183,7 +183,7 @@ std::string AuthErrorResponse(opendnp3::IINField iin,
                               uint16_t assocId,
                               opendnp3::AuthErrorCode code,
                               opendnp3::DNPTime timestamp,
-                              std::string hexErrorText)
+                              const std::string& hexErrorText)
 {
     Buffer buffer(DEFAULT_MAX_APDU_SIZE);
     APDUResponse apdu(buffer.GetWSlice());
@@ -207,7 +207,7 @@ std::string ChallengeResponse(opendnp3::IINField iin,
                               uint16_t user,
                               HMACType hmacType,
                               ChallengeReason reason,
-                              std::string challengeDataHex)
+                              const std::string& challengeDataHex)
 {
     Buffer buffer(DEFAULT_MAX_APDU_SIZE);
     APDUResponse apdu(buffer.GetWSlice());
@@ -225,7 +225,7 @@ std::string ChallengeResponse(opendnp3::IINField iin,
     return ToHex(apdu.ToRSlice());
 }
 
-std::string ChallengeReply(uint8_t appSeq, uint32_t challengeSeqNum, uint16_t userNum, std::string hmacHex)
+std::string ChallengeReply(uint8_t appSeq, uint32_t challengeSeqNum, uint16_t userNum, const std::string& hmacHex)
 {
     Buffer buffer(DEFAULT_MAX_APDU_SIZE);
     APDURequest apdu(buffer.GetWSlice());
@@ -391,7 +391,7 @@ std::string FinishUpdateKeyChangeResponse(uint8_t seq, const std::string& hmac)
     return ToHex(apdu.ToRSlice());
 }
 
-std::string KeyWrapData(uint16_t keyLengthBytes, uint8_t keyRepeatValue, std::string keyStatusMsg)
+std::string KeyWrapData(uint16_t keyLengthBytes, uint8_t keyRepeatValue, const std::string& keyStatusMsg)
 {
     Buffer key(keyLengthBytes);
     key.GetWSlice().SetAllTo(keyRepeatValue);

--- a/cpp/tests/libs/src/dnp3mocks/APDUHexBuilders.h
+++ b/cpp/tests/libs/src/dnp3mocks/APDUHexBuilders.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -97,7 +97,7 @@ std::string AuthErrorResponse(opendnp3::IINField iin,
                               uint16_t assocId,
                               opendnp3::AuthErrorCode code,
                               opendnp3::DNPTime timestamp,
-                              std::string hexText);
+                              const std::string& hexErrorText);
 
 std::string ChallengeResponse(opendnp3::IINField iin,
                               uint8_t seq,
@@ -105,9 +105,9 @@ std::string ChallengeResponse(opendnp3::IINField iin,
                               uint16_t user,
                               opendnp3::HMACType hmacType,
                               opendnp3::ChallengeReason reason,
-                              std::string challengeDataHex);
+                              const std::string& challengeDataHex);
 
-std::string ChallengeReply(uint8_t appSeq, uint32_t challengeSeqNum, uint16_t userNum, std::string hmacHex);
+std::string ChallengeReply(uint8_t appSeq, uint32_t challengeSeqNum, uint16_t userNum, const std::string& hmacHex);
 
 std::string KeyStatusResponse(opendnp3::IINField iin,
                               uint8_t seq,
@@ -146,7 +146,7 @@ std::string FinishUpdateKeyChangeRequest(
 
 std::string FinishUpdateKeyChangeResponse(uint8_t seq, const std::string& hmac);
 
-std::string KeyWrapData(uint16_t keyLengthBytes, uint8_t keyRepeatValue, std::string keyStatusMsg);
+std::string KeyWrapData(uint16_t keyLengthBytes, uint8_t keyRepeatValue, const std::string& keyStatusMsg);
 
 } // namespace hex
 

--- a/cpp/tests/libs/src/dnp3mocks/CallbackQueue.h
+++ b/cpp/tests/libs/src/dnp3mocks/CallbackQueue.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/dnp3mocks/CommandCallbackQueue.h
+++ b/cpp/tests/libs/src/dnp3mocks/CommandCallbackQueue.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/dnp3mocks/DataSink.cpp
+++ b/cpp/tests/libs/src/dnp3mocks/DataSink.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/dnp3mocks/DataSink.h
+++ b/cpp/tests/libs/src/dnp3mocks/DataSink.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/dnp3mocks/MockCommandHandler.h
+++ b/cpp/tests/libs/src/dnp3mocks/MockCommandHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/dnp3mocks/MockFrameSink.cpp
+++ b/cpp/tests/libs/src/dnp3mocks/MockFrameSink.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -79,14 +79,14 @@ bool MockFrameSink::OnFrame(const LinkHeaderFields& header, const openpal::RSlic
     return true;
 }
 
-void MockFrameSink::AddAction(std::function<void()> fun)
+void MockFrameSink::AddAction(const std::function<void()>& fun)
 {
     m_actions.push_back(fun);
 }
 
 void MockFrameSink::ExecuteAction()
 {
-    if (m_actions.size() > 0)
+    if (!m_actions.empty())
     {
         auto f = m_actions.front();
         m_actions.pop_front();

--- a/cpp/tests/libs/src/dnp3mocks/MockFrameSink.h
+++ b/cpp/tests/libs/src/dnp3mocks/MockFrameSink.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -46,9 +46,9 @@ public:
 
     void Reset();
 
-    bool CheckLast(LinkFunction aCode, bool aIsMaster, uint16_t aDest, uint16_t aSrc);
-    bool CheckLastWithFCB(LinkFunction aCode, bool aIsMaster, bool aFcb, uint16_t aDest, uint16_t aSrc);
-    bool CheckLastWithDFC(LinkFunction aCode, bool aIsMaster, bool aIsRcvBuffFull, uint16_t aDest, uint16_t aSrc);
+    bool CheckLast(LinkFunction func, bool aIsMaster, uint16_t aDest, uint16_t aSrc);
+    bool CheckLastWithFCB(LinkFunction func, bool aIsMaster, bool aFcb, uint16_t aDest, uint16_t aSrc);
+    bool CheckLastWithDFC(LinkFunction func, bool aIsMaster, bool aIsRcvBuffFull, uint16_t aDest, uint16_t aSrc);
 
     // Last frame information
     size_t m_num_frames;
@@ -58,7 +58,7 @@ public:
 
     // Add a function to execute the next time a frame is received
     // This allows us to test re-entrant behaviors
-    void AddAction(std::function<void()> fun);
+    void AddAction(const std::function<void()>& fun);
 
     DataSink received;
 

--- a/cpp/tests/libs/src/dnp3mocks/MockLinkListener.h
+++ b/cpp/tests/libs/src/dnp3mocks/MockLinkListener.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/dnp3mocks/MockLowerLayer.cpp
+++ b/cpp/tests/libs/src/dnp3mocks/MockLowerLayer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -22,7 +22,7 @@
 #include <testlib/BufferHelpers.h>
 #include <testlib/HexConversions.h>
 
-#include <assert.h>
+#include <cassert>
 
 using namespace openpal;
 using namespace testlib;
@@ -46,12 +46,10 @@ std::string MockLowerLayer::PopWriteAsHex()
     {
         return "";
     }
-    else
-    {
-        auto ret = sendQueue.front();
-        sendQueue.pop();
-        return ToHex(ret.payload);
-    }
+
+    auto ret = sendQueue.front();
+    sendQueue.pop();
+    return ToHex(ret.payload);
 }
 
 bool MockLowerLayer::BeginTransmit(const Message& message)
@@ -62,7 +60,7 @@ bool MockLowerLayer::BeginTransmit(const Message& message)
 
 void MockLowerLayer::SendUp(const openpal::RSlice& data, const Addresses& addresses)
 {
-    if (pUpperLayer)
+    if (pUpperLayer != nullptr)
     {
         pUpperLayer->OnReceive(Message(addresses, data));
     }
@@ -76,7 +74,7 @@ void MockLowerLayer::SendUp(const std::string& arHexData, const Addresses& addre
 
 void MockLowerLayer::SendComplete()
 {
-    if (pUpperLayer)
+    if (pUpperLayer != nullptr)
     {
         pUpperLayer->OnTxReady();
     }
@@ -84,14 +82,14 @@ void MockLowerLayer::SendComplete()
 
 void MockLowerLayer::ThisLayerUp()
 {
-    if (pUpperLayer)
+    if (pUpperLayer != nullptr)
     {
         pUpperLayer->OnLowerLayerUp();
     }
 }
 void MockLowerLayer::ThisLayerDown()
 {
-    if (pUpperLayer)
+    if (pUpperLayer != nullptr)
     {
         pUpperLayer->OnLowerLayerDown();
     }

--- a/cpp/tests/libs/src/dnp3mocks/MockLowerLayer.h
+++ b/cpp/tests/libs/src/dnp3mocks/MockLowerLayer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -32,7 +32,7 @@ class MockLowerLayer : public ILowerLayer, public HasUpperLayer
 {
 public:
     void SendUp(const openpal::RSlice& data, const Addresses& addresses = Addresses());
-    void SendUp(const std::string& hex, const Addresses& addresses = Addresses());
+    void SendUp(const std::string& arHexData, const Addresses& addresses = Addresses());
 
     void SendComplete();
     void ThisLayerUp();
@@ -43,7 +43,7 @@ public:
     size_t NumWrites() const;
     std::string PopWriteAsHex();
 
-    virtual bool BeginTransmit(const Message& buffer) override final;
+    virtual bool BeginTransmit(const Message& message) override final;
 
 private:
     std::queue<Message> sendQueue;

--- a/cpp/tests/libs/src/dnp3mocks/MockMasterApplication.h
+++ b/cpp/tests/libs/src/dnp3mocks/MockMasterApplication.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/dnp3mocks/MockOutstationApplication.h
+++ b/cpp/tests/libs/src/dnp3mocks/MockOutstationApplication.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/dnp3mocks/MockSOEHandler.h
+++ b/cpp/tests/libs/src/dnp3mocks/MockSOEHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/dnp3mocks/MockTaskCallback.h
+++ b/cpp/tests/libs/src/dnp3mocks/MockTaskCallback.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/dnp3mocks/MockUpperLayer.cpp
+++ b/cpp/tests/libs/src/dnp3mocks/MockUpperLayer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -62,7 +62,7 @@ bool MockUpperLayer::OnLowerLayerDown()
 
 bool MockUpperLayer::SendDown(const openpal::RSlice& data, const Addresses& addresses)
 {
-    return this->pLowerLayer ? pLowerLayer->BeginTransmit(Message(addresses, data)) : false;
+    return this->pLowerLayer != nullptr ? pLowerLayer->BeginTransmit(Message(addresses, data)) : false;
 }
 
 bool MockUpperLayer::SendDown(const std::string& hex, const Addresses& addresses)

--- a/cpp/tests/libs/src/dnp3mocks/MockUpperLayer.h
+++ b/cpp/tests/libs/src/dnp3mocks/MockUpperLayer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/dnp3mocks/NullSOEHandler.cpp
+++ b/cpp/tests/libs/src/dnp3mocks/NullSOEHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -24,4 +24,4 @@ namespace opendnp3
 {
 
 NullSOEHandler NullSOEHandler::instance;
-}
+} // namespace opendnp3

--- a/cpp/tests/libs/src/dnp3mocks/NullSOEHandler.h
+++ b/cpp/tests/libs/src/dnp3mocks/NullSOEHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/dnp3mocks/ProtocolUtil.cpp
+++ b/cpp/tests/libs/src/dnp3mocks/ProtocolUtil.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/dnp3mocks/ProtocolUtil.h
+++ b/cpp/tests/libs/src/dnp3mocks/ProtocolUtil.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/testlib/BufferHelpers.cpp
+++ b/cpp/tests/libs/src/testlib/BufferHelpers.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -23,10 +23,10 @@
 
 #include <openpal/util/ToHex.h>
 
-#include <assert.h>
 #include <memory.h>
 
 #include <algorithm>
+#include <cassert>
 #include <exception>
 #include <sstream>
 #include <stdexcept>

--- a/cpp/tests/libs/src/testlib/BufferHelpers.h
+++ b/cpp/tests/libs/src/testlib/BufferHelpers.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -52,8 +52,8 @@ public:
 
 private:
     std::string RemoveSpaces(const std::string& hex);
-    void RemoveSpacesInPlace(std::string& hex);
-    static uint32_t Validate(const std::string& hex);
+    void RemoveSpacesInPlace(std::string& s);
+    static uint32_t Validate(const std::string& s);
 };
 
 } // namespace testlib

--- a/cpp/tests/libs/src/testlib/CopyableBuffer.cpp
+++ b/cpp/tests/libs/src/testlib/CopyableBuffer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -85,16 +85,14 @@ bool CopyableBuffer::operator==(const CopyableBuffer& other) const
 {
     if (other.Size() != this->Size())
         return false;
-    else
-    {
-        for (size_t i = 0; i < this->Size(); ++i)
-        {
-            if (this->buffer[i] != other.buffer[i])
-                return false;
-        }
 
-        return true;
+    for (size_t i = 0; i < this->Size(); ++i)
+    {
+        if (this->buffer[i] != other.buffer[i])
+            return false;
     }
+
+    return true;
 }
 
 } // namespace testlib

--- a/cpp/tests/libs/src/testlib/CopyableBuffer.h
+++ b/cpp/tests/libs/src/testlib/CopyableBuffer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/testlib/HexConversions.cpp
+++ b/cpp/tests/libs/src/testlib/HexConversions.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/testlib/HexConversions.h
+++ b/cpp/tests/libs/src/testlib/HexConversions.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/testlib/MockExecutor.h
+++ b/cpp/tests/libs/src/testlib/MockExecutor.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -107,7 +107,7 @@ class MockTimer : public openpal::ITimer
     friend class MockExecutor;
 
 public:
-    MockTimer(MockExecutor*, const openpal::MonotonicTimestamp&, const openpal::action_t& runnable);
+    MockTimer(MockExecutor*, const openpal::MonotonicTimestamp&, openpal::action_t runnable);
 
     // implement ITimer
     void Cancel();

--- a/cpp/tests/libs/src/testlib/MockLogHandler.cpp
+++ b/cpp/tests/libs/src/testlib/MockLogHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -43,7 +43,7 @@ void MockLogHandlerImpl::Log(const LogEntry& entry)
         std::cout << entry.loggerid << " - " << entry.message << std::endl;
     }
 
-    this->messages.push_back(entry);
+    this->messages.emplace_back(entry);
 }
 
 void MockLogHandler::ClearLog()
@@ -65,12 +65,10 @@ bool MockLogHandler::GetNextEntry(LogRecord& record)
 {
     if (impl->messages.empty())
         return false;
-    else
-    {
-        record = impl->messages.front();
-        impl->messages.pop_front();
-        return true;
-    }
+
+    record = impl->messages.front();
+    impl->messages.pop_front();
+    return true;
 }
 
 } // namespace testlib

--- a/cpp/tests/libs/src/testlib/MockLogHandler.h
+++ b/cpp/tests/libs/src/testlib/MockLogHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/testlib/MockUTCTimeSource.h
+++ b/cpp/tests/libs/src/testlib/MockUTCTimeSource.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/testlib/Random.h
+++ b/cpp/tests/libs/src/testlib/Random.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/testlib/RandomDouble.h
+++ b/cpp/tests/libs/src/testlib/RandomDouble.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/libs/src/testlib/RandomizedBuffer.cpp
+++ b/cpp/tests/libs/src/testlib/RandomizedBuffer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -22,7 +22,7 @@
 namespace testlib
 {
 
-RandomizedBuffer::RandomizedBuffer(uint32_t size) : testlib::CopyableBuffer(size), rand()
+RandomizedBuffer::RandomizedBuffer(uint32_t size) : testlib::CopyableBuffer(size)
 {
     Randomize();
 }

--- a/cpp/tests/libs/src/testlib/RandomizedBuffer.h
+++ b/cpp/tests/libs/src/testlib/RandomizedBuffer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/CatchTestStart.cpp
+++ b/cpp/tests/opendnp3/src/CatchTestStart.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestAPDUParsing.cpp
+++ b/cpp/tests/opendnp3/src/TestAPDUParsing.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -44,7 +44,7 @@ using namespace testlib;
 void TestComplex(const std::string& hex,
                  ParseResult expected,
                  size_t numCalls,
-                 std::function<void(MockApduHeaderHandler&)> validate)
+                 const std::function<void(MockApduHeaderHandler&)>& validate)
 {
     HexSequence buffer(hex);
     MockApduHeaderHandler mock;
@@ -246,7 +246,7 @@ TEST_CASE(SUITE("ParserDoesNotAllowEmptyOctetStrings"))
     auto result = APDUParser::Parse(buffer.ToRSlice(), mock, nullptr);
 
     REQUIRE((result == ParseResult::INVALID_OBJECT));
-    REQUIRE(0 == mock.records.size());
+    REQUIRE(mock.records.empty());
 }
 
 TEST_CASE(SUITE("Group1Var2CountWithIndexUInt8"))

--- a/cpp/tests/opendnp3/src/TestAPDUWriting.cpp
+++ b/cpp/tests/opendnp3/src/TestAPDUWriting.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -35,8 +35,9 @@
 
 #include <testlib/HexConversions.h>
 
-#include <assert.h>
 #include <catch.hpp>
+
+#include <cassert>
 
 using namespace openpal;
 using namespace opendnp3;

--- a/cpp/tests/opendnp3/src/TestAuthRequestParser.cpp
+++ b/cpp/tests/opendnp3/src/TestAuthRequestParser.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestCRC.cpp
+++ b/cpp/tests/opendnp3/src/TestCRC.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestCastLongLongDouble.cpp
+++ b/cpp/tests/opendnp3/src/TestCastLongLongDouble.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -18,8 +18,8 @@
  * limitations under the License.
  */
 #include <catch.hpp>
-#include <math.h>
 
+#include <cmath>
 #include <iostream>
 
 #define SUITE(name) "Casting - " name

--- a/cpp/tests/opendnp3/src/TestCollectionTransform.cpp
+++ b/cpp/tests/opendnp3/src/TestCollectionTransform.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestDatabase.cpp
+++ b/cpp/tests/opendnp3/src/TestDatabase.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -47,7 +47,7 @@ void TestBufferForEvent(bool isEvent,
     }
     else
     {
-        REQUIRE((queue.size() == 0));
+        REQUIRE((queue.empty()));
     }
 }
 

--- a/cpp/tests/opendnp3/src/TestEventStorage.cpp
+++ b/cpp/tests/opendnp3/src/TestEventStorage.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestGroup120Var1.cpp
+++ b/cpp/tests/opendnp3/src/TestGroup120Var1.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestGroup120Var2.cpp
+++ b/cpp/tests/opendnp3/src/TestGroup120Var2.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestGroup120Var5.cpp
+++ b/cpp/tests/opendnp3/src/TestGroup120Var5.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestIndexSearch.cpp
+++ b/cpp/tests/opendnp3/src/TestIndexSearch.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestLinkFrame.cpp
+++ b/cpp/tests/opendnp3/src/TestLinkFrame.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -48,10 +48,8 @@ std::string FormatUserData(
     {
         return ToHex(LinkFrame::FormatConfirmedUserData(wrapper, aIsMaster, aFcb, aDest, aSrc, hs, hs.Size(), nullptr));
     }
-    else
-    {
-        return ToHex(LinkFrame::FormatUnconfirmedUserData(wrapper, aIsMaster, aDest, aSrc, hs, hs.Size(), nullptr));
-    }
+
+    return ToHex(LinkFrame::FormatUnconfirmedUserData(wrapper, aIsMaster, aDest, aSrc, hs, hs.Size(), nullptr));
 }
 
 #define SUITE(name) "DNPLinkFrame - " name

--- a/cpp/tests/opendnp3/src/TestLinkLayer.cpp
+++ b/cpp/tests/opendnp3/src/TestLinkLayer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestLinkLayerKeepAlive.cpp
+++ b/cpp/tests/opendnp3/src/TestLinkLayerKeepAlive.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestLinkReceiver.cpp
+++ b/cpp/tests/opendnp3/src/TestLinkReceiver.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestLinkRoute.cpp
+++ b/cpp/tests/opendnp3/src/TestLinkRoute.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestList.cpp
+++ b/cpp/tests/opendnp3/src/TestList.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestLog.cpp
+++ b/cpp/tests/opendnp3/src/TestLog.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestMaster.cpp
+++ b/cpp/tests/opendnp3/src/TestMaster.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -179,7 +179,7 @@ TEST_CASE(SUITE("Retries use exponential backoff"))
     REQUIRE(t.exe->AdvanceToNextTimer());
     REQUIRE(t.exe->GetTime().milliseconds == 5000);
     REQUIRE(t.exe->RunMany() > 0);
-    REQUIRE(t.lower->PopWriteAsHex() == "");
+    REQUIRE(t.lower->PopWriteAsHex().empty());
 
     // advance to the retry
     REQUIRE(t.exe->AdvanceToNextTimer());
@@ -192,7 +192,7 @@ TEST_CASE(SUITE("Retries use exponential backoff"))
     REQUIRE(t.exe->AdvanceToNextTimer());
     REQUIRE(t.exe->GetTime().milliseconds == 15000);
     REQUIRE(t.exe->RunMany() > 0);
-    REQUIRE(t.lower->PopWriteAsHex() == "");
+    REQUIRE(t.lower->PopWriteAsHex().empty());
 
     // advance to the retry
     REQUIRE(t.exe->AdvanceToNextTimer());
@@ -670,7 +670,7 @@ TEST_CASE(SUITE("MasterWritesTimeAndInterval"))
     REQUIRE(t.lower->PopWriteAsHex() == "C0 02 32 04 28 01 00 07 00 03 00 00 00 00 00 04 00 00 00 05");
     t.context->OnTxReady();
     t.SendToMaster("C0 81 00 00");
-    REQUIRE(t.lower->PopWriteAsHex() == "");
+    REQUIRE(t.lower->PopWriteAsHex().empty());
 
     REQUIRE(callback.numStart == 1);
     REQUIRE(callback.results.size() == 1);
@@ -690,7 +690,7 @@ TEST_CASE(SUITE("Cold restart fails with empty response"))
     REQUIRE(t.lower->PopWriteAsHex() == "C0 0D"); // cold restart
     t.context->OnTxReady();
     t.SendToMaster("C0 81 00 00");
-    REQUIRE(t.lower->PopWriteAsHex() == "");
+    REQUIRE(t.lower->PopWriteAsHex().empty());
 
     REQUIRE(queue.responses.size() == 1);
     REQUIRE(queue.responses[0].summary == TaskCompletion::FAILURE_BAD_RESPONSE);
@@ -709,7 +709,7 @@ TEST_CASE(SUITE("Warm restart fails with empty response"))
     REQUIRE(t.lower->PopWriteAsHex() == "C0 0E"); // warm restart
     t.context->OnTxReady();
     t.SendToMaster("C0 81 00 00 34 01 07 01 BB BB");
-    REQUIRE(t.lower->PopWriteAsHex() == "");
+    REQUIRE(t.lower->PopWriteAsHex().empty());
 
     REQUIRE(queue.responses.size() == 1);
     REQUIRE(queue.responses[0].summary == TaskCompletion::SUCCESS);

--- a/cpp/tests/opendnp3/src/TestMasterAssignClass.cpp
+++ b/cpp/tests/opendnp3/src/TestMasterAssignClass.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -49,7 +49,7 @@ TEST_CASE(SUITE("AssignsClassAfterConnect"))
     t.exe->RunMany();
 
     REQUIRE(t.context->tstate == MContext::TaskState::IDLE);
-    REQUIRE(t.lower->PopWriteAsHex() == "");
+    REQUIRE(t.lower->PopWriteAsHex().empty());
 
     REQUIRE(t.application->taskStartEvents.size() == 1);
     REQUIRE(t.application->taskStartEvents[0] == MasterTaskType::ASSIGN_CLASS);

--- a/cpp/tests/opendnp3/src/TestMasterCommandRequests.cpp
+++ b/cpp/tests/opendnp3/src/TestMasterCommandRequests.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -156,7 +156,7 @@ TEST_CASE(SUITE("SelectAndOperate"))
 
     t.exe->RunMany();
 
-    REQUIRE(t.lower->PopWriteAsHex() == ""); // nore more packets
+    REQUIRE(t.lower->PopWriteAsHex().empty()); // nore more packets
 
     REQUIRE(queue.PopOnlyEqualValue(TaskCompletion::SUCCESS,
                                     CommandPointResult(0, 1, CommandPointState::SUCCESS, CommandStatus::SUCCESS)));
@@ -194,7 +194,7 @@ TEST_CASE(SUITE("SelectAndOperateWithConfirmResponse"))
     t.SendToMaster("C1 81 00 00 " + crob);
     t.exe->RunMany();
 
-    REQUIRE(t.lower->PopWriteAsHex() == ""); // nore more packets
+    REQUIRE(t.lower->PopWriteAsHex().empty()); // nore more packets
     REQUIRE(queue.PopOnlyEqualValue(TaskCompletion::SUCCESS,
                                     CommandPointResult(0, 1, CommandPointState::SUCCESS, CommandStatus::SUCCESS)));
 }
@@ -227,7 +227,7 @@ TEST_CASE(SUITE("can select and operate with one byte qualifier optimization ena
     t.SendToMaster("C1 81 00 00 " + crob_header_hex);
     t.exe->RunMany();
 
-    REQUIRE(t.lower->PopWriteAsHex() == ""); // nore more packets
+    REQUIRE(t.lower->PopWriteAsHex().empty()); // nore more packets
     REQUIRE(queue.PopOnlyEqualValue(TaskCompletion::SUCCESS,
                                     CommandPointResult(0, 7, CommandPointState::SUCCESS, CommandStatus::SUCCESS)));
 }

--- a/cpp/tests/opendnp3/src/TestMasterMultiCommandRequests.cpp
+++ b/cpp/tests/opendnp3/src/TestMasterMultiCommandRequests.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -79,7 +79,7 @@ TEST_CASE(SUITE("DirectOperateTwoCROB"))
 
     REQUIRE(t.exe->RunMany() > 0);
 
-    REQUIRE(t.lower->PopWriteAsHex() == ""); // nore more packets
+    REQUIRE(t.lower->PopWriteAsHex().empty()); // nore more packets
 
     REQUIRE(queue.PopOnlyEqualValue(TaskCompletion::SUCCESS,
                                     {CommandPointResult(0, 1, CommandPointState::SUCCESS, CommandStatus::SUCCESS),
@@ -119,7 +119,7 @@ TEST_CASE(SUITE("SelectAndOperateTwoCROBSOneAO"))
 
     REQUIRE(t.exe->RunMany() > 0);
 
-    REQUIRE(t.lower->PopWriteAsHex() == ""); // nore more packets
+    REQUIRE(t.lower->PopWriteAsHex().empty()); // nore more packets
 
     REQUIRE(queue.PopOnlyEqualValue(TaskCompletion::SUCCESS,
                                     {CommandPointResult(0, 1, CommandPointState::SUCCESS, CommandStatus::SUCCESS),

--- a/cpp/tests/opendnp3/src/TestMasterMultidrop.cpp
+++ b/cpp/tests/opendnp3/src/TestMasterMultidrop.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -30,8 +30,8 @@ using namespace opendnp3;
 
 // helpers
 
-void ExpectRequestAndCauseResponseTimeout(MasterTestFixture&, const std::string& expected);
-void ExpectRequestAndRespond(MasterTestFixture&, const std::string& expected, const std::string& response);
+void ExpectRequestAndCauseResponseTimeout(MasterTestFixture& /*session*/, const std::string& expected);
+void ExpectRequestAndRespond(MasterTestFixture& /*session*/, const std::string& expected, const std::string& response);
 
 #define SUITE(name) "MasterMultidropTestSuite - " name
 
@@ -53,7 +53,7 @@ TEST_CASE(SUITE("Multidrop scheduling is priroity based"))
     REQUIRE(executor->RunMany() > 0);
 
     REQUIRE(t1.lower->PopWriteAsHex() == hex::IntegrityPoll(0));
-    REQUIRE(t2.lower->PopWriteAsHex() == "");
+    REQUIRE(t2.lower->PopWriteAsHex().empty());
 
     t1.context->OnTxReady();
     t1.SendToMaster(hex::EmptyResponse(0, IINField(IINBit::DEVICE_RESTART)));
@@ -63,7 +63,7 @@ TEST_CASE(SUITE("Multidrop scheduling is priroity based"))
     // The IIN clear has higher priority than the integrity poll, so it is run first
 
     REQUIRE(t1.lower->PopWriteAsHex() == hex::ClearRestartIIN(1));
-    REQUIRE(t2.lower->PopWriteAsHex() == "");
+    REQUIRE(t2.lower->PopWriteAsHex().empty());
 
     t1.context->OnTxReady();
     t1.SendToMaster(hex::EmptyResponse(1));
@@ -72,7 +72,7 @@ TEST_CASE(SUITE("Multidrop scheduling is priroity based"))
 
     // Finally, the 2nd master gets to run it's integrity poll
 
-    REQUIRE(t1.lower->PopWriteAsHex() == "");
+    REQUIRE(t1.lower->PopWriteAsHex().empty());
     REQUIRE(t2.lower->PopWriteAsHex() == hex::IntegrityPoll(0));
 }
 
@@ -95,7 +95,7 @@ TEST_CASE(SUITE("Shutting down a master causes 2nd master to run scheduled task"
     REQUIRE(executor->RunMany() > 0);
 
     REQUIRE(t1.lower->PopWriteAsHex() == hex::IntegrityPoll(0));
-    REQUIRE(t2.lower->PopWriteAsHex() == "");
+    REQUIRE(t2.lower->PopWriteAsHex().empty());
 
     t1.context->OnTxReady();
     // instead of sending a reply, shutdown the first master
@@ -103,7 +103,7 @@ TEST_CASE(SUITE("Shutting down a master causes 2nd master to run scheduled task"
 
     REQUIRE(executor->RunMany() > 0);
 
-    REQUIRE(t1.lower->PopWriteAsHex() == "");
+    REQUIRE(t1.lower->PopWriteAsHex().empty());
     REQUIRE(t2.lower->PopWriteAsHex() == hex::IntegrityPoll(0));
 }
 

--- a/cpp/tests/opendnp3/src/TestMasterUnsolBehaviors.cpp
+++ b/cpp/tests/opendnp3/src/TestMasterUnsolBehaviors.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestMeasurementHandler.cpp
+++ b/cpp/tests/opendnp3/src/TestMeasurementHandler.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestOutstation.cpp
+++ b/cpp/tests/opendnp3/src/TestOutstation.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -129,7 +129,7 @@ TEST_CASE(SUITE("NoResponseToNoAckCodes"))
         auto request = ToHex(bytes, 2, true);
 
         t.SendToOutstation(request);
-        REQUIRE(t.lower->PopWriteAsHex() == "");
+        REQUIRE(t.lower->PopWriteAsHex().empty());
 
         ++sequence;
     }
@@ -259,7 +259,7 @@ TEST_CASE(SUITE("WriteTimeDateNotAsking"))
     t.application->allowTimeWrite = false;
     t.SendToOutstation("C0 02 32 01 07 01 D2 04 00 00 00 00"); // write Grp50Var1, value = 1234 ms after epoch
     REQUIRE(t.lower->PopWriteAsHex() == "C0 81 80 04");        // param error
-    REQUIRE(t.application->timestamps.size() == 0);
+    REQUIRE(t.application->timestamps.empty());
 }
 
 TEST_CASE(SUITE("WriteTimeDateMultipleObjects"))
@@ -368,7 +368,7 @@ TEST_CASE(SUITE("ReadClass0MultiFragAnalog"))
     t.OnTxReady();
     t.SendToOutstation("C3 00");
 
-    REQUIRE(t.lower->PopWriteAsHex() == "");
+    REQUIRE(t.lower->PopWriteAsHex().empty());
 }
 
 TEST_CASE(SUITE("ReadFuncNotSupported"))

--- a/cpp/tests/opendnp3/src/TestOutstationAssignClass.cpp
+++ b/cpp/tests/opendnp3/src/TestOutstationAssignClass.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestOutstationCommandResponses.cpp
+++ b/cpp/tests/opendnp3/src/TestOutstationCommandResponses.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -356,7 +356,7 @@ TEST_CASE(SUITE("DirectOperateNoResponseGroup12Var1"))
     for (uint32_t i = 1; i < 5; ++i)
     {
         t.SendToOutstation(directOperateNoACK);
-        REQUIRE(t.lower->PopWriteAsHex() == "");
+        REQUIRE(t.lower->PopWriteAsHex().empty());
         REQUIRE(t.cmdHandler->NumInvocations() == i);
     }
 }

--- a/cpp/tests/opendnp3/src/TestOutstationDiscontiguousIndices.cpp
+++ b/cpp/tests/opendnp3/src/TestOutstationDiscontiguousIndices.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestOutstationEventResponses.cpp
+++ b/cpp/tests/opendnp3/src/TestOutstationEventResponses.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestOutstationStateMachine.cpp
+++ b/cpp/tests/opendnp3/src/TestOutstationStateMachine.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -64,5 +64,5 @@ TEST_CASE(SUITE("Responds to non-READ request while waiting for unsolicited conf
     REQUIRE(t.lower->PopWriteAsHex() == "C0 81 80 00"); // null response
     t.OnTxReady();
 
-    REQUIRE(t.lower->PopWriteAsHex() == ""); // shouldn't send anything else
+    REQUIRE(t.lower->PopWriteAsHex().empty()); // shouldn't send anything else
 }

--- a/cpp/tests/opendnp3/src/TestOutstationUnsolicitedResponses.cpp
+++ b/cpp/tests/opendnp3/src/TestOutstationUnsolicitedResponses.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -104,7 +104,7 @@ TEST_CASE(SUITE("UnsolData"))
     REQUIRE(t.lower->PopWriteAsHex() == "F1 82 80 00 02 01 28 01 00 02 00 01");
     t.OnTxReady();
     t.SendToOutstation(hex::UnsolConfirm(1));
-    REQUIRE(t.lower->PopWriteAsHex() == "");
+    REQUIRE(t.lower->PopWriteAsHex().empty());
 }
 
 TEST_CASE(SUITE("UnsolEventBufferOverflow"))
@@ -134,7 +134,7 @@ TEST_CASE(SUITE("UnsolEventBufferOverflow"))
     t.OnTxReady();
     t.SendToOutstation(hex::UnsolConfirm(1));
 
-    REQUIRE(t.lower->PopWriteAsHex() == "");
+    REQUIRE(t.lower->PopWriteAsHex().empty());
 }
 
 TEST_CASE(SUITE("UnsolMultiFragments"))
@@ -151,7 +151,7 @@ TEST_CASE(SUITE("UnsolMultiFragments"))
     REQUIRE(t.lower->PopWriteAsHex() == hex::NullUnsolicited(0));
     t.OnTxReady();
     t.SendToOutstation(hex::UnsolConfirm(0));
-    REQUIRE(t.lower->PopWriteAsHex() == "");
+    REQUIRE(t.lower->PopWriteAsHex().empty());
 
     t.Transaction([](IUpdateHandler& db) {
         db.Update(Analog(7, 0x01), 1);
@@ -168,7 +168,7 @@ TEST_CASE(SUITE("UnsolMultiFragments"))
     t.OnTxReady();
     t.SendToOutstation(hex::UnsolConfirm(2));
 
-    REQUIRE(t.lower->PopWriteAsHex() == "");
+    REQUIRE(t.lower->PopWriteAsHex().empty());
 }
 
 void WriteDuringUnsol(bool beforeTx)
@@ -205,7 +205,7 @@ void WriteDuringUnsol(bool beforeTx)
 
     // now send the confirm to the outstation
     t.SendToOutstation(hex::UnsolConfirm(1));
-    REQUIRE(t.lower->PopWriteAsHex() == "");
+    REQUIRE(t.lower->PopWriteAsHex().empty());
 }
 
 // Test that non-read fragments are immediately responded to while
@@ -240,15 +240,9 @@ TEST_CASE(SUITE("ReadDuringUnsol"))
 
     auto readClass1 = "C0 01 3C 02 06";
 
-    if (true)
     {
         t.OnTxReady();
         t.SendToOutstation(readClass1);
-    }
-    else
-    {
-        t.SendToOutstation(readClass1);
-        t.OnTxReady();
     }
 
     t.SendToOutstation(hex::UnsolConfirm(1));
@@ -328,7 +322,7 @@ TEST_CASE(SUITE("UnsolEnable"))
     // do a transaction to show that unsol data is not being reported yet
     t.Transaction([](IUpdateHandler& db) { db.Update(Binary(false, 0x01), 0); });
 
-    REQUIRE(t.lower->PopWriteAsHex() == "");
+    REQUIRE(t.lower->PopWriteAsHex().empty());
 
     // Enable unsol class 1
     t.SendToOutstation("C0 14 3C 02 06");

--- a/cpp/tests/opendnp3/src/TestShiftableBuffer.cpp
+++ b/cpp/tests/opendnp3/src/TestShiftableBuffer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestTransportLayer.cpp
+++ b/cpp/tests/opendnp3/src/TestTransportLayer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -131,7 +131,7 @@ TEST_CASE(SUITE("ReceiveLargestPossibleAPDU"))
 
     vector<string> packets;
     const string apdu = test.GeneratePacketSequence(packets, num_packets, last_packet_length);
-    for (string s : packets)
+    for (const string& s : packets)
     {
         test.link.SendUp(s);
     }
@@ -238,9 +238,9 @@ TEST_CASE(SUITE("SendFullAPDU"))
     REQUIRE(numPackets == test.link.sends.size());
     REQUIRE(packets.size() == test.link.sends.size());
 
-    for (size_t i = 0; i < packets.size(); ++i)
+    for (const auto& packet : packets)
     {
-        REQUIRE(packets[i] == test.link.PopWriteAsHex());
+        REQUIRE(packet == test.link.PopWriteAsHex());
     }
 
     test.transport.OnTxReady();

--- a/cpp/tests/opendnp3/src/TestTypedCommandHeader.cpp
+++ b/cpp/tests/opendnp3/src/TestTypedCommandHeader.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -33,7 +33,7 @@ using namespace opendnp3;
 using namespace openpal;
 using namespace testlib;
 
-std::string WriteToHex(const CommandSet& set, IndexQualifierMode mode);
+std::string WriteToHex(const CommandSet& commands, IndexQualifierMode mode);
 
 #define SUITE(name) "TypedCommandHeaderTestSuite - " name
 
@@ -101,7 +101,7 @@ TEST_CASE(SUITE("Command set can be moved and written"))
 
     CommandSet commands2(std::move(commands));
 
-    REQUIRE(WriteToHex(commands, IndexQualifierMode::always_two_bytes) == "");
+    REQUIRE(WriteToHex(commands, IndexQualifierMode::always_two_bytes).empty());
     REQUIRE(WriteToHex(commands2, IndexQualifierMode::always_two_bytes)
             == "29 02 28 01 00 0A 00 07 00 00 29 01 28 01 00 0B 00 08 00 00 00 00");
 }

--- a/cpp/tests/opendnp3/src/TestTypes.cpp
+++ b/cpp/tests/opendnp3/src/TestTypes.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/TestUtil.cpp
+++ b/cpp/tests/opendnp3/src/TestUtil.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -25,7 +25,7 @@ using namespace std;
 using namespace testlib;
 
 #define SUITE(name) "UtilSuite - " name
-template<int N> void TestHex(const std::string& hex, uint8_t* compareBytes, size_t count)
+template<int N> void TestHex(const std::string& hex, const uint8_t* compareBytes, size_t count)
 {
     HexSequence hs(hex);
 

--- a/cpp/tests/opendnp3/src/TestWriteConversions.cpp
+++ b/cpp/tests/opendnp3/src/TestWriteConversions.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/APDUHelpers.cpp
+++ b/cpp/tests/opendnp3/src/mocks/APDUHelpers.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/APDUHelpers.h
+++ b/cpp/tests/opendnp3/src/mocks/APDUHelpers.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/BufferSegment.cpp
+++ b/cpp/tests/opendnp3/src/mocks/BufferSegment.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -23,10 +23,10 @@
 
 #include <testlib/HexConversions.h>
 
-#include <assert.h>
 #include <memory.h>
 
 #include <algorithm>
+#include <cassert>
 #include <exception>
 #include <sstream>
 

--- a/cpp/tests/opendnp3/src/mocks/BufferSegment.h
+++ b/cpp/tests/opendnp3/src/mocks/BufferSegment.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/DNPHelpers.cpp
+++ b/cpp/tests/opendnp3/src/mocks/DNPHelpers.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/DNPHelpers.h
+++ b/cpp/tests/opendnp3/src/mocks/DNPHelpers.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/DatabaseTestObject.h
+++ b/cpp/tests/opendnp3/src/mocks/DatabaseTestObject.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/FanoutDataObserver.h
+++ b/cpp/tests/opendnp3/src/mocks/FanoutDataObserver.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/LinkHex.cpp
+++ b/cpp/tests/opendnp3/src/mocks/LinkHex.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/LinkHex.h
+++ b/cpp/tests/opendnp3/src/mocks/LinkHex.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/LinkLayerTest.cpp
+++ b/cpp/tests/opendnp3/src/mocks/LinkLayerTest.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -30,8 +30,7 @@ namespace opendnp3
 LinkLayerTest::LinkLayerTest(const LinkConfig& config) : LinkLayerTest(LinkLayerConfig(config, false)) {}
 
 LinkLayerTest::LinkLayerTest(const LinkLayerConfig& config)
-    : log(),
-      exe(std::make_shared<testlib::MockExecutor>()),
+    : exe(std::make_shared<testlib::MockExecutor>()),
       listener(std::make_shared<MockLinkListener>()),
       upper(std::make_shared<MockTransportLayer>()),
       link(log.logger, exe, upper, listener, config),
@@ -75,7 +74,7 @@ uint32_t LinkLayerTest::NumTotalWrites()
     return numTotalWrites;
 }
 
-void LinkLayerTest::BeginTransmit(const openpal::RSlice& buffer, ILinkSession&)
+void LinkLayerTest::BeginTransmit(const openpal::RSlice& buffer, ILinkSession& /*context*/)
 {
     ++numTotalWrites;
     this->writeQueue.push_back(ToHex(buffer));

--- a/cpp/tests/opendnp3/src/mocks/LinkLayerTest.h
+++ b/cpp/tests/opendnp3/src/mocks/LinkLayerTest.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/LinkReceiverTest.h
+++ b/cpp/tests/opendnp3/src/mocks/LinkReceiverTest.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/MasterTestFixture.cpp
+++ b/cpp/tests/opendnp3/src/mocks/MasterTestFixture.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/MasterTestFixture.h
+++ b/cpp/tests/opendnp3/src/mocks/MasterTestFixture.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/MeasurementComparisons.h
+++ b/cpp/tests/opendnp3/src/mocks/MeasurementComparisons.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/MockAPDUHeaderHandler.h
+++ b/cpp/tests/opendnp3/src/mocks/MockAPDUHeaderHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/MockEventWriteHandler.h
+++ b/cpp/tests/opendnp3/src/mocks/MockEventWriteHandler.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/MockLinkLayer.h
+++ b/cpp/tests/opendnp3/src/mocks/MockLinkLayer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/MockTransportLayer.cpp
+++ b/cpp/tests/opendnp3/src/mocks/MockTransportLayer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/MockTransportLayer.h
+++ b/cpp/tests/opendnp3/src/mocks/MockTransportLayer.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/OutstationTestObject.cpp
+++ b/cpp/tests/opendnp3/src/mocks/OutstationTestObject.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -28,8 +28,7 @@ namespace opendnp3
 {
 
 OutstationTestObject::OutstationTestObject(const OutstationConfig& config, const DatabaseSizes& dbSizes)
-    : log(),
-      exe(std::make_shared<MockExecutor>()),
+    : exe(std::make_shared<MockExecutor>()),
       lower(std::make_shared<MockLowerLayer>()),
       cmdHandler(std::make_shared<MockCommandHandler>(CommandStatus::SUCCESS)),
       application(std::make_shared<MockOutstationApplication>()),
@@ -74,10 +73,8 @@ bool OutstationTestObject::AdvanceToNextTimer()
     {
         return exe->RunMany() > 0;
     }
-    else
-    {
-        return false;
-    }
+
+    return false;
 }
 
 size_t OutstationTestObject::AdvanceTime(const openpal::TimeDuration& td)

--- a/cpp/tests/opendnp3/src/mocks/OutstationTestObject.h
+++ b/cpp/tests/opendnp3/src/mocks/OutstationTestObject.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/TestHelpers.h
+++ b/cpp/tests/opendnp3/src/mocks/TestHelpers.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/opendnp3/src/mocks/TransportTestObject.cpp
+++ b/cpp/tests/opendnp3/src/mocks/TransportTestObject.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -37,7 +37,7 @@ namespace opendnp3
 {
 
 TransportTestObject::TransportTestObject(bool openOnStart, uint32_t maxRxFragmentSize)
-    : log(), exe(), transport(log.logger, maxRxFragmentSize)
+    : transport(log.logger, maxRxFragmentSize)
 {
     link.SetUpperLayer(transport);
     transport.SetLinkLayer(link);
@@ -62,7 +62,7 @@ std::string TransportTestObject::GetData(const std::string& arHdr, uint8_t aSeed
     }
 
     ostringstream oss;
-    if (arHdr.size() > 0)
+    if (!arHdr.empty())
         oss << arHdr << " ";
     oss << ToHex(buff, buff.Size(), true);
     return oss.str();

--- a/cpp/tests/opendnp3/src/mocks/TransportTestObject.h
+++ b/cpp/tests/opendnp3/src/mocks/TransportTestObject.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/openpal/src/CatchTestStart.cpp
+++ b/cpp/tests/openpal/src/CatchTestStart.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/openpal/src/TestFloatSerialization.cpp
+++ b/cpp/tests/openpal/src/TestFloatSerialization.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -60,10 +60,10 @@ template<class T> bool TestReadWriteFloat(T value)
     return true;
 }
 
-template<class T> bool TestFloatParsing(std::string hex, typename T::Type value)
+template<class T> bool TestFloatParsing(const std::string& hex, typename T::Type value)
 {
     HexSequence hs(hex);
-    const uint32_t TYPE_SIZE = static_cast<uint32_t>(sizeof(typename T::Type));
+    const auto TYPE_SIZE = static_cast<uint32_t>(sizeof(typename T::Type));
     REQUIRE((hs.Size() == TYPE_SIZE));
 
     Buffer buffer(2 * TYPE_SIZE);

--- a/cpp/tests/openpal/src/TestIntegerSerialization.cpp
+++ b/cpp/tests/openpal/src/TestIntegerSerialization.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/cpp/tests/openpal/src/TestStaticBuffer.cpp
+++ b/cpp/tests/openpal/src/TestStaticBuffer.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/adapters/CString.h
+++ b/java/cpp/adapters/CString.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/adapters/ChannelListenerAdapter.h
+++ b/java/cpp/adapters/ChannelListenerAdapter.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/adapters/CommandHandlerAdapter.cpp
+++ b/java/cpp/adapters/CommandHandlerAdapter.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/adapters/CommandHandlerAdapter.h
+++ b/java/cpp/adapters/CommandHandlerAdapter.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/adapters/ConfigReader.cpp
+++ b/java/cpp/adapters/ConfigReader.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -48,11 +48,11 @@ MasterParams ConfigReader::ConvertMasterConfig(JNIEnv* env, jobject jcfg)
     cfg.responseTimeout = TimeDuration::Milliseconds(dur.toMillis(env, config.getresponseTimeout(env, jcfg)));
     cfg.timeSyncMode
         = static_cast<TimeSyncMode>(jni::JCache::TimeSyncMode.toType(env, config.gettimeSyncMode(env, jcfg)));
-    cfg.disableUnsolOnStartup = !!config.getdisableUnsolOnStartup(env, jcfg);
-    cfg.ignoreRestartIIN = !!config.getignoreRestartIIN(env, jcfg);
+    cfg.disableUnsolOnStartup = !(config.getdisableUnsolOnStartup(env, jcfg) == 0u);
+    cfg.ignoreRestartIIN = !(config.getignoreRestartIIN(env, jcfg) == 0u);
     cfg.unsolClassMask = ConvertClassField(env, config.getunsolClassMask(env, jcfg));
     cfg.startupIntegrityClassMask = ConvertClassField(env, config.getstartupIntegrityClassMask(env, jcfg));
-    cfg.integrityOnEventOverflowIIN = !!config.getintegrityOnEventOverflowIIN(env, jcfg);
+    cfg.integrityOnEventOverflowIIN = !(config.getintegrityOnEventOverflowIIN(env, jcfg) == 0u);
     cfg.taskRetryPeriod = TimeDuration::Milliseconds(dur.toMillis(env, config.gettaskRetryPeriod(env, jcfg)));
     cfg.taskStartTimeout = TimeDuration::Milliseconds(dur.toMillis(env, config.gettaskStartTimeout(env, jcfg)));
     cfg.maxTxFragSize = config.getmaxTxFragSize(env, jcfg);
@@ -69,8 +69,8 @@ LinkConfig ConfigReader::ConvertLinkConfig(JNIEnv* env, jobject jlinkcfg)
 
     auto& ref = jni::JCache::LinkLayerConfig;
 
-    cfg.IsMaster = !!ref.getisMaster(env, jlinkcfg);
-    cfg.UseConfirms = !!ref.getuseConfirms(env, jlinkcfg);
+    cfg.IsMaster = !(ref.getisMaster(env, jlinkcfg) == 0u);
+    cfg.UseConfirms = !(ref.getuseConfirms(env, jlinkcfg) == 0u);
     cfg.NumRetry = ref.getnumRetry(env, jlinkcfg);
     cfg.LocalAddr = static_cast<uint16_t>(ref.getlocalAddr(env, jlinkcfg));
     cfg.RemoteAddr = static_cast<uint16_t>(ref.getremoteAddr(env, jlinkcfg));
@@ -138,7 +138,7 @@ opendnp3::OutstationParams ConfigReader::ConvertOutstationConfig(JNIEnv* env, jo
     config.unsolRetryTimeout = ConvertDuration(env, cfg.getunsolRetryTimeout(env, jconfig));
     config.maxTxFragSize = cfg.getmaxTxFragSize(env, jconfig);
     config.maxRxFragSize = cfg.getmaxRxFragSize(env, jconfig);
-    config.allowUnsolicited = !!cfg.getallowUnsolicited(env, jconfig);
+    config.allowUnsolicited = !(cfg.getallowUnsolicited(env, jconfig) == 0u);
 
     return config;
 }

--- a/java/cpp/adapters/ConfigReader.h
+++ b/java/cpp/adapters/ConfigReader.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -30,11 +30,11 @@
 class ConfigReader
 {
 public:
-    static asiodnp3::MasterStackConfig ConvertMasterStackConfig(JNIEnv* env, jobject jconfig);
+    static asiodnp3::MasterStackConfig ConvertMasterStackConfig(JNIEnv* env, jobject jcfg);
     static asiodnp3::OutstationStackConfig ConvertOutstationStackConfig(JNIEnv* env, jobject jconfig);
 
 private:
-    static opendnp3::LinkConfig ConvertLinkConfig(JNIEnv* env, jobject jconfig);
+    static opendnp3::LinkConfig ConvertLinkConfig(JNIEnv* env, jobject jlinkcfg);
     static opendnp3::MasterParams ConvertMasterConfig(JNIEnv* apEnv, jobject jcfg);
 
     static opendnp3::ClassField ConvertClassField(JNIEnv* env, jobject jclassmask);

--- a/java/cpp/adapters/Conversions.cpp
+++ b/java/cpp/adapters/Conversions.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/adapters/Conversions.h
+++ b/java/cpp/adapters/Conversions.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/adapters/GlobalRef.h
+++ b/java/cpp/adapters/GlobalRef.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/adapters/JNI.cpp
+++ b/java/cpp/adapters/JNI.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -22,17 +22,17 @@
 
 #include "../jni/JCache.h"
 
-#include <assert.h>
+#include <cassert>
 
 using namespace std;
 
-JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved)
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /*reserved*/)
 {
     JNI::Initialize(vm);
     return jni::JCache::init(JNI::GetEnv()) ? OPENDNP3_JNI_VERSION : JNI_ERR;
 }
 
-JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* vm, void* reserved)
+JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* /*vm*/, void* /*reserved*/)
 {
     jni::JCache::cleanup(JNI::GetEnv());
 }
@@ -40,7 +40,7 @@ JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* vm, void* reserved)
 JNIEnv* JNI::GetEnv()
 {
     JNIEnv* env = nullptr;
-    vm->GetEnv((void**)&env, OPENDNP3_JNI_VERSION);
+    vm->GetEnv(reinterpret_cast<void**>(&env), OPENDNP3_JNI_VERSION);
     assert(env);
     return env;
 }
@@ -54,7 +54,7 @@ void JNI::Initialize(JavaVM* vmin)
 bool JNI::AttachCurrentThread()
 {
     JNIEnv* env;
-    return vm->AttachCurrentThread((void**)&env, nullptr) == 0;
+    return vm->AttachCurrentThread(reinterpret_cast<void**>(&env), nullptr) == 0;
 }
 
 bool JNI::DetachCurrentThread()
@@ -79,7 +79,7 @@ void JNI::Iterate(JNIEnv* env, jobject iterable, const std::function<void(LocalR
 {
     auto iterator = jni::JCache::Iterable.iterator(env, iterable);
 
-    while (jni::JCache::Iterator.hasNext(env, iterator))
+    while (jni::JCache::Iterator.hasNext(env, iterator) != 0u)
     {
         callback(jni::JCache::Iterator.next(env, iterator));
     }
@@ -90,7 +90,7 @@ void JNI::IterateWithIndex(JNIEnv* env, jobject iterable, const std::function<vo
     auto iterator = jni::JCache::Iterable.iterator(env, iterable);
 
     int i = 0;
-    while (jni::JCache::Iterator.hasNext(env, iterator))
+    while (jni::JCache::Iterator.hasNext(env, iterator) != 0u)
     {
         callback(jni::JCache::Iterator.next(env, iterator), i);
         ++i;

--- a/java/cpp/adapters/JNI.h
+++ b/java/cpp/adapters/JNI.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/adapters/LocalRef.h
+++ b/java/cpp/adapters/LocalRef.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/adapters/LogHandlerAdapter.cpp
+++ b/java/cpp/adapters/LogHandlerAdapter.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/adapters/LogHandlerAdapter.h
+++ b/java/cpp/adapters/LogHandlerAdapter.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/adapters/MasterApplicationAdapter.cpp
+++ b/java/cpp/adapters/MasterApplicationAdapter.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -41,7 +41,7 @@ void MasterApplicationAdapter::OnTaskStart(MasterTaskType type, TaskId id)
 {
     const auto env = JNI::GetEnv();
     auto jtasktype = jni::JCache::MasterTaskType.fromType(env, static_cast<jint>(type));
-    auto jtaskid = jni::JCache::TaskId.init2(env, id.GetId(), id.IsDefined());
+    auto jtaskid = jni::JCache::TaskId.init2(env, id.GetId(), static_cast<jboolean>(id.IsDefined()));
     jni::JCache::MasterApplication.onTaskStart(env, proxy, jtasktype, jtaskid);
 }
 
@@ -50,7 +50,7 @@ void MasterApplicationAdapter::OnTaskComplete(const TaskInfo& info)
     const auto env = JNI::GetEnv();
     auto jtype = jni::JCache::MasterTaskType.fromType(env, static_cast<jint>(info.type));
     auto jresult = jni::JCache::TaskCompletion.fromType(env, static_cast<jint>(info.result));
-    auto jtaskid = jni::JCache::TaskId.init2(env, info.id.GetId(), info.id.IsDefined());
+    auto jtaskid = jni::JCache::TaskId.init2(env, info.id.GetId(), static_cast<jboolean>(info.id.IsDefined()));
 
     auto jinfo = jni::JCache::TaskInfo.init3(env, jtype, jresult, jtaskid);
     jni::JCache::MasterApplication.onTaskComplete(env, proxy, jinfo);
@@ -71,7 +71,7 @@ void MasterApplicationAdapter::OnClose()
 bool MasterApplicationAdapter::AssignClassDuringStartup()
 {
     const auto env = JNI::GetEnv();
-    return !!jni::JCache::MasterApplication.assignClassDuringStartup(env, proxy);
+    return !(jni::JCache::MasterApplication.assignClassDuringStartup(env, proxy) == 0u);
 }
 
 void MasterApplicationAdapter::ConfigureAssignClassRequest(const WriteHeaderFunT& fun)
@@ -91,7 +91,7 @@ void MasterApplicationAdapter::ConfigureAssignClassRequest(const WriteHeaderFunT
         fun(Header::From(clazz));
 
         // write the header for the assigned type
-        if (jni::JCache::Range.isDefined(env, jrange))
+        if (jni::JCache::Range.isDefined(env, jrange) != 0u)
         {
             const auto jstart = jni::JCache::Range.getstart(env, jrange);
             const auto jstop = jni::JCache::Range.getstop(env, jrange);

--- a/java/cpp/adapters/MasterApplicationAdapter.h
+++ b/java/cpp/adapters/MasterApplicationAdapter.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/adapters/OutstationApplicationAdapter.cpp
+++ b/java/cpp/adapters/OutstationApplicationAdapter.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -28,19 +28,19 @@ using namespace opendnp3;
 bool OutstationApplicationAdapter::SupportsWriteAbsoluteTime()
 {
     const auto env = JNI::GetEnv();
-    return !!JCache::OutstationApplication.supportsWriteAbsoluteTime(env, proxy);
+    return !(JCache::OutstationApplication.supportsWriteAbsoluteTime(env, proxy) == 0u);
 }
 
 bool OutstationApplicationAdapter::WriteAbsoluteTime(const openpal::UTCTimestamp& timestamp)
 {
     const auto env = JNI::GetEnv();
-    return !!JCache::OutstationApplication.writeAbsoluteTime(env, proxy, timestamp.msSinceEpoch);
+    return !(JCache::OutstationApplication.writeAbsoluteTime(env, proxy, timestamp.msSinceEpoch) == 0u);
 }
 
 bool OutstationApplicationAdapter::SupportsAssignClass()
 {
     const auto env = JNI::GetEnv();
-    return !!JCache::OutstationApplication.supportsAssignClass(env, proxy);
+    return !(JCache::OutstationApplication.supportsAssignClass(env, proxy) == 0u);
 }
 
 void OutstationApplicationAdapter::RecordClassAssignment(AssignClassType type,
@@ -61,10 +61,10 @@ ApplicationIIN OutstationApplicationAdapter::GetApplicationIIN() const
     const auto env = JNI::GetEnv();
     auto jiin = JCache::OutstationApplication.getApplicationIIN(env, proxy);
     ApplicationIIN iin;
-    iin.configCorrupt = !!JCache::ApplicationIIN.getconfigCorrupt(env, jiin);
-    iin.deviceTrouble = !!JCache::ApplicationIIN.getdeviceTrouble(env, jiin);
-    iin.localControl = !!JCache::ApplicationIIN.getlocalControl(env, jiin);
-    iin.needTime = !!JCache::ApplicationIIN.getneedTime(env, jiin);
+    iin.configCorrupt = !(JCache::ApplicationIIN.getconfigCorrupt(env, jiin) == 0u);
+    iin.deviceTrouble = !(JCache::ApplicationIIN.getdeviceTrouble(env, jiin) == 0u);
+    iin.localControl = !(JCache::ApplicationIIN.getlocalControl(env, jiin) == 0u);
+    iin.needTime = !(JCache::ApplicationIIN.getneedTime(env, jiin) == 0u);
     return iin;
 }
 

--- a/java/cpp/adapters/OutstationApplicationAdapter.h
+++ b/java/cpp/adapters/OutstationApplicationAdapter.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/adapters/SOEHandlerAdapter.cpp
+++ b/java/cpp/adapters/SOEHandlerAdapter.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -61,7 +61,7 @@ void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info,
 void SOEHandlerAdapter::Process(const HeaderInfo& info, const ICollection<Indexed<Binary>>& values)
 {
     auto create = [](JNIEnv* env, const Binary& value) -> LocalRef<jobject> {
-        return jni::JCache::BinaryInput.init3(env, value.value, value.flags.value, value.time);
+        return jni::JCache::BinaryInput.init3(env, static_cast<jboolean>(value.value), value.flags.value, value.time);
     };
 
     auto call = [](JNIEnv* env, jobject proxy, jobject hinfo, jobject list) {
@@ -123,7 +123,8 @@ void SOEHandlerAdapter::Process(const HeaderInfo& info, const ICollection<Indexe
 void SOEHandlerAdapter::Process(const HeaderInfo& info, const ICollection<Indexed<BinaryOutputStatus>>& values)
 {
     auto create = [](JNIEnv* env, const BinaryOutputStatus& value) -> LocalRef<jobject> {
-        return jni::JCache::BinaryOutputStatus.init3(env, value.value, value.flags.value, value.time);
+        return jni::JCache::BinaryOutputStatus.init3(env, static_cast<jboolean>(value.value), value.flags.value,
+                                                     value.time);
     };
     auto call = [](JNIEnv* env, jobject proxy, jobject hinfo, jobject list) {
         jni::JCache::SOEHandler.processBOS(env, proxy, hinfo, list);
@@ -168,8 +169,8 @@ LocalRef<jobject> SOEHandlerAdapter::Convert(JNIEnv* env, const opendnp3::Header
     auto gv = jni::JCache::GroupVariation.fromType(env, GroupVariationToType(info.gv));
     auto qc = jni::JCache::QualifierCode.fromType(env, QualifierCodeToType(info.qualifier));
     auto tsmode = jni::JCache::TimestampMode.fromType(env, static_cast<jint>(info.tsmode));
-    jboolean isEvent = info.isEventVariation;
-    jboolean flagsValid = info.flagsValid;
+    jboolean isEvent = static_cast<jboolean>(info.isEventVariation);
+    jboolean flagsValid = static_cast<jboolean>(info.flagsValid);
     jint headerIndex = info.headerIndex;
 
     return jni::JCache::HeaderInfo.init6(env, gv, qc, tsmode, isEvent, flagsValid, headerIndex);

--- a/java/cpp/adapters/SOEHandlerAdapter.h
+++ b/java/cpp/adapters/SOEHandlerAdapter.h
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you

--- a/java/cpp/com_automatak_dnp3_impl_ChangeSetImpl.cpp
+++ b/java/cpp/com_automatak_dnp3_impl_ChangeSetImpl.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -24,27 +24,29 @@
 using namespace opendnp3;
 using namespace asiodnp3;
 
-JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_create_1instance_1native(JNIEnv* env, jobject)
+JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_create_1instance_1native(JNIEnv* /*env*/,
+                                                                                            jobject /*unused*/)
 {
     return (jlong) new UpdateBuilder();
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_destroy_1instance_1native(JNIEnv* env,
-                                                                                            jobject,
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_destroy_1instance_1native(JNIEnv* /*env*/,
+                                                                                            jobject /*unused*/,
                                                                                             jlong native)
 {
     delete (UpdateBuilder*)native;
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1binary_1native(
-    JNIEnv* env, jobject, jlong native, jboolean value, jbyte flags, jlong time, jint index, jint mode)
+    JNIEnv* /*env*/, jobject /*unused*/, jlong native, jboolean value, jbyte flags, jlong time, jint index, jint mode)
 {
     const auto changes = (UpdateBuilder*)native;
-    changes->Update(Binary(!!value, flags, DNPTime(time)), static_cast<uint16_t>(index), static_cast<EventMode>(mode));
+    changes->Update(Binary(!(value == 0u), flags, DNPTime(time)), static_cast<uint16_t>(index),
+                    static_cast<EventMode>(mode));
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1double_1binary_1native(
-    JNIEnv* env, jobject, jlong native, jint value, jbyte flags, jlong time, jint index, jint mode)
+    JNIEnv* /*env*/, jobject /*unused*/, jlong native, jint value, jbyte flags, jlong time, jint index, jint mode)
 {
     const auto changes = (UpdateBuilder*)native;
     changes->Update(DoubleBitBinary(static_cast<DoubleBit>(value), flags, DNPTime(time)), static_cast<uint16_t>(index),
@@ -52,14 +54,14 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1double
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1analog_1native(
-    JNIEnv* env, jobject, jlong native, jdouble value, jbyte flags, jlong time, jint index, jint mode)
+    JNIEnv* /*env*/, jobject /*unused*/, jlong native, jdouble value, jbyte flags, jlong time, jint index, jint mode)
 {
     const auto changes = (UpdateBuilder*)native;
     changes->Update(Analog(value, flags, DNPTime(time)), static_cast<uint16_t>(index), static_cast<EventMode>(mode));
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1counter_1native(
-    JNIEnv* env, jobject, jlong native, jlong value, jbyte flags, jlong time, jint index, jint mode)
+    JNIEnv* /*env*/, jobject /*unused*/, jlong native, jlong value, jbyte flags, jlong time, jint index, jint mode)
 {
     const auto changes = (UpdateBuilder*)native;
     changes->Update(Counter(static_cast<uint32_t>(value), flags, DNPTime(time)), static_cast<uint16_t>(index),
@@ -67,7 +69,7 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1counte
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1frozen_1counter_1native(
-    JNIEnv* env, jobject, jlong native, jlong value, jbyte flags, jlong time, jint index, jint mode)
+    JNIEnv* /*env*/, jobject /*unused*/, jlong native, jlong value, jbyte flags, jlong time, jint index, jint mode)
 {
     const auto changes = (UpdateBuilder*)native;
     changes->Update(FrozenCounter(static_cast<uint32_t>(value), flags, DNPTime(time)), static_cast<uint16_t>(index),
@@ -75,15 +77,15 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1frozen
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1bo_1status_1native(
-    JNIEnv* env, jobject, jlong native, jboolean value, jbyte flags, jlong time, jint index, jint mode)
+    JNIEnv* /*env*/, jobject /*unused*/, jlong native, jboolean value, jbyte flags, jlong time, jint index, jint mode)
 {
     const auto changes = (UpdateBuilder*)native;
-    changes->Update(BinaryOutputStatus(!!value, flags, DNPTime(time)), static_cast<uint16_t>(index),
+    changes->Update(BinaryOutputStatus(!(value == 0u), flags, DNPTime(time)), static_cast<uint16_t>(index),
                     static_cast<EventMode>(mode));
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1ao_1status_1native(
-    JNIEnv* env, jobject, jlong native, jdouble value, jbyte flags, jlong time, jint index, jint mode)
+    JNIEnv* /*env*/, jobject /*unused*/, jlong native, jdouble value, jbyte flags, jlong time, jint index, jint mode)
 {
     const auto changes = (UpdateBuilder*)native;
     changes->Update(AnalogOutputStatus(value, flags, DNPTime(time)), static_cast<uint16_t>(index),

--- a/java/cpp/com_automatak_dnp3_impl_ChannelImpl.cpp
+++ b/java/cpp/com_automatak_dnp3_impl_ChannelImpl.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -34,8 +34,8 @@
 using namespace asiodnp3;
 using namespace opendnp3;
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChannelImpl_set_1log_1level_1native(JNIEnv* env,
-                                                                                        jobject,
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChannelImpl_set_1log_1level_1native(JNIEnv* /*env*/,
+                                                                                        jobject /*unused*/,
                                                                                         jlong native,
                                                                                         jint levels)
 {
@@ -44,7 +44,7 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChannelImpl_set_1log_1level_
 }
 
 JNIEXPORT jobject JNICALL Java_com_automatak_dnp3_impl_ChannelImpl_get_1statistics_1native(JNIEnv* env,
-                                                                                           jobject,
+                                                                                           jobject /*unused*/,
                                                                                            jlong native)
 {
     const auto channel = (std::shared_ptr<IChannel>*)native;
@@ -61,20 +61,24 @@ JNIEXPORT jobject JNICALL Java_com_automatak_dnp3_impl_ChannelImpl_get_1statisti
     return env->NewGlobalRef(jni::JCache::LinkStatistics.init2(env, channelStats, parserStats));
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChannelImpl_shutdown_1native(JNIEnv* env, jobject, jlong native)
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChannelImpl_shutdown_1native(JNIEnv* /*env*/,
+                                                                                 jobject /*unused*/,
+                                                                                 jlong native)
 {
     const auto channel = (std::shared_ptr<IChannel>*)native;
     (*channel)->Shutdown();
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChannelImpl_destroy_1native(JNIEnv*, jobject, jlong native)
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChannelImpl_destroy_1native(JNIEnv* /*unused*/,
+                                                                                jobject /*unused*/,
+                                                                                jlong native)
 {
     const auto channel = (std::shared_ptr<IChannel>*)native;
     delete channel; // drop our reference
 }
 
 JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ChannelImpl_get_1native_1master(
-    JNIEnv* env, jobject, jlong native, jstring jid, jobject handler, jobject application, jobject jconfig)
+    JNIEnv* env, jobject /*unused*/, jlong native, jstring jid, jobject handler, jobject application, jobject jconfig)
 {
     const auto channel = (std::shared_ptr<IChannel>*)native;
 
@@ -89,8 +93,13 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ChannelImpl_get_1native_1ma
     return stack ? (jlong) new std::shared_ptr<IMaster>(stack) : 0;
 }
 
-JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ChannelImpl_get_1native_1outstation(
-    JNIEnv* env, jobject, jlong native, jstring jid, jobject commandHandler, jobject application, jobject jconfig)
+JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ChannelImpl_get_1native_1outstation(JNIEnv* env,
+                                                                                         jobject /*unused*/,
+                                                                                         jlong native,
+                                                                                         jstring jid,
+                                                                                         jobject commandHandler,
+                                                                                         jobject application,
+                                                                                         jobject jconfig)
 {
     const auto channel = (std::shared_ptr<IChannel>*)native;
 

--- a/java/cpp/com_automatak_dnp3_impl_CommandBuilderImpl.cpp
+++ b/java/cpp/com_automatak_dnp3_impl_CommandBuilderImpl.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -26,20 +26,21 @@
 
 using namespace opendnp3;
 
-JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_CommandBuilderImpl_create_1native(JNIEnv* env, jobject)
+JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_CommandBuilderImpl_create_1native(JNIEnv* /*env*/,
+                                                                                       jobject /*unused*/)
 {
     return (jlong) new CommandSet();
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_CommandBuilderImpl_destroy_1native(JNIEnv* env,
-                                                                                       jobject,
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_CommandBuilderImpl_destroy_1native(JNIEnv* /*env*/,
+                                                                                       jobject /*unused*/,
                                                                                        jlong native)
 {
     delete (CommandSet*)native;
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_CommandBuilderImpl_add_1crob_1native(JNIEnv* env,
-                                                                                         jobject,
+                                                                                         jobject /*unused*/,
                                                                                          jlong native,
                                                                                          jobject jcommands)
 {
@@ -92,7 +93,7 @@ template<class T, class Cache> void process_analogs(JNIEnv* env, jlong native, j
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_CommandBuilderImpl_add_1aoI16_1native(JNIEnv* env,
-                                                                                          jobject,
+                                                                                          jobject /*unused*/,
                                                                                           jlong native,
                                                                                           jobject jcommands)
 {
@@ -100,7 +101,7 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_CommandBuilderImpl_add_1aoI1
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_CommandBuilderImpl_add_1aoI32_1native(JNIEnv* env,
-                                                                                          jobject,
+                                                                                          jobject /*unused*/,
                                                                                           jlong native,
                                                                                           jobject jcommands)
 {
@@ -108,7 +109,7 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_CommandBuilderImpl_add_1aoI3
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_CommandBuilderImpl_add_1aoF32_1native(JNIEnv* env,
-                                                                                          jobject,
+                                                                                          jobject /*unused*/,
                                                                                           jlong native,
                                                                                           jobject jcommands)
 {
@@ -116,7 +117,7 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_CommandBuilderImpl_add_1aoF3
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_CommandBuilderImpl_add_1aoD64_1native(JNIEnv* env,
-                                                                                          jobject,
+                                                                                          jobject /*unused*/,
                                                                                           jlong native,
                                                                                           jobject jcommands)
 {

--- a/java/cpp/com_automatak_dnp3_impl_ManagerImpl.cpp
+++ b/java/cpp/com_automatak_dnp3_impl_ManagerImpl.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -41,12 +41,13 @@ asiopal::TLSConfig ConvertTLSConfig(JNIEnv* env, jobject jconfig)
     CString cipherList(env, ref.getcipherList(env, jconfig));
 
     return asiopal::TLSConfig(peerCertFilePath.str(), localCertFilePath.str(), privateKeyFilePath.str(),
-                              ref.getmaxVerifyDepth(env, jconfig), !!ref.getallowTLSv10(env, jconfig),
-                              !!ref.getallowTLSv11(env, jconfig), !!ref.getallowTLSv12(env, jconfig), cipherList.str());
+                              ref.getmaxVerifyDepth(env, jconfig), !(ref.getallowTLSv10(env, jconfig) == 0u),
+                              !(ref.getallowTLSv11(env, jconfig) == 0u), !(ref.getallowTLSv12(env, jconfig) == 0u),
+                              cipherList.str());
 }
 
-JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_create_1native_1manager(JNIEnv* env,
-                                                                                         jobject,
+JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_create_1native_1manager(JNIEnv* /*env*/,
+                                                                                         jobject /*unused*/,
                                                                                          jint concurreny,
                                                                                          jobject loghandler)
 {
@@ -58,15 +59,15 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_create_1native_
     return (jlong) new DNP3Manager(concurreny, adapter, attach, detach);
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_shutdown_1native_1manager(JNIEnv*,
-                                                                                          jobject,
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_shutdown_1native_1manager(JNIEnv* /*unused*/,
+                                                                                          jobject /*unused*/,
                                                                                           jlong pointer)
 {
     delete (DNP3Manager*)pointer;
 }
 
 JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1channel_1tcp_1client(JNIEnv* env,
-                                                                                                   jobject,
+                                                                                                   jobject /*unused*/,
                                                                                                    jlong native,
                                                                                                    jstring jid,
                                                                                                    jint jlevels,
@@ -81,7 +82,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
     CString id(env, jid);
     CString adapter(env, jadapter);
     ChannelRetry retry(TimeDuration::Milliseconds(jminRetry), TimeDuration::Milliseconds(jmaxRetry));
-    auto listener = jlistener ? std::make_shared<ChannelListenerAdapter>(jlistener) : nullptr;
+    auto listener = jlistener != nullptr ? std::make_shared<ChannelListenerAdapter>(jlistener) : nullptr;
 
     // Convert endpoints
     std::vector<asiopal::IPEndpoint> endpoints;
@@ -100,7 +101,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
 }
 
 JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1channel_1tcp_1server(JNIEnv* env,
-                                                                                                   jobject,
+                                                                                                   jobject /*unused*/,
                                                                                                    jlong native,
                                                                                                    jstring jid,
                                                                                                    jint jlevels,
@@ -114,7 +115,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
     CString id(env, jid);
     CString adapter(env, jadapter);
 
-    auto listener = jlistener ? std::make_shared<ChannelListenerAdapter>(jlistener) : nullptr;
+    auto listener = jlistener != nullptr ? std::make_shared<ChannelListenerAdapter>(jlistener) : nullptr;
 
     auto channel = manager->AddTCPServer(id.str(), jlevels, static_cast<ServerAcceptMode>(jmode), adapter.str(),
                                          static_cast<uint16_t>(jport), listener);
@@ -123,7 +124,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
 }
 
 JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1channel_1tls_1client(JNIEnv* env,
-                                                                                                   jobject,
+                                                                                                   jobject /*unused*/,
                                                                                                    jlong native,
                                                                                                    jstring jid,
                                                                                                    jint jlevels,
@@ -140,7 +141,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
     CString adapter(env, jadapter);
     ChannelRetry retry(TimeDuration::Milliseconds(jminRetry), TimeDuration::Milliseconds(jmaxRetry));
     auto tlsconf = ConvertTLSConfig(env, jtlsconfig);
-    auto listener = jlistener ? std::make_shared<ChannelListenerAdapter>(jlistener) : nullptr;
+    auto listener = jlistener != nullptr ? std::make_shared<ChannelListenerAdapter>(jlistener) : nullptr;
 
     // Convert endpoints
     std::vector<asiopal::IPEndpoint> endpoints;
@@ -161,7 +162,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
 }
 
 JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1channel_1tls_1server(JNIEnv* env,
-                                                                                                   jobject,
+                                                                                                   jobject /*unused*/,
                                                                                                    jlong native,
                                                                                                    jstring jid,
                                                                                                    jint jlevels,
@@ -178,7 +179,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
 
     auto tlsconf = ConvertTLSConfig(env, jtlsconfig);
 
-    auto listener = jlistener ? std::make_shared<ChannelListenerAdapter>(jlistener) : nullptr;
+    auto listener = jlistener != nullptr ? std::make_shared<ChannelListenerAdapter>(jlistener) : nullptr;
 
     std::error_code ec;
 
@@ -189,7 +190,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
 }
 
 JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1channel_1serial(JNIEnv* env,
-                                                                                              jobject,
+                                                                                              jobject /*unused*/,
                                                                                               jlong native,
                                                                                               jstring jid,
                                                                                               jint jlevels,
@@ -218,7 +219,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
     settings.parity = opendnp3::ParityFromType(static_cast<uint8_t>(jparity));
     settings.stopBits = opendnp3::StopBitsFromType(static_cast<uint8_t>(jstopbits));
 
-    auto listener = jlistener ? std::make_shared<ChannelListenerAdapter>(jlistener) : nullptr;
+    auto listener = jlistener != nullptr ? std::make_shared<ChannelListenerAdapter>(jlistener) : nullptr;
 
     auto channel = manager->AddSerial(id.str(), jlevels, retry, settings, listener);
 

--- a/java/cpp/com_automatak_dnp3_impl_MasterImpl.cpp
+++ b/java/cpp/com_automatak_dnp3_impl_MasterImpl.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -29,8 +29,8 @@
 
 #include <memory>
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_set_1log_1level_1native(JNIEnv* env,
-                                                                                       jobject,
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_set_1log_1level_1native(JNIEnv* /*env*/,
+                                                                                       jobject /*unused*/,
                                                                                        jlong native,
                                                                                        jint levels)
 {
@@ -39,7 +39,7 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_set_1log_1level_1
 }
 
 JNIEXPORT jobject JNICALL Java_com_automatak_dnp3_impl_MasterImpl_get_1statistics_1native(JNIEnv* env,
-                                                                                          jobject,
+                                                                                          jobject /*unused*/,
                                                                                           jlong native)
 {
     const auto master = (std::shared_ptr<asiodnp3::IMaster>*)native;
@@ -47,31 +47,40 @@ JNIEXPORT jobject JNICALL Java_com_automatak_dnp3_impl_MasterImpl_get_1statistic
     return env->NewGlobalRef(Conversions::ConvertStackStatistics(env, stats));
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_enable_1native(JNIEnv* env, jobject, jlong native)
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_enable_1native(JNIEnv* /*env*/,
+                                                                              jobject /*unused*/,
+                                                                              jlong native)
 {
     const auto master = (std::shared_ptr<asiodnp3::IMaster>*)native;
     (*master)->Enable();
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_disable_1native(JNIEnv* env, jobject, jlong native)
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_disable_1native(JNIEnv* /*env*/,
+                                                                               jobject /*unused*/,
+                                                                               jlong native)
 {
     const auto master = (std::shared_ptr<asiodnp3::IMaster>*)native;
     (*master)->Disable();
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_shutdown_1native(JNIEnv* env, jobject, jlong native)
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_shutdown_1native(JNIEnv* /*env*/,
+                                                                                jobject /*unused*/,
+                                                                                jlong native)
 {
     const auto master = (std::shared_ptr<asiodnp3::IMaster>*)native;
     (*master)->Shutdown();
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_destroy_1native(JNIEnv*, jobject, jlong native)
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_destroy_1native(JNIEnv* /*unused*/,
+                                                                               jobject /*unused*/,
+                                                                               jlong native)
 {
     const auto master = (std::shared_ptr<asiodnp3::IMaster>*)native;
     delete master;
 }
 
-template<class Fun> void operate(JNIEnv* env, jlong native, jlong nativeCommandSet, jobject future, const Fun& operate)
+template<class Fun>
+void operate(JNIEnv* /*env*/, jlong native, jlong nativeCommandSet, jobject future, const Fun& operate)
 {
     auto& set = *(opendnp3::CommandSet*)nativeCommandSet;
 
@@ -100,7 +109,7 @@ template<class Fun> void operate(JNIEnv* env, jlong native, jlong nativeCommandS
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_select_1and_1operate_1native(
-    JNIEnv* env, jobject, jlong native, jlong nativeCommandSet, jobject future)
+    JNIEnv* env, jobject /*unused*/, jlong native, jlong nativeCommandSet, jobject future)
 {
     auto sbo = [](asiodnp3::IMaster& master, opendnp3::CommandSet& commandset,
                   const opendnp3::CommandCallbackT& callback) -> void {
@@ -111,7 +120,7 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_select_1and_1oper
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_direct_1operate_1native(
-    JNIEnv* env, jobject, jlong native, jlong nativeCommandSet, jobject future)
+    JNIEnv* env, jobject /*unused*/, jlong native, jlong nativeCommandSet, jobject future)
 {
     auto directOp = [](asiodnp3::IMaster& master, opendnp3::CommandSet& commandset,
                        const opendnp3::CommandCallbackT& callback) -> void {
@@ -154,7 +163,7 @@ bool ConvertJHeader(JNIEnv* env, jobject jheader, opendnp3::Header& header)
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_scan_1native(JNIEnv* env,
-                                                                            jobject,
+                                                                            jobject /*unused*/,
                                                                             jlong native,
                                                                             jobject jheaders)
 {
@@ -176,7 +185,7 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_scan_1native(JNIE
 }
 
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_MasterImpl_add_1periodic_1scan_1native(
-    JNIEnv* env, jobject, jlong native, jobject jduration, jobject jheaders)
+    JNIEnv* env, jobject /*unused*/, jlong native, jobject jduration, jobject jheaders)
 {
     const auto master = (std::shared_ptr<asiodnp3::IMaster>*)native;
 

--- a/java/cpp/com_automatak_dnp3_impl_OutstationImpl.cpp
+++ b/java/cpp/com_automatak_dnp3_impl_OutstationImpl.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -24,8 +24,8 @@
 #include "asiodnp3/IOutstation.h"
 #include "asiodnp3/UpdateBuilder.h"
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_set_1log_1level_1native(JNIEnv* env,
-                                                                                           jobject,
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_set_1log_1level_1native(JNIEnv* /*env*/,
+                                                                                           jobject /*unused*/,
                                                                                            jlong native,
                                                                                            jint levels)
 {
@@ -34,7 +34,7 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_set_1log_1lev
 }
 
 JNIEXPORT jobject JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_get_1statistics_1native(JNIEnv* env,
-                                                                                              jobject,
+                                                                                              jobject /*unused*/,
                                                                                               jlong native)
 {
     auto outstation = (std::shared_ptr<asiodnp3::IOutstation>*)native;
@@ -42,32 +42,40 @@ JNIEXPORT jobject JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_get_1stati
     return env->NewGlobalRef(Conversions::ConvertStackStatistics(env, stats));
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_enable_1native(JNIEnv* env, jobject, jlong native)
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_enable_1native(JNIEnv* /*env*/,
+                                                                                  jobject /*unused*/,
+                                                                                  jlong native)
 {
     auto outstation = (std::shared_ptr<asiodnp3::IOutstation>*)native;
     (*outstation)->Enable();
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_disable_1native(JNIEnv* env, jobject, jlong native)
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_disable_1native(JNIEnv* /*env*/,
+                                                                                   jobject /*unused*/,
+                                                                                   jlong native)
 {
     auto outstation = (std::shared_ptr<asiodnp3::IOutstation>*)native;
     (*outstation)->Disable();
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_shutdown_1native(JNIEnv* env, jobject, jlong native)
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_shutdown_1native(JNIEnv* /*env*/,
+                                                                                    jobject /*unused*/,
+                                                                                    jlong native)
 {
     auto outstation = (std::shared_ptr<asiodnp3::IOutstation>*)native;
     (*outstation)->Shutdown();
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_destroy_1native(JNIEnv*, jobject, jlong native)
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_destroy_1native(JNIEnv* /*unused*/,
+                                                                                   jobject /*unused*/,
+                                                                                   jlong native)
 {
     auto outstation = (std::shared_ptr<asiodnp3::IOutstation>*)native;
     delete outstation;
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_apply_1native(JNIEnv* env,
-                                                                                 jobject,
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_OutstationImpl_apply_1native(JNIEnv* /*env*/,
+                                                                                 jobject /*unused*/,
                                                                                  jlong native,
                                                                                  jlong nativeChangeSet)
 {

--- a/java/cpp/jni/JNITaskConfig.cpp
+++ b/java/cpp/jni/JNITaskConfig.cpp
@@ -1,22 +1,3 @@
-/*
- * Copyright 2013-2019 Automatak, LLC
- *
- * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
- * See the NOTICE file distributed with this work for additional information
- * regarding copyright ownership. Green Energy Corp and Automatak LLC license
- * this file to you under the Apache License, Version 2.0 (the "License"); you
- * may not use this file except in compliance with the License. You may obtain
- * a copy of the License at:
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 //
 //  _   _         ______    _ _ _   _             _ _ _
 // | \ | |       |  ____|  | (_) | (_)           | | | |
@@ -29,12 +10,23 @@
 // 
 // This file is auto-generated. Do not edit manually
 // 
-// Copyright 2016 Automatak LLC
+// Copyright 2013-2019 Automatak, LLC
 // 
-// Automatak LLC (www.automatak.com) licenses this file
-// to you under the the Apache License Version 2.0 (the "License"):
+// Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+// LLC (www.automatak.com) under one or more contributor license agreements.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership. Green Energy Corp and Automatak LLC license
+// this file to you under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License. You may obtain
+// a copy of the License at:
 // 
-// http://www.apache.org/licenses/LICENSE-2.0.html
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 #include "JNITaskConfig.h"


### PR DESCRIPTION
- Added clang-tidy integration with `ENABLE_CLANG_TIDY`.
- Added custom target `clang-tidy` that fixes automatically the code. Be warned that some fixes are not perfect.