### PR TITLE
Add auto-versioning to .NET components

### DIFF
--- a/dotnet/CLRAdapter/CMakeLists.txt
+++ b/dotnet/CLRAdapter/CMakeLists.txt
@@ -1,5 +1,8 @@
 
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/AssemblyInfo.cpp "[assembly:System::Reflection::AssemblyVersion(\"${opendnp3_VERSION}\")];")
+
 add_library(DNP3CLRAdapter SHARED
+${CMAKE_CURRENT_BINARY_DIR}/AssemblyInfo.cpp
 src/CallbackAdapters.cpp
 src/CallbackAdapters.h
 src/ChangeSetAdapter.cpp

--- a/dotnet/CLRInterface/CMakeLists.txt
+++ b/dotnet/CLRInterface/CMakeLists.txt
@@ -1,6 +1,9 @@
 enable_language(CSharp)
 
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/AssemblyInfo.cs "[assembly: System.Reflection.AssemblyVersion(\"${opendnp3_VERSION}\")]")
+
 add_library(DNP3CLRInterface SHARED
+${CMAKE_CURRENT_BINARY_DIR}/AssemblyInfo.cs
 src/ApplicationIIN.cs
 src/BaseMeasurementTypes.cs
 src/ChangeSet.cs


### PR DESCRIPTION
Generates AssemblyInfo.cs/AssemblyInfo.cpp during cmake initialization