### PR TITLE
C# event class association (develop)

### DIFF
--- a/dotnet/CLRAdapter/src/Conversions.cpp
+++ b/dotnet/CLRAdapter/src/Conversions.cpp
@@ -437,6 +437,7 @@ namespace DNP3
 
             cfg.database = Convert(config->databaseTemplate);
             cfg.link = ConvertConfig(config->link);
+            cfg.outstation = ConvertConfig(config->outstation);
 
             return cfg;
         }
@@ -459,18 +460,18 @@ namespace DNP3
             return config;
         }
 
-        opendnp3::GroupVariationID Conversions::Convert(PointClass clazz)
+        opendnp3::PointClass Conversions::Convert(PointClass clazz)
         {
             switch (clazz)
             {
             case (PointClass::Class1):
-                return opendnp3::GroupVariationID(60, 1);
+                return opendnp3::PointClass::Class1;
             case (PointClass::Class2):
-                return opendnp3::GroupVariationID(60, 2);
+                return opendnp3::PointClass::Class2;
             case (PointClass::Class3):
-                return opendnp3::GroupVariationID(60, 3);
+                return opendnp3::PointClass::Class3;
             default:
-                return opendnp3::GroupVariationID(60, 4);
+                return opendnp3::PointClass::Class0;
             }
         }
 

--- a/dotnet/CLRAdapter/src/Conversions.h
+++ b/dotnet/CLRAdapter/src/Conversions.h
@@ -162,7 +162,7 @@ namespace Automatak
 				static opendnp3::MasterStackConfig ConvertConfig(MasterStackConfig^ config);
 				static opendnp3::OutstationStackConfig ConvertConfig(OutstationStackConfig^ config);				
 
-				static opendnp3::GroupVariationID Convert(PointClass clazz);				
+				static opendnp3::PointClass Convert(PointClass clazz);				
 				static array<System::Byte>^ Convert(const opendnp3::Buffer& bytes);				
 
 				template <class Target, class Source>
@@ -215,6 +215,7 @@ namespace Automatak
 
 						for (int i = 0; i < source->Count; ++i)
 						{
+                            target[i].clazz = Convert(source[i]->clazz);
 							target[i].evariation = (typename Info::event_variation_t) source[i]->eventVariation;
 						}
 					}


### PR DESCRIPTION
Fixes #291 in develop branch. It also fixes another issue introduced in the `develop` branch, where the `OutstationConfig` was not set properly.