### PR TITLE
Add broadcast support

### DIFF
--- a/cpp/examples/master-gprs/ExampleListenCallbacks.cpp
+++ b/cpp/examples/master-gprs/ExampleListenCallbacks.cpp
@@ -150,11 +150,11 @@ void ExampleListenCallbacks::OnFirstFrame(uint64_t sessionid,
 
     // do we already have a session with this outstation?
     const auto iter = std::find_if(this->sessions.begin(), this->sessions.end(),
-                                   [&](const auto& item) { return item.address == header.src; });
+                                   [&](const auto& item) { return item.address == header.addresses.source; });
     if (iter != this->sessions.end())
     {
 
-        std::cout << "Already connected to outstation w/ address " << header.src << ". Closing first connection."
+        std::cout << "Already connected to outstation w/ address " << header.addresses.source << ". Closing first connection."
                   << std::endl;
 
         // if so, shutdown the existing session
@@ -165,8 +165,8 @@ void ExampleListenCallbacks::OnFirstFrame(uint64_t sessionid,
     MasterStackConfig config;
 
     // use the master and outstation addresses that the outstation is using
-    config.link.LocalAddr = header.dest;
-    config.link.RemoteAddr = header.src;
+    config.link.LocalAddr = header.addresses.destination;
+    config.link.RemoteAddr = header.addresses.source;
 
     // don't disable unsolicited reporting when the master comes online
     config.master.disableUnsolOnStartup = false;
@@ -174,13 +174,13 @@ void ExampleListenCallbacks::OnFirstFrame(uint64_t sessionid,
     config.master.startupIntegrityClassMask = ClassField::None();
 
     const auto session
-        = acceptor.AcceptSession(GetSessionName(header.src, sessionid), std::make_shared<ExampleSOEHandler>(header.src),
+        = acceptor.AcceptSession(GetSessionName(header.addresses.source, sessionid), std::make_shared<ExampleSOEHandler>(header.addresses.source),
                                  std::make_shared<DefaultMasterApplication>(), config);
 
     // add to the list
-    this->sessions.emplace_back(SessionInfo{sessionid, header.src, session});
+    this->sessions.emplace_back(SessionInfo{sessionid, header.addresses.source, session});
 
-    std::cout << "Outstation session start: " << header.src << std::endl;
+    std::cout << "Outstation session start: " << header.addresses.source << std::endl;
 }
 
 void ExampleListenCallbacks::OnConnectionClose(uint64_t sessionid,

--- a/cpp/lib/CMakeLists.txt
+++ b/cpp/lib/CMakeLists.txt
@@ -532,6 +532,7 @@ set(opendnp3_src
     ./src/gen/objects/Group121.cpp
     ./src/gen/objects/Group122.cpp
 
+    ./src/link/Addresses.cpp
     ./src/link/CRC.cpp
     ./src/link/LinkContext.cpp
     ./src/link/LinkFrame.cpp

--- a/cpp/lib/include/opendnp3/link/Addresses.h
+++ b/cpp/lib/include/opendnp3/link/Addresses.h
@@ -46,6 +46,8 @@ struct Addresses
         return !((*this) == other);
     }
 
+    bool IsBroadcast() const;
+
     uint16_t source = 0;
     uint16_t destination = 0;
 };

--- a/cpp/lib/include/opendnp3/link/LinkHeaderFields.h
+++ b/cpp/lib/include/opendnp3/link/LinkHeaderFields.h
@@ -30,19 +30,13 @@ struct LinkHeaderFields
 {
     LinkHeaderFields();
 
-    LinkHeaderFields(LinkFunction func, bool isMaster, bool fcb, bool fcvdfc, uint16_t dest, uint16_t src_);
-
-    Addresses ToAddresses() const
-    {
-        return Addresses(src, dest);
-    }
+    LinkHeaderFields(LinkFunction func, bool isMaster, bool fcb, bool fcvdfc, Addresses addresses);
 
     LinkFunction func;
     bool isFromMaster;
     bool fcb;
     bool fcvdfc;
-    uint16_t dest;
-    uint16_t src;
+    Addresses addresses;
 };
 
 } // namespace opendnp3

--- a/cpp/lib/src/channel/IOHandler.cpp
+++ b/cpp/lib/src/channel/IOHandler.cpp
@@ -239,12 +239,12 @@ void IOHandler::OnNewChannel(const std::shared_ptr<IAsyncChannel>& channel)
 
 bool IOHandler::OnFrame(const LinkHeaderFields& header, const ser4cpp::rseq_t& userdata)
 {
-    if (this->SendToSession(Addresses(header.src, header.dest), header, userdata))
+    if (this->SendToSession(header.addresses, header, userdata))
     {
         return true;
     }
 
-    FORMAT_LOG_BLOCK(this->logger, flags::WARN, "Frame w/ unknown route, source: %i, dest %i", header.src, header.dest);
+    FORMAT_LOG_BLOCK(this->logger, flags::WARN, "Frame w/ unknown route, source: %i, dest %i", header.addresses.source, header.addresses.destination);
     return false;
 }
 

--- a/cpp/lib/src/link/Addresses.cpp
+++ b/cpp/lib/src/link/Addresses.cpp
@@ -26,9 +26,9 @@ namespace opendnp3
 
 bool Addresses::IsBroadcast() const
 {
-    return this->destination == LL_BROADCAST_DONT_CONFIRM ||
-           this->destination == LL_BROADCAST_SHALL_CONFIRM ||
-           this->destination == LL_BROADCAST_OPTIONAL_CONFIRM;
+    return this->destination == LinkBroadcastAddress::DontConfirm ||
+           this->destination == LinkBroadcastAddress::ShallConfirm ||
+           this->destination == LinkBroadcastAddress::OptionalConfirm;
 }
 
 } // namespace opendnp3

--- a/cpp/lib/src/link/Addresses.cpp
+++ b/cpp/lib/src/link/Addresses.cpp
@@ -17,19 +17,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "opendnp3/link/LinkHeaderFields.h"
+#include "opendnp3/link/Addresses.h"
+
+#include "link/LinkLayerConstants.h"
 
 namespace opendnp3
 {
-LinkHeaderFields::LinkHeaderFields()
-    : func(LinkFunction::INVALID), isFromMaster(false), fcb(false), fcvdfc(false), addresses(Addresses())
-{
-}
 
-LinkHeaderFields::LinkHeaderFields(
-    LinkFunction func_, bool isMaster_, bool fcb_, bool fcvdfc_, Addresses addresses_)
-    : func(func_), isFromMaster(isMaster_), fcb(fcb_), fcvdfc(fcvdfc_), addresses(addresses_)
+bool Addresses::IsBroadcast() const
 {
+    return this->destination == LL_BROADCAST_DONT_CONFIRM ||
+           this->destination == LL_BROADCAST_SHALL_CONFIRM ||
+           this->destination == LL_BROADCAST_OPTIONAL_CONFIRM;
 }
 
 } // namespace opendnp3

--- a/cpp/lib/src/link/LinkContext.cpp
+++ b/cpp/lib/src/link/LinkContext.cpp
@@ -352,10 +352,14 @@ bool LinkContext::OnFrame(const LinkHeaderFields& header, const ser4cpp::rseq_t&
     {
         // Broadcast addresses can only be used for sending data.
         // If confirmed data is used, no response is sent back.
-        if(header.func == LinkFunction::PRI_UNCONFIRMED_USER_DATA || header.func == LinkFunction::PRI_CONFIRMED_USER_DATA)
+        if(header.func == LinkFunction::PRI_UNCONFIRMED_USER_DATA)
         {
             this->PushDataUp(Message(header.addresses, userdata));
             return true;
+        }
+        else if(header.func == LinkFunction::PRI_CONFIRMED_USER_DATA)
+        {
+            pSecState = &pSecState->OnConfirmedUserData(*this, header.addresses.source, header.fcb, true, Message(header.addresses, userdata));
         }
         else
         {
@@ -393,7 +397,7 @@ bool LinkContext::OnFrame(const LinkHeaderFields& header, const ser4cpp::rseq_t&
         break;
     case (LinkFunction::PRI_CONFIRMED_USER_DATA):
         pSecState
-            = &pSecState->OnConfirmedUserData(*this, header.addresses.source, header.fcb, Message(header.addresses, userdata));
+            = &pSecState->OnConfirmedUserData(*this, header.addresses.source, header.fcb, false, Message(header.addresses, userdata));
         break;
     case (LinkFunction::PRI_UNCONFIRMED_USER_DATA):
         this->PushDataUp(Message(header.addresses, userdata));

--- a/cpp/lib/src/link/LinkContext.cpp
+++ b/cpp/lib/src/link/LinkContext.cpp
@@ -363,7 +363,6 @@ bool LinkContext::OnFrame(const LinkHeaderFields& header, const ser4cpp::rseq_t&
             ++statistics.numUnexpectedFrame;
             return false;
         }
-        
     }
 
     // reset the keep-alive timestamp

--- a/cpp/lib/src/link/LinkLayerConstants.h
+++ b/cpp/lib/src/link/LinkLayerConstants.h
@@ -35,9 +35,12 @@ const uint8_t LPDU_MAX_USER_DATA_SIZE = 250;
 const uint16_t LPDU_MAX_FRAME_SIZE = 292; // 10(header) + 250 (user data) + 32 (block CRC's) = 292 frame bytes
 
 // Broadcast addresses
-const uint16_t LL_BROADCAST_DONT_CONFIRM = 0xFFFD;
-const uint16_t LL_BROADCAST_SHALL_CONFIRM = 0xFFFE;
-const uint16_t LL_BROADCAST_OPTIONAL_CONFIRM = 0xFFFF;
+enum LinkBroadcastAddress : uint16_t
+{
+    DontConfirm = 0xFFFD,
+    ShallConfirm = 0xFFFE,
+    OptionalConfirm = 0xFFFF,
+};
 
 /// Indices for use with buffers containing link headers
 enum LinkHeaderIndex : uint8_t

--- a/cpp/lib/src/link/LinkLayerConstants.h
+++ b/cpp/lib/src/link/LinkLayerConstants.h
@@ -34,6 +34,11 @@ const uint8_t LPDU_DATA_PLUS_CRC_SIZE = 18;
 const uint8_t LPDU_MAX_USER_DATA_SIZE = 250;
 const uint16_t LPDU_MAX_FRAME_SIZE = 292; // 10(header) + 250 (user data) + 32 (block CRC's) = 292 frame bytes
 
+// Broadcast addresses
+const uint16_t LL_BROADCAST_DONT_CONFIRM = 0xFFFD;
+const uint16_t LL_BROADCAST_SHALL_CONFIRM = 0xFFFE;
+const uint16_t LL_BROADCAST_OPTIONAL_CONFIRM = 0xFFFF;
+
 /// Indices for use with buffers containing link headers
 enum LinkHeaderIndex : uint8_t
 {

--- a/cpp/lib/src/link/LinkLayerParser.cpp
+++ b/cpp/lib/src/link/LinkLayerParser.cpp
@@ -141,7 +141,7 @@ LinkLayerParser::State LinkLayerParser::ParseBody()
 void LinkLayerParser::PushFrame(IFrameSink& sink)
 {
     LinkHeaderFields fields(header.GetFuncEnum(), header.IsFromMaster(), header.IsFcbSet(), header.IsFcvDfcSet(),
-                            header.GetDest(), header.GetSrc());
+                            Addresses(header.GetSrc(), header.GetDest()));
 
     sink.OnFrame(fields, userData);
 

--- a/cpp/lib/src/link/SecLinkLayerStates.cpp
+++ b/cpp/lib/src/link/SecLinkLayerStates.cpp
@@ -53,6 +53,7 @@ SecStateBase& SLLS_NotReset::OnTestLinkStatus(LinkContext& ctx, uint16_t /*sourc
 SecStateBase& SLLS_NotReset::OnConfirmedUserData(LinkContext& ctx,
                                                  uint16_t /*source*/,
                                                  bool /*fcb*/,
+                                                 bool /*isBroadcast*/,
                                                  const Message& /*message*/)
 {
     ++ctx.statistics.numUnexpectedFrame;
@@ -94,9 +95,12 @@ SecStateBase& SLLS_Reset::OnTestLinkStatus(LinkContext& ctx, uint16_t source, bo
     return *this;
 }
 
-SecStateBase& SLLS_Reset::OnConfirmedUserData(LinkContext& ctx, uint16_t source, bool fcb, const Message& message)
+SecStateBase& SLLS_Reset::OnConfirmedUserData(LinkContext& ctx, uint16_t source, bool fcb, bool isBroadcast, const Message& message)
 {
-    ctx.QueueAck(source);
+    if(!isBroadcast)
+    {
+        ctx.QueueAck(source);
+    }
 
     if (ctx.nextReadFCB == fcb)
     {

--- a/cpp/lib/src/link/SecLinkLayerStates.h
+++ b/cpp/lib/src/link/SecLinkLayerStates.h
@@ -39,7 +39,7 @@ public:
     virtual SecStateBase& OnRequestLinkStatus(LinkContext&, uint16_t source) = 0;
 
     virtual SecStateBase& OnTestLinkStatus(LinkContext&, uint16_t source, bool fcb) = 0;
-    virtual SecStateBase& OnConfirmedUserData(LinkContext&, uint16_t source, bool fcb, const Message& message) = 0;
+    virtual SecStateBase& OnConfirmedUserData(LinkContext&, uint16_t source, bool fcb, bool isBroadcast, const Message& message) = 0;
 
     virtual SecStateBase& OnTxReady(LinkContext& ctx);
 
@@ -65,6 +65,7 @@ public:
     virtual SecStateBase& OnConfirmedUserData(LinkContext&,
                                               uint16_t source,
                                               bool fcb,
+                                              bool isBroadcast,
                                               const Message& message) override final;
 };
 
@@ -98,6 +99,7 @@ template<class NextState>
 SecStateBase& SLLS_TransmitWaitBase<NextState>::OnConfirmedUserData(LinkContext& ctx,
                                                                     uint16_t source,
                                                                     bool fcb,
+                                                                    bool isBroadcast,
                                                                     const Message& message)
 {
     SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "Ignoring link frame, remote is flooding");
@@ -112,7 +114,7 @@ class SLLS_NotReset final : public SecStateBase
 public:
     MACRO_STATE_SINGLETON_INSTANCE(SLLS_NotReset);
 
-    virtual SecStateBase& OnConfirmedUserData(LinkContext&, uint16_t source, bool fcb, const Message& message) override;
+    virtual SecStateBase& OnConfirmedUserData(LinkContext&, uint16_t source, bool fcb, bool isBroadcast, const Message& message) override;
     virtual SecStateBase& OnResetLinkStates(LinkContext&, uint16_t source) override;
     virtual SecStateBase& OnRequestLinkStatus(LinkContext&, uint16_t source) override;
     virtual SecStateBase& OnTestLinkStatus(LinkContext&, uint16_t source, bool fcb) override;
@@ -125,7 +127,7 @@ class SLLS_Reset final : public SecStateBase
 {
     MACRO_STATE_SINGLETON_INSTANCE(SLLS_Reset);
 
-    virtual SecStateBase& OnConfirmedUserData(LinkContext&, uint16_t source, bool fcb, const Message& message) override;
+    virtual SecStateBase& OnConfirmedUserData(LinkContext&, uint16_t source, bool fcb, bool isBroadcast, const Message& message) override;
     virtual SecStateBase& OnResetLinkStates(LinkContext&, uint16_t source) override;
     virtual SecStateBase& OnRequestLinkStatus(LinkContext&, uint16_t source) override;
     virtual SecStateBase& OnTestLinkStatus(LinkContext&, uint16_t source, bool fcb) override;

--- a/cpp/lib/src/master/DefaultListenCallbacks.cpp
+++ b/cpp/lib/src/master/DefaultListenCallbacks.cpp
@@ -52,8 +52,8 @@ void DefaultListenCallbacks::OnFirstFrame(uint64_t sessionid,
 
     // full implementations will look up config information for the SRC address
 
-    config.link.LocalAddr = header.dest;
-    config.link.RemoteAddr = header.src;
+    config.link.LocalAddr = header.addresses.destination;
+    config.link.RemoteAddr = header.addresses.source;
 
     auto soe = std::make_shared<PrintingSOEHandler>();
     auto app = std::make_shared<DefaultMasterApplication>();

--- a/cpp/lib/src/outstation/OutstationContext.cpp
+++ b/cpp/lib/src/outstation/OutstationContext.cpp
@@ -414,7 +414,6 @@ IINField OContext::GetDynamicIIN()
 
 void OContext::UpdateLastBroadcastMessageReceived(uint16_t destination)
 {
-    auto broadcastType = LinkBroadcastAddress::OptionalConfirm;
     switch(destination)
     {
     case LinkBroadcastAddress::DontConfirm:

--- a/cpp/lib/src/outstation/OutstationContext.cpp
+++ b/cpp/lib/src/outstation/OutstationContext.cpp
@@ -181,6 +181,11 @@ OutstationState& OContext::ProcessNewRequest(const ParsedRequest& request)
 
 bool OContext::ProcessObjects(const ParsedRequest& request)
 {
+    if(request.addresses.IsBroadcast())
+    {
+        return this->ProcessBroadcastRequest(request);
+    }
+
     if (Functions::IsNoAckFuncCode(request.header.function))
     {
         // this is the only request we process while we are transmitting
@@ -221,10 +226,41 @@ bool OContext::ProcessConfirm(const ParsedRequest& request)
     return true;
 }
 
-void OContext::BeginResponseTx(uint16_t destination, const ser4cpp::rseq_t& data, const AppControlField& control)
+OutstationState& OContext::BeginResponseTx(uint16_t destination, APDUResponse& response)
 {
-    this->sol.tx.Record(control, data);
+    if(lastBroadcastMessageReceived.is_set())
+    {
+        response.SetIIN(response.GetIIN() | IINField(IINBit::ALL_STATIONS));
+
+        if(lastBroadcastMessageReceived.get() != LinkBroadcastAddress::ShallConfirm)
+        {
+            lastBroadcastMessageReceived.clear();
+        }
+        else
+        {
+            // The broadcast address requested a confirmation
+            auto control = response.GetControl();
+            control.CON = true;
+            response.SetControl(control);
+        }
+    }
+
+    const auto data = response.ToRSeq();
+    this->sol.tx.Record(response.GetControl(), data);
     this->BeginTx(destination, data);
+
+    if (response.GetControl().CON)
+    {
+        this->RestartConfirmTimer();
+        return StateSolicitedConfirmWait::Inst();
+    }
+
+    return StateIdle::Inst();
+}
+
+void OContext::BeginRetransmitLastResponse(uint16_t destination)
+{
+    this->BeginTx(destination, this->sol.tx.GetLastResponse());
 }
 
 void OContext::BeginUnsolTx(const AppControlField& control, const ser4cpp::rseq_t& response)
@@ -332,7 +368,7 @@ void OContext::RespondToNonReadRequest(const ParsedRequest& request)
     response.SetControl(AppControlField(true, true, false, false, request.header.control.SEQ));
     auto iin = this->HandleNonReadResponse(request.header, request.objects, writer);
     response.SetIIN(iin | this->GetResponseIIN());
-    this->BeginResponseTx(request.addresses.source, response.ToRSeq(), response.GetControl());
+    this->BeginResponseTx(request.addresses.source, response);
 }
 
 OutstationState& OContext::RespondToReadRequest(const ParsedRequest& request)
@@ -348,15 +384,7 @@ OutstationState& OContext::RespondToReadRequest(const ParsedRequest& request)
     response.SetControl(result.second);
     response.SetIIN(result.first | this->GetResponseIIN());
 
-    this->BeginResponseTx(request.addresses.source, response.ToRSeq(), response.GetControl());
-
-    if (result.second.CON)
-    {
-        this->RestartConfirmTimer();
-        return StateSolicitedConfirmWait::Inst();
-    }
-
-    return StateIdle::Inst();
+    return this->BeginResponseTx(request.addresses.source, response);
 }
 
 OutstationState& OContext::ContinueMultiFragResponse(const Addresses& addresses, const AppSeqNum& seq)
@@ -369,15 +397,8 @@ OutstationState& OContext::ContinueMultiFragResponse(const Addresses& addresses,
     this->sol.seq.confirmNum = seq;
     response.SetControl(control);
     response.SetIIN(this->GetResponseIIN());
-    this->BeginResponseTx(addresses.source, response.ToRSeq(), response.GetControl());
 
-    if (control.CON)
-    {
-        this->RestartConfirmTimer();
-        return StateSolicitedConfirmWait::Inst();
-    }
-
-    return StateIdle::Inst();
+    return this->BeginResponseTx(addresses.source, response);
 }
 
 bool OContext::CanTransmit() const
@@ -406,7 +427,7 @@ IINField OContext::GetDynamicIIN()
 bool OContext::ProcessMessage(const Message& message)
 {
     // is the message addressed to this outstation
-    if (message.addresses.destination != this->addresses.source)
+    if (message.addresses.destination != this->addresses.source && !message.addresses.IsBroadcast())
     {
         return false;
     }
@@ -461,6 +482,98 @@ IUpdateHandler& OContext::GetUpdateHandler()
 
 //// ----------------------------- function handlers -----------------------------
 
+bool OContext::ProcessBroadcastRequest(const ParsedRequest& request)
+{
+    const auto isHandled = HandleBroadcastRequest(request);
+
+    if(isHandled)
+    {
+        auto broadcastType = LinkBroadcastAddress::OptionalConfirm;
+        switch(request.addresses.destination)
+        {
+        case LinkBroadcastAddress::DontConfirm:
+            broadcastType = LinkBroadcastAddress::DontConfirm;
+            break;
+        case LinkBroadcastAddress::ShallConfirm:
+            broadcastType = LinkBroadcastAddress::ShallConfirm;
+            break;
+        case LinkBroadcastAddress::OptionalConfirm:
+            broadcastType = LinkBroadcastAddress::OptionalConfirm;
+            break;
+        }
+
+        lastBroadcastMessageReceived.set(broadcastType);
+    }
+
+    return isHandled;
+}
+
+bool OContext::HandleBroadcastRequest(const ParsedRequest& request)
+{
+    switch (request.header.function)
+    {
+    case (FunctionCode::WRITE):
+        this->HandleWrite(request.objects);
+        return true;
+    case (FunctionCode::DIRECT_OPERATE_NR):
+        this->HandleDirectOperate(request.objects, OperateType::DirectOperateNoAck, nullptr);
+        return true;
+    case (FunctionCode::ASSIGN_CLASS):
+    {
+        if(this->application->SupportsAssignClass())
+        {
+            this->HandleAssignClass(request.objects);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    case (FunctionCode::RECORD_CURRENT_TIME):
+    {
+        if(request.objects.is_not_empty())
+        {
+            this->HandleRecordCurrentTime();
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+        
+    }
+    case (FunctionCode::DISABLE_UNSOLICITED):
+    {
+        if(this->params.allowUnsolicited)
+        {
+            this->HandleDisableUnsolicited(request.objects, nullptr);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    case (FunctionCode::ENABLE_UNSOLICITED):
+    {
+        if(this->params.allowUnsolicited)
+        {
+            this->HandleEnableUnsolicited(request.objects, nullptr);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    default:
+        FORMAT_LOG_BLOCK(this->logger, flags::WARN, "Ignoring broadcast on function code: %s",
+                         FunctionCodeToString(request.header.function));
+        return false;
+    }
+}
+
 bool OContext::ProcessRequestNoAck(const ParsedRequest& request)
 {
     switch (request.header.function)
@@ -499,10 +612,10 @@ IINField OContext::HandleNonReadResponse(const APDUHeader& header, const ser4cpp
     case (FunctionCode::RECORD_CURRENT_TIME):
         return objects.is_empty() ? this->HandleRecordCurrentTime() : IINField(IINBit::PARAM_ERROR);
     case (FunctionCode::DISABLE_UNSOLICITED):
-        return this->params.allowUnsolicited ? this->HandleDisableUnsolicited(objects, writer)
+        return this->params.allowUnsolicited ? this->HandleDisableUnsolicited(objects, &writer)
                                              : IINField(IINBit::FUNC_NOT_SUPPORTED);
     case (FunctionCode::ENABLE_UNSOLICITED):
-        return this->params.allowUnsolicited ? this->HandleEnableUnsolicited(objects, writer)
+        return this->params.allowUnsolicited ? this->HandleEnableUnsolicited(objects, &writer)
                                              : IINField(IINBit::FUNC_NOT_SUPPORTED);
     default:
         return IINField(IINBit::FUNC_NOT_SUPPORTED);
@@ -672,7 +785,7 @@ IINField OContext::HandleAssignClass(const ser4cpp::rseq_t& objects)
     return IINField(IINBit::FUNC_NOT_SUPPORTED);
 }
 
-IINField OContext::HandleDisableUnsolicited(const ser4cpp::rseq_t& objects, HeaderWriter& /*writer*/)
+IINField OContext::HandleDisableUnsolicited(const ser4cpp::rseq_t& objects, HeaderWriter* /*writer*/)
 {
     ClassBasedRequestHandler handler;
     auto result = APDUParser::Parse(objects, handler, &this->logger);
@@ -685,7 +798,7 @@ IINField OContext::HandleDisableUnsolicited(const ser4cpp::rseq_t& objects, Head
     return IINFromParseResult(result);
 }
 
-IINField OContext::HandleEnableUnsolicited(const ser4cpp::rseq_t& objects, HeaderWriter& /*writer*/)
+IINField OContext::HandleEnableUnsolicited(const ser4cpp::rseq_t& objects, HeaderWriter* /*writer*/)
 {
     ClassBasedRequestHandler handler;
     auto result = APDUParser::Parse(objects, handler, &this->logger);

--- a/cpp/lib/src/outstation/OutstationContext.h
+++ b/cpp/lib/src/outstation/OutstationContext.h
@@ -110,8 +110,6 @@ private:
 
     bool ProcessBroadcastRequest(const ParsedRequest& request);
 
-    bool HandleBroadcastRequest(const ParsedRequest& request);
-
     bool ProcessRequestNoAck(const ParsedRequest& request);
 
     bool ProcessConfirm(const ParsedRequest& request);
@@ -122,7 +120,7 @@ private:
 
     void BeginRetransmitLastResponse(uint16_t destination);
 
-    void BeginUnsolTx(const AppControlField& control, const ser4cpp::rseq_t& response);
+    void BeginUnsolTx(APDUResponse& response);
 
     void BeginTx(uint16_t destination, const ser4cpp::rseq_t& message);
 
@@ -139,6 +137,10 @@ private:
     IINField GetResponseIIN();
 
     IINField GetDynamicIIN();
+
+    void UpdateLastBroadcastMessageReceived(uint16_t destination);
+
+    void CheckForBroadcastConfirmation(APDUResponse& response);
 
     /// --- methods for handling app-layer functions ---
 

--- a/cpp/lib/src/outstation/OutstationContext.h
+++ b/cpp/lib/src/outstation/OutstationContext.h
@@ -98,7 +98,7 @@ private:
 
     OutstationState& OnReceiveSolRequest(const ParsedRequest& request);
 
-    void RespondToNonReadRequest(const ParsedRequest& request);
+    OutstationState& RespondToNonReadRequest(const ParsedRequest& request);
 
     // ---- Processing functions --------
 

--- a/cpp/lib/src/outstation/OutstationContext.h
+++ b/cpp/lib/src/outstation/OutstationContext.h
@@ -21,6 +21,7 @@
 #define OPENDNP3_OUTSTATIONCONTEXT_H
 
 #include "LayerInterfaces.h"
+#include "link/LinkLayerConstants.h"
 #include "outstation/ControlState.h"
 #include "outstation/Database.h"
 #include "outstation/DeferredRequest.h"
@@ -40,6 +41,7 @@
 #include "opendnp3/outstation/OutstationConfig.h"
 
 #include <ser4cpp/container/Pair.h>
+#include <ser4cpp/container/Settable.h>
 
 #include <exe4cpp/IExecutor.h>
 
@@ -106,13 +108,19 @@ private:
 
     bool ProcessRequest(const ParsedRequest& request);
 
+    bool ProcessBroadcastRequest(const ParsedRequest& request);
+
+    bool HandleBroadcastRequest(const ParsedRequest& request);
+
     bool ProcessRequestNoAck(const ParsedRequest& request);
 
     bool ProcessConfirm(const ParsedRequest& request);
 
     // ---- common helper methods ----
 
-    void BeginResponseTx(uint16_t destination, const ser4cpp::rseq_t& data, const AppControlField& control);
+    OutstationState& BeginResponseTx(uint16_t destination, APDUResponse& response);
+
+    void BeginRetransmitLastResponse(uint16_t destination);
 
     void BeginUnsolTx(const AppControlField& control, const ser4cpp::rseq_t& response);
 
@@ -152,8 +160,8 @@ private:
     IINField HandleRecordCurrentTime();
     IINField HandleRestart(const ser4cpp::rseq_t& objects, bool isWarmRestart, HeaderWriter* pWriter);
     IINField HandleAssignClass(const ser4cpp::rseq_t& objects);
-    IINField HandleDisableUnsolicited(const ser4cpp::rseq_t& objects, HeaderWriter& writer);
-    IINField HandleEnableUnsolicited(const ser4cpp::rseq_t& objects, HeaderWriter& writer);
+    IINField HandleDisableUnsolicited(const ser4cpp::rseq_t& objects, HeaderWriter* writer);
+    IINField HandleEnableUnsolicited(const ser4cpp::rseq_t& objects, HeaderWriter* writer);
     IINField HandleCommandWithConstant(const ser4cpp::rseq_t& objects, HeaderWriter& writer, CommandStatus status);
 
     // ------ resources --------
@@ -190,6 +198,9 @@ private:
     OutstationSolState sol;
     OutstationUnsolState unsol;
     OutstationState* state = &StateIdle::Inst();
+
+    // ------ Dynamic state related to broadcast messages ------
+    ser4cpp::Settable<LinkBroadcastAddress> lastBroadcastMessageReceived;
 };
 
 } // namespace opendnp3

--- a/cpp/lib/src/outstation/OutstationStates.cpp
+++ b/cpp/lib/src/outstation/OutstationStates.cpp
@@ -68,6 +68,12 @@ OutstationState& StateIdle::OnRepeatReadRequest(OContext& ctx, const ParsedReque
     return *this;
 }
 
+OutstationState& StateIdle::OnBroadcastMessage(OContext& ctx, const ParsedRequest& request)
+{
+    ctx.ProcessBroadcastRequest(request);
+    return *this;
+}
+
 // ------------- StateSolicitedConfirmWait ----------------
 
 StateSolicitedConfirmWait StateSolicitedConfirmWait::instance;
@@ -134,6 +140,12 @@ OutstationState& StateSolicitedConfirmWait::OnRepeatReadRequest(OContext& ctx, c
     return *this;
 }
 
+OutstationState& StateSolicitedConfirmWait::OnBroadcastMessage(OContext& ctx, const ParsedRequest& request)
+{
+    ctx.ProcessBroadcastRequest(request);
+    return StateIdle::Inst();
+}
+
 // ------------- StateUnsolicitedConfirmWait ----------------
 
 StateUnsolicitedConfirmWait StateUnsolicitedConfirmWait::instance;
@@ -157,6 +169,7 @@ OutstationState& StateUnsolicitedConfirmWait::OnConfirm(OContext& ctx, const Par
 
     ctx.history.Reset(); // any time we get a confirm we can treat any request as a new request
     ctx.confirmTimer.cancel();
+    ctx.lastBroadcastMessageReceived.clear();
 
     if (ctx.unsol.completedNull)
     {
@@ -205,6 +218,12 @@ OutstationState& StateUnsolicitedConfirmWait::OnRepeatReadRequest(OContext& ctx,
 {
     ctx.deferred.Set(request);
     return *this;
+}
+
+OutstationState& StateUnsolicitedConfirmWait::OnBroadcastMessage(OContext& ctx, const ParsedRequest& request)
+{
+    ctx.ProcessBroadcastRequest(request);
+    return StateIdle::Inst();
 }
 
 } // namespace opendnp3

--- a/cpp/lib/src/outstation/OutstationStates.cpp
+++ b/cpp/lib/src/outstation/OutstationStates.cpp
@@ -53,8 +53,7 @@ OutstationState& StateIdle::OnNewReadRequest(OContext& ctx, const ParsedRequest&
 
 OutstationState& StateIdle::OnNewNonReadRequest(OContext& ctx, const ParsedRequest& request)
 {
-    ctx.RespondToNonReadRequest(request);
-    return *this;
+    return ctx.RespondToNonReadRequest(request);
 }
 
 OutstationState& StateIdle::OnRepeatNonReadRequest(OContext& ctx, const ParsedRequest& request)
@@ -118,8 +117,7 @@ OutstationState& StateSolicitedConfirmWait::OnNewReadRequest(OContext& ctx, cons
 OutstationState& StateSolicitedConfirmWait::OnNewNonReadRequest(OContext& ctx, const ParsedRequest& request)
 {
     ctx.confirmTimer.cancel();
-    ctx.RespondToNonReadRequest(request);
-    return StateIdle::Inst();
+    return ctx.RespondToNonReadRequest(request);
 }
 
 OutstationState& StateSolicitedConfirmWait::OnRepeatNonReadRequest(OContext& ctx, const ParsedRequest& request)

--- a/cpp/lib/src/outstation/OutstationStates.cpp
+++ b/cpp/lib/src/outstation/OutstationStates.cpp
@@ -59,13 +59,13 @@ OutstationState& StateIdle::OnNewNonReadRequest(OContext& ctx, const ParsedReque
 
 OutstationState& StateIdle::OnRepeatNonReadRequest(OContext& ctx, const ParsedRequest& request)
 {
-    ctx.BeginResponseTx(request.addresses.source, ctx.sol.tx.GetLastResponse(), ctx.sol.tx.GetLastControl());
+    ctx.BeginRetransmitLastResponse(request.addresses.source);
     return *this;
 }
 
 OutstationState& StateIdle::OnRepeatReadRequest(OContext& ctx, const ParsedRequest& request)
 {
-    ctx.BeginResponseTx(request.addresses.source, ctx.sol.tx.GetLastResponse(), ctx.sol.tx.GetLastControl());
+    ctx.BeginRetransmitLastResponse(request.addresses.source);
     return *this;
 }
 
@@ -93,6 +93,7 @@ OutstationState& StateSolicitedConfirmWait::OnConfirm(OContext& ctx, const Parse
     ctx.history.Reset(); // any time we get a confirm we can treat any request as a new request
     ctx.confirmTimer.cancel();
     ctx.eventBuffer.ClearWritten();
+    ctx.lastBroadcastMessageReceived.clear();
 
     if (ctx.rspContext.HasSelection())
     {
@@ -124,14 +125,14 @@ OutstationState& StateSolicitedConfirmWait::OnNewNonReadRequest(OContext& ctx, c
 OutstationState& StateSolicitedConfirmWait::OnRepeatNonReadRequest(OContext& ctx, const ParsedRequest& request)
 {
     ctx.confirmTimer.cancel();
-    ctx.BeginResponseTx(request.addresses.source, ctx.sol.tx.GetLastResponse(), ctx.sol.tx.GetLastControl());
+    ctx.BeginRetransmitLastResponse(request.addresses.source);
     return *this;
 }
 
 OutstationState& StateSolicitedConfirmWait::OnRepeatReadRequest(OContext& ctx, const ParsedRequest& request)
 {
     ctx.RestartConfirmTimer();
-    ctx.BeginResponseTx(request.addresses.source, ctx.sol.tx.GetLastResponse(), ctx.sol.tx.GetLastControl());
+    ctx.BeginRetransmitLastResponse(request.addresses.source);
     return *this;
 }
 
@@ -198,7 +199,7 @@ OutstationState& StateUnsolicitedConfirmWait::OnNewNonReadRequest(OContext& ctx,
 
 OutstationState& StateUnsolicitedConfirmWait::OnRepeatNonReadRequest(OContext& ctx, const ParsedRequest& request)
 {
-    ctx.BeginResponseTx(request.addresses.source, ctx.sol.tx.GetLastResponse(), ctx.sol.tx.GetLastControl());
+    ctx.BeginRetransmitLastResponse(request.addresses.source);
     return *this;
 }
 

--- a/cpp/lib/src/outstation/OutstationStates.h
+++ b/cpp/lib/src/outstation/OutstationStates.h
@@ -53,18 +53,20 @@ public:
     virtual OutstationState& OnRepeatNonReadRequest(OContext&, const ParsedRequest& request) = 0;
 
     virtual OutstationState& OnRepeatReadRequest(OContext&, const ParsedRequest& request) = 0;
+
+    virtual OutstationState& OnBroadcastMessage(OContext&, const ParsedRequest& request) = 0;
 };
 
 class StateIdle final : public OutstationState
 {
 
 public:
-    virtual bool IsIdle() override
+    bool IsIdle() final
     {
         return true;
     }
 
-    virtual const char* Name() override
+    const char* Name() final
     {
         return "Idle";
     }
@@ -74,17 +76,19 @@ public:
         return instance;
     }
 
-    virtual OutstationState& OnConfirm(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnConfirm(OContext&, const ParsedRequest& request) final;
 
-    virtual OutstationState& OnConfirmTimeout(OContext&) override;
+    OutstationState& OnConfirmTimeout(OContext&) final;
 
-    virtual OutstationState& OnNewReadRequest(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnNewReadRequest(OContext&, const ParsedRequest& request) final;
 
-    virtual OutstationState& OnNewNonReadRequest(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnNewNonReadRequest(OContext&, const ParsedRequest& request) final;
 
-    virtual OutstationState& OnRepeatNonReadRequest(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnRepeatNonReadRequest(OContext&, const ParsedRequest& request) final;
 
-    virtual OutstationState& OnRepeatReadRequest(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnRepeatReadRequest(OContext&, const ParsedRequest& request) final;
+
+    OutstationState& OnBroadcastMessage(OContext&, const ParsedRequest& request) final;
 
 private:
     static StateIdle instance;
@@ -104,22 +108,24 @@ public:
         return instance;
     }
 
-    virtual const char* Name() override
+    const char* Name() final
     {
         return "SolicitedConfirmWait";
     }
 
-    virtual OutstationState& OnConfirm(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnConfirm(OContext&, const ParsedRequest& request) final;
 
-    virtual OutstationState& OnConfirmTimeout(OContext&) override;
+    OutstationState& OnConfirmTimeout(OContext&) final;
 
-    virtual OutstationState& OnNewReadRequest(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnNewReadRequest(OContext&, const ParsedRequest& request) final;
 
-    virtual OutstationState& OnNewNonReadRequest(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnNewNonReadRequest(OContext&, const ParsedRequest& request) final;
 
-    virtual OutstationState& OnRepeatNonReadRequest(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnRepeatNonReadRequest(OContext&, const ParsedRequest& request) final;
 
-    virtual OutstationState& OnRepeatReadRequest(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnRepeatReadRequest(OContext&, const ParsedRequest& request) final;
+
+    OutstationState& OnBroadcastMessage(OContext&, const ParsedRequest& request) final;
 
 private:
     static StateSolicitedConfirmWait instance;
@@ -139,22 +145,24 @@ public:
         return instance;
     }
 
-    virtual const char* Name() override
+    const char* Name() final
     {
         return "UnsolicitedConfirmWait";
     }
 
-    virtual OutstationState& OnConfirm(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnConfirm(OContext&, const ParsedRequest& request) final;
 
-    virtual OutstationState& OnConfirmTimeout(OContext&) override;
+    OutstationState& OnConfirmTimeout(OContext&) final;
 
-    virtual OutstationState& OnNewReadRequest(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnNewReadRequest(OContext&, const ParsedRequest& request) final;
 
-    virtual OutstationState& OnNewNonReadRequest(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnNewNonReadRequest(OContext&, const ParsedRequest& request) final;
 
-    virtual OutstationState& OnRepeatNonReadRequest(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnRepeatNonReadRequest(OContext&, const ParsedRequest& request) final;
 
-    virtual OutstationState& OnRepeatReadRequest(OContext&, const ParsedRequest& request) override;
+    OutstationState& OnRepeatReadRequest(OContext&, const ParsedRequest& request) final;
+
+    OutstationState& OnBroadcastMessage(OContext&, const ParsedRequest& request) final;
 
 private:
     static StateUnsolicitedConfirmWait instance;

--- a/cpp/tests/dnp3mocks/src/MockFrameSink.cpp
+++ b/cpp/tests/dnp3mocks/src/MockFrameSink.cpp
@@ -44,8 +44,8 @@ void MockFrameSink::Reset()
 
 bool MockFrameSink::CheckLast(LinkFunction func, bool isMaster, uint16_t dest, uint16_t src)
 {
-    return (m_last_header.func == func) && (isMaster == m_last_header.isFromMaster) && (m_last_header.src == src)
-        && (m_last_header.dest == dest);
+    return (m_last_header.func == func) && (isMaster == m_last_header.isFromMaster) && (m_last_header.addresses.source == src)
+        && (m_last_header.addresses.destination == dest);
 }
 
 bool MockFrameSink::CheckLastWithFCB(LinkFunction func, bool isMaster, bool aFcb, uint16_t dest, uint16_t src)

--- a/cpp/tests/integration/TestMasterServerSmoke.cpp
+++ b/cpp/tests/integration/TestMasterServerSmoke.cpp
@@ -117,8 +117,8 @@ public:
     void OnFirstFrame(uint64_t sessionid, const opendnp3::LinkHeaderFields& header, ISessionAcceptor& acceptor) override
     {
         MasterStackConfig config;
-        config.link.LocalAddr = header.dest;
-        config.link.RemoteAddr = header.src;
+        config.link.LocalAddr = header.addresses.destination;
+        config.link.RemoteAddr = header.addresses.source;
         auto soe = std::make_shared<PrintingSOEHandler>();
         auto app = std::make_shared<DefaultMasterApplication>();
 

--- a/cpp/tests/unit/CMakeLists.txt
+++ b/cpp/tests/unit/CMakeLists.txt
@@ -46,6 +46,7 @@ set(unittests_src
     ./TestMasterUnsolBehaviors.cpp
     ./TestMeasurementHandler.cpp
     ./TestOutstation.cpp
+    ./TestOutstationBroadcast.cpp
     ./TestOutstationAssignClass.cpp
     ./TestOutstationCommandResponses.cpp
     ./TestOutstationDiscontiguousIndices.cpp

--- a/cpp/tests/unit/TestLinkAddresses.cpp
+++ b/cpp/tests/unit/TestLinkAddresses.cpp
@@ -34,3 +34,11 @@ TEST_CASE(SUITE("LinkAddressesEqualityComparison"))
     REQUIRE(lr1 != lr2);
     REQUIRE(lr3 == lr2);
 }
+
+TEST_CASE(SUITE("LinkAddressesIsBroadcast"))
+{
+    REQUIRE(Addresses(1, 0xFFFD).IsBroadcast());
+    REQUIRE(Addresses(1, 0xFFFE).IsBroadcast());
+    REQUIRE(Addresses(1, 0xFFFF).IsBroadcast());
+    REQUIRE(!Addresses(1, 1024).IsBroadcast());
+}

--- a/cpp/tests/unit/TestLinkLayer.cpp
+++ b/cpp/tests/unit/TestLinkLayer.cpp
@@ -109,7 +109,7 @@ TEST_CASE(SUITE("UnconfirmedBroadcastDataPassedUpFromIdleUnreset"))
     LinkLayerTest t;
     t.link.OnLowerLayerUp();
     ByteStr bs(250, 0);
-    t.OnFrame(LinkFunction::PRI_UNCONFIRMED_USER_DATA, false, false, false, LL_BROADCAST_SHALL_CONFIRM, 1024, bs.ToRSeq());
+    t.OnFrame(LinkFunction::PRI_UNCONFIRMED_USER_DATA, false, false, false, LinkBroadcastAddress::ShallConfirm, 1024, bs.ToRSeq());
     REQUIRE(t.upper->receivedQueue.size() == 1);
     REQUIRE(t.upper->receivedQueue.front() == bs.ToHex());
 }
@@ -141,7 +141,7 @@ TEST_CASE(SUITE("BroadcastSecondaryResetLink"))
 {
     LinkLayerTest t(LinkLayerTest::DefaultConfig());
     t.link.OnLowerLayerUp();
-    t.OnFrame(LinkFunction::PRI_RESET_LINK_STATES, false, false, false, LL_BROADCAST_SHALL_CONFIRM, 1024);
+    t.OnFrame(LinkFunction::PRI_RESET_LINK_STATES, false, false, false, LinkBroadcastAddress::ShallConfirm, 1024);
 
     REQUIRE(t.NumTotalWrites() == 0);
     REQUIRE(t.link.GetStatistics().numUnexpectedFrame == 1);
@@ -176,15 +176,12 @@ TEST_CASE(SUITE("BroadcastConfirmedData"))
     LinkLayerTest t(cfg);
     t.link.OnLowerLayerUp();
 
-    t.OnFrame(LinkFunction::PRI_RESET_LINK_STATES, false, false, false, 1, 1024);
-    REQUIRE(t.NumTotalWrites() == 1);
-    t.link.OnTxReady();
-
     ByteStr b(250, 0);
-    t.OnFrame(LinkFunction::PRI_CONFIRMED_USER_DATA, false, false, false, LL_BROADCAST_SHALL_CONFIRM, 1024, b.ToRSeq());
+    t.OnFrame(LinkFunction::PRI_CONFIRMED_USER_DATA, false, false, false, LinkBroadcastAddress::ShallConfirm, 1024, b.ToRSeq());
     t.link.OnTxReady();
-    REQUIRE(t.NumTotalWrites() == 1);
-    REQUIRE(t.link.GetStatistics().numUnexpectedFrame == 1);
+    REQUIRE(t.upper->receivedQueue.size() == 1);
+    REQUIRE(t.upper->receivedQueue.front() == b.ToHex());
+    REQUIRE(t.link.GetStatistics().numUnexpectedFrame == 0);
 }
 
 // When we get another reset links when we're already reset,
@@ -252,7 +249,7 @@ TEST_CASE(SUITE("BroadcastRequestStatusOfLink"))
 {
     LinkLayerTest t;
     t.link.OnLowerLayerUp();
-    t.OnFrame(LinkFunction::PRI_REQUEST_LINK_STATUS, false, false, false, LL_BROADCAST_SHALL_CONFIRM,
+    t.OnFrame(LinkFunction::PRI_REQUEST_LINK_STATUS, false, false, false, LinkBroadcastAddress::ShallConfirm,
               1024);
     REQUIRE(t.NumTotalWrites() == 0);
     REQUIRE(t.link.GetStatistics().numUnexpectedFrame == 1);
@@ -279,7 +276,7 @@ TEST_CASE(SUITE("BroadcastTestLinkStates"))
 {
     LinkLayerTest t;
     t.link.OnLowerLayerUp();
-    t.OnFrame(LinkFunction::PRI_TEST_LINK_STATES, false, false, false, LL_BROADCAST_SHALL_CONFIRM, 1024);
+    t.OnFrame(LinkFunction::PRI_TEST_LINK_STATES, false, false, false, LinkBroadcastAddress::ShallConfirm, 1024);
     REQUIRE(t.NumTotalWrites() == 0);
     REQUIRE(t.link.GetStatistics().numUnexpectedFrame == 1);
 }

--- a/cpp/tests/unit/TestOutstationBroadcast.cpp
+++ b/cpp/tests/unit/TestOutstationBroadcast.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2013-2019 Automatak, LLC
+ *
+ * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+ * LLC (www.automatak.com) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Green Energy Corp and Automatak LLC license
+ * this file to you under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "utils/OutstationTestObject.h"
+#include "utils/APDUHexBuilders.h"
+
+#include <dnp3mocks/DatabaseHelpers.h>
+
+#include <ser4cpp/util/HexConversions.h>
+
+#include <catch.hpp>
+
+using namespace opendnp3;
+
+#define SUITE(name) "OutstationBroadcastTestSuite - " name
+
+TEST_CASE(SUITE("Mandatory confirmation broadcast asks for confirmation"))
+{
+    OutstationConfig config;
+    OutstationTestObject t(config, DatabaseConfig());
+    t.LowerLayerUp();
+
+    t.BroadcastToOutstation(LinkBroadcastAddress::ShallConfirm, hex::ClearRestartIIN(0));
+
+    // Outstation should not respond to broadcast request
+    REQUIRE(t.lower->HasNoData());
+
+    // The next response should have ALL_STATIONS IIN set, and should ask for confirmation
+    t.SendToOutstation(hex::ClassPoll(2, PointClass::Class0));
+    REQUIRE(t.lower->PopWriteAsHex() == "E2 81 01 00");
+    t.OnTxReady();
+
+    // The next response should have ALL_STATIONS IIN set, and should ask for confirmation
+    t.SendToOutstation(hex::ClassPoll(3, PointClass::Class0));
+    REQUIRE(t.lower->PopWriteAsHex() == "E3 81 01 00");
+    t.OnTxReady();
+
+    // Confirm the last response
+    t.SendToOutstation(hex::SolicitedConfirm(3));
+    t.OnTxReady();
+
+    // Check that no confirmation is asked and that ALL_STATIONS IIN is reset
+    t.SendToOutstation(hex::ClassPoll(3, PointClass::Class0));
+    REQUIRE(t.lower->PopWriteAsHex() == "C3 81 00 00");
+}
+
+TEST_CASE(SUITE("No confirmation broadcast does not ask for confirmation, but set the ALL_STATIONS IIN bit once."))
+{
+    OutstationConfig config;
+    OutstationTestObject t(config, DatabaseConfig());
+    t.LowerLayerUp();
+
+    t.BroadcastToOutstation(LinkBroadcastAddress::DontConfirm, hex::ClearRestartIIN(0));
+
+    // Outstation should not respond to broadcast request
+    REQUIRE(t.lower->HasNoData());
+
+    // The next response should have ALL_STATIONS IIN set and restart IIN reset.
+    t.SendToOutstation(hex::ClassPoll(2, PointClass::Class0));
+    REQUIRE(t.lower->PopWriteAsHex() == "C2 81 01 00");
+    t.OnTxReady();
+
+    // The next response should have ALL_STATIONS IIN reset
+    t.SendToOutstation(hex::ClassPoll(3, PointClass::Class0));
+    REQUIRE(t.lower->PopWriteAsHex() == "C3 81 00 00");
+}
+
+TEST_CASE(SUITE("Broadcast on unsupported function code should not set the ALL_STATIONS."))
+{
+    OutstationConfig config;
+    OutstationTestObject t(config, DatabaseConfig());
+    t.LowerLayerUp();
+
+    t.BroadcastToOutstation(LinkBroadcastAddress::DontConfirm, hex::MeasureDelay(0));
+
+    // Outstation should not respond to broadcast request
+    REQUIRE(t.lower->HasNoData());
+
+    // The next response should NOT have ALL_STATIONS IIN
+    t.SendToOutstation(hex::ClassPoll(2, PointClass::Class0));
+    REQUIRE(t.lower->PopWriteAsHex() == "C2 81 80 00");
+    t.OnTxReady();
+}

--- a/cpp/tests/unit/TestOutstationStateMachine.cpp
+++ b/cpp/tests/unit/TestOutstationStateMachine.cpp
@@ -30,7 +30,7 @@ using namespace opendnp3;
 
 #define SUITE(name) "OutstationStateMachineTestSuite - " name
 
-TEST_CASE(SUITE("Responds to repeat READ request with same octets as last repsond"))
+TEST_CASE(SUITE("Responds to repeat READ request with same octets as last response"))
 {
     OutstationConfig config;
     OutstationTestObject t(config, configure::by_count_of::analog_input(1));

--- a/cpp/tests/unit/utils/LinkLayerTest.cpp
+++ b/cpp/tests/unit/utils/LinkLayerTest.cpp
@@ -45,7 +45,7 @@ bool LinkLayerTest::OnFrame(LinkFunction func,
                             uint16_t source,
                             const ser4cpp::rseq_t& userdata)
 {
-    LinkHeaderFields fields(func, isMaster, fcb, fcvdfc, dest, source);
+    LinkHeaderFields fields(func, isMaster, fcb, fcvdfc, Addresses(source, dest));
     return link.OnFrame(fields, userdata);
 }
 

--- a/cpp/tests/unit/utils/OutstationTestObject.cpp
+++ b/cpp/tests/unit/utils/OutstationTestObject.cpp
@@ -59,6 +59,13 @@ size_t OutstationTestObject::SendToOutstation(const std::string& hex)
     return exe->run_many();
 }
 
+size_t OutstationTestObject::BroadcastToOutstation(LinkBroadcastAddress broadcast_address, const std::string& hex)
+{
+    HexSequence hs(hex);
+    context.OnReceive(Message(Addresses(0, broadcast_address), hs.ToRSeq()));
+    return exe->run_many();
+}
+
 size_t OutstationTestObject::NumPendingTimers() const
 {
     return exe->num_pending_timers();

--- a/cpp/tests/unit/utils/OutstationTestObject.h
+++ b/cpp/tests/unit/utils/OutstationTestObject.h
@@ -21,6 +21,7 @@
 #define OPENDNP3_UNITTESTS_OUTSTATION_TEST_OBJECT_H
 
 #include <opendnp3/LogLevels.h>
+#include <link/LinkLayerConstants.h>
 #include <outstation/Database.h>
 #include <outstation/OutstationContext.h>
 
@@ -40,6 +41,8 @@ public:
     OutstationTestObject(const opendnp3::OutstationConfig& config, const opendnp3::DatabaseConfig& db_config = opendnp3::DatabaseConfig());
 
     size_t SendToOutstation(const std::string& hex);
+
+    size_t BroadcastToOutstation(opendnp3::LinkBroadcastAddress broadcast_address, const std::string& hex);
 
     size_t LowerLayerUp();
 


### PR DESCRIPTION
Closes #80.

Add broadcast support. Only a few functions support broadcasts:
- Write (2)
- Direct Operate - No Acknowledgment (6)
- Enable/Disable Unsolicited (20/21)
- Assign class (22)
- Record Current Time (24)

The `BROADCAST_OPTIONAL_CONFIRM` (`0xFFFF`) acts exactly like `BROADCAST_DONT_CONFIRM` (`0xFFFD`).