### PR TITLE
Add Freeze support

### DIFF
--- a/cpp/examples/outstation-udp/main.cpp
+++ b/cpp/examples/outstation-udp/main.cpp
@@ -21,6 +21,7 @@
 #include <opendnp3/DNP3Manager.h>
 #include <opendnp3/LogLevels.h>
 #include <opendnp3/channel/PrintingChannelListener.h>
+#include <opendnp3/outstation/DefaultOutstationApplication.h>
 #include <opendnp3/outstation/IUpdateHandler.h>
 #include <opendnp3/outstation/SimpleCommandHandler.h>
 #include <opendnp3/outstation/UpdateBuilder.h>

--- a/cpp/examples/outstation/main.cpp
+++ b/cpp/examples/outstation/main.cpp
@@ -35,7 +35,7 @@ using namespace opendnp3;
 
 DatabaseConfig ConfigureDatabase()
 {
-    DatabaseConfig config(10); // 10 of each type
+    DatabaseConfig config(1); // 10 of each type
             
     config.analog_input[0].clazz = PointClass::Class2;
     config.analog_input[0].svariation = StaticAnalogVariation::Group30Var5;
@@ -96,6 +96,11 @@ int main(int argc, char* argv[])
     // updating the outstation's database.
     auto outstation = channel->AddOutstation("outstation", SuccessCommandHandler::Create(),
                                              app, config);
+
+    UpdateBuilder builder;
+    builder.Modify(FlagsType::Counter, 0, 9, 0x01);
+    builder.Modify(FlagsType::FrozenCounter, 0, 9, 0x01);
+    outstation->Apply(builder.Build());
 
     // Enable the outstation and start communications
     outstation->Enable();

--- a/cpp/examples/outstation/main.cpp
+++ b/cpp/examples/outstation/main.cpp
@@ -83,11 +83,11 @@ int main(int argc, char* argv[])
     // you can override an default outstation parameters here
     // in this example, we've enabled the oustation to use unsolicted reporting
     // if the master enables it
-    config.outstation.params.allowUnsolicited = false;
+    config.outstation.params.allowUnsolicited = true;
 
     // You can override the default link layer settings here
     // in this example we've changed the default link layer addressing
-    config.link.LocalAddr = 1024;
+    config.link.LocalAddr = 10;
     config.link.RemoteAddr = 1;
     config.link.KeepAliveTimeout = TimeDuration::Max();    
 
@@ -96,11 +96,6 @@ int main(int argc, char* argv[])
     // updating the outstation's database.
     auto outstation = channel->AddOutstation("outstation", SuccessCommandHandler::Create(),
                                              app, config);
-
-    UpdateBuilder builder;
-    builder.Modify(FlagsType::Counter, 0, 9, 0x01);
-    builder.Modify(FlagsType::FrozenCounter, 0, 9, 0x01);
-    outstation->Apply(builder.Build());
 
     // Enable the outstation and start communications
     outstation->Enable();
@@ -139,6 +134,11 @@ void AddUpdates(UpdateBuilder& builder, State& state, const std::string& argumen
         {
             builder.Update(Counter(state.count), 0);
             ++state.count;
+            break;
+        }
+        case ('f'):
+        {
+            builder.FreezeCounter(0, false);
             break;
         }
         case ('a'):

--- a/cpp/examples/outstation/main.cpp
+++ b/cpp/examples/outstation/main.cpp
@@ -35,7 +35,7 @@ using namespace opendnp3;
 
 DatabaseConfig ConfigureDatabase()
 {
-    DatabaseConfig config(1); // 10 of each type
+    DatabaseConfig config(10); // 10 of each type
             
     config.analog_input[0].clazz = PointClass::Class2;
     config.analog_input[0].svariation = StaticAnalogVariation::Group30Var5;
@@ -89,7 +89,7 @@ int main(int argc, char* argv[])
     // in this example we've changed the default link layer addressing
     config.link.LocalAddr = 10;
     config.link.RemoteAddr = 1;
-    config.link.KeepAliveTimeout = TimeDuration::Max();    
+    config.link.KeepAliveTimeout = TimeDuration::Max();
 
     // Create a new outstation with a log level, command handler, and
     // config info this	returns a thread-safe interface used for

--- a/cpp/examples/outstation/main.cpp
+++ b/cpp/examples/outstation/main.cpp
@@ -21,6 +21,7 @@
 #include <opendnp3/DNP3Manager.h>
 #include <opendnp3/LogLevels.h>
 #include <opendnp3/channel/PrintingChannelListener.h>
+#include <opendnp3/outstation/IUpdateHandler.h>
 #include <opendnp3/outstation/SimpleCommandHandler.h>
 #include <opendnp3/outstation/UpdateBuilder.h>
 
@@ -34,11 +35,11 @@ using namespace opendnp3;
 DatabaseConfig ConfigureDatabase()
 {
     DatabaseConfig config(10); // 10 of each type
-
+            
     config.analog_input[0].clazz = PointClass::Class2;
     config.analog_input[0].svariation = StaticAnalogVariation::Group30Var5;
     config.analog_input[0].evariation = EventAnalogVariation::Group32Var7;
-
+            
     return config;
 }
 
@@ -48,25 +49,13 @@ struct State
     double value = 0;
     bool binary = false;
     DoubleBit dbit = DoubleBit::DETERMINED_OFF;
+    uint8_t octetStringValue = 1;
 };
 
 void AddUpdates(UpdateBuilder& builder, State& state, const std::string& arguments);
 
 int main(int argc, char* argv[])
 {
-    if (argc != 4)
-    {
-        std::cout << "usage: master-gprs-tls-demo <ca certificate> <certificate chain> <private key>" << std::endl;
-        return -1;
-    }
-
-    std::string caCertificate(argv[1]);
-    std::string certificateChain(argv[2]);
-    std::string privateKey(argv[3]);
-
-    std::cout << "Using CA certificate: " << caCertificate << std::endl;
-    std::cout << "Using certificate chain: " << certificateChain << std::endl;
-    std::cout << "Using private key file: " << privateKey << std::endl;
 
     // Specify what log levels to use. NORMAL is warning and above
     // You can add all the comms logging by uncommenting below.
@@ -74,43 +63,36 @@ int main(int argc, char* argv[])
 
     // This is the main point of interaction with the stack
     // Allocate a single thread to the pool since this is a single outstation
+    // Log messages to the console
     DNP3Manager manager(1, ConsoleLogger::Create());
 
-    std::error_code ec;
-
     // Create a TCP server (listener)
-    auto channel = manager.AddTLSServer("server", logLevels, ServerAcceptMode::CloseExisting, IPEndpoint("0.0.0.0", 20001),
-                                        TLSConfig(caCertificate, certificateChain, privateKey, 2),
-                                        PrintingChannelListener::Create(), ec);
-
-    if (ec)
-    {
-        std::cout << "Unable to create tls server: " << ec.message() << std::endl;
-        return ec.value();
-    }
+    auto channel = manager.AddTCPServer("server", logLevels, ServerAcceptMode::CloseExisting, IPEndpoint("0.0.0.0", 20000),
+                                        PrintingChannelListener::Create());
 
     // The main object for a outstation. The defaults are useable,
     // but understanding the options are important.
-    OutstationStackConfig stackConfig(ConfigureDatabase());
+    OutstationStackConfig config(ConfigureDatabase());
 
-    // specify the maximum size of the event buffers
-    stackConfig.outstation.eventBufferConfig = EventBufferConfig::AllTypes(10);
+    // Specify the maximum size of the event buffers
+    config.outstation.eventBufferConfig = EventBufferConfig::AllTypes(100);
 
     // you can override an default outstation parameters here
     // in this example, we've enabled the oustation to use unsolicted reporting
     // if the master enables it
-    stackConfig.outstation.params.allowUnsolicited = true;
+    config.outstation.params.allowUnsolicited = true;
 
     // You can override the default link layer settings here
     // in this example we've changed the default link layer addressing
-    stackConfig.link.LocalAddr = 10;
-    stackConfig.link.RemoteAddr = 1;    
+    config.link.LocalAddr = 10;
+    config.link.RemoteAddr = 1;
+    config.link.KeepAliveTimeout = TimeDuration::Max();    
 
     // Create a new outstation with a log level, command handler, and
     // config info this	returns a thread-safe interface used for
     // updating the outstation's database.
     auto outstation = channel->AddOutstation("outstation", SuccessCommandHandler::Create(),
-                                             DefaultOutstationApplication::Create(), stackConfig);
+                                             DefaultOutstationApplication::Create(), config);
 
     // Enable the outstation and start communications
     outstation->Enable();
@@ -122,13 +104,14 @@ int main(int argc, char* argv[])
     while (true)
     {
         std::cout << "Enter one or more measurement changes then press <enter>" << std::endl;
-        std::cout << "c = counter, b = binary, d = doublebit, a = analog, 'quit' = exit" << std::endl;
+        std::cout << "c = counter, b = binary, d = doublebit, a = analog, o = octet string, 'quit' = exit" << std::endl;
         std::cin >> input;
 
         if (input == "quit")
-            return 0;
+            return 0; // DNP3Manager destructor cleanups up everything automatically
         else
         {
+            // update measurement values based on input string
             UpdateBuilder builder;
             AddUpdates(builder, state, input);
             outstation->Apply(builder.Build());
@@ -167,6 +150,13 @@ void AddUpdates(UpdateBuilder& builder, State& state, const std::string& argumen
             builder.Update(DoubleBitBinary(state.dbit), 0);
             state.dbit
                 = (state.dbit == DoubleBit::DETERMINED_OFF) ? DoubleBit::DETERMINED_ON : DoubleBit::DETERMINED_OFF;
+            break;
+        }
+        case ('o'):
+        {
+            OctetString value(Buffer(&state.octetStringValue, 1));
+            builder.Update(value, 0);
+            state.octetStringValue += 1;
             break;
         }
         default:

--- a/cpp/examples/tls/outstation/main.cpp
+++ b/cpp/examples/tls/outstation/main.cpp
@@ -21,6 +21,7 @@
 #include <opendnp3/DNP3Manager.h>
 #include <opendnp3/LogLevels.h>
 #include <opendnp3/channel/PrintingChannelListener.h>
+#include <opendnp3/outstation/DefaultOutstationApplication.h>
 #include <opendnp3/outstation/SimpleCommandHandler.h>
 #include <opendnp3/outstation/UpdateBuilder.h>
 

--- a/cpp/lib/CMakeLists.txt
+++ b/cpp/lib/CMakeLists.txt
@@ -149,6 +149,7 @@ set(opendnp3_public_headers
 
     ./include/opendnp3/outstation/ApplicationIIN.h
     ./include/opendnp3/outstation/DatabaseConfig.h
+    ./include/opendnp3/outstation/DefaultOutstationApplication.h
     ./include/opendnp3/outstation/EventBufferConfig.h
     ./include/opendnp3/outstation/ICommandHandler.h
     ./include/opendnp3/outstation/IDnpTimeSource.h
@@ -632,6 +633,7 @@ set(opendnp3_src
     ./src/outstation/CommandResponseHandler.cpp
     ./src/outstation/Database.cpp
     ./src/outstation/DatabaseConfig.cpp
+    ./src/outstation/DefaultOutstationApplication.cpp
     ./src/outstation/DeferredRequest.cpp
     ./src/outstation/EventBufferConfig.cpp
     ./src/outstation/FreezeRequestHandler.cpp

--- a/cpp/lib/CMakeLists.txt
+++ b/cpp/lib/CMakeLists.txt
@@ -140,17 +140,18 @@ set(opendnp3_public_headers
     ./include/opendnp3/master/IUTCTimeSource.h
     ./include/opendnp3/master/MasterParams.h
     ./include/opendnp3/master/PrintingSOEHandler.h
-	./include/opendnp3/master/ResponseInfo.h
+    ./include/opendnp3/master/ResponseInfo.h
     ./include/opendnp3/master/RestartOperationResult.h
     ./include/opendnp3/master/TaskConfig.h
     ./include/opendnp3/master/TaskId.h
     ./include/opendnp3/master/TaskInfo.h
-	./include/opendnp3/master/X509Info.h
+    ./include/opendnp3/master/X509Info.h
 
     ./include/opendnp3/outstation/ApplicationIIN.h
-    ./include/opendnp3/outstation/DatabaseConfig.h    
+    ./include/opendnp3/outstation/DatabaseConfig.h
     ./include/opendnp3/outstation/EventBufferConfig.h
     ./include/opendnp3/outstation/ICommandHandler.h
+    ./include/opendnp3/outstation/IDnpTimeSource.h
     ./include/opendnp3/outstation/IOutstation.h
     ./include/opendnp3/outstation/IOutstationApplication.h
     ./include/opendnp3/outstation/IUpdateHandler.h
@@ -370,6 +371,7 @@ set(opendnp3_private_headers
     ./src/outstation/Database.h
     ./src/outstation/DeferredRequest.h
     ./src/outstation/Event.h
+    ./src/outstation/FreezeRequestHandler.h
     ./src/outstation/IClassAssigner.h
     ./src/outstation/ICommandAction.h
     ./src/outstation/IEventReceiver.h
@@ -632,6 +634,7 @@ set(opendnp3_src
     ./src/outstation/DatabaseConfig.cpp
     ./src/outstation/DeferredRequest.cpp
     ./src/outstation/EventBufferConfig.cpp
+    ./src/outstation/FreezeRequestHandler.cpp
     ./src/outstation/IINHelpers.cpp
     ./src/outstation/IOutstationApplication.cpp
     ./src/outstation/OctetStringSerializer.cpp

--- a/cpp/lib/include/opendnp3/outstation/DefaultOutstationApplication.h
+++ b/cpp/lib/include/opendnp3/outstation/DefaultOutstationApplication.h
@@ -60,8 +60,8 @@ public:
 
     virtual RestartMode ColdRestartSupport() const override { return RestartMode::UNSUPPORTED; }
     virtual RestartMode WarmRestartSupport() const override { return RestartMode::UNSUPPORTED; }
-    virtual uint16_t ColdRestart() { return 65535; }
-    virtual uint16_t WarmRestart() { return 65535; }
+    virtual uint16_t ColdRestart() override { return 65535; }
+    virtual uint16_t WarmRestart() override { return 65535; }
 
 private:
     bool IsTimeValid() const;

--- a/cpp/lib/include/opendnp3/outstation/DefaultOutstationApplication.h
+++ b/cpp/lib/include/opendnp3/outstation/DefaultOutstationApplication.h
@@ -65,10 +65,11 @@ public:
 
 private:
     bool IsTimeValid() const;
+    bool NeedsTime() const;
 
     TimeDuration refresh_rate;
-    UTCTimestamp last_timestamp;
-    std::chrono::steady_clock::time_point last_update = std::chrono::steady_clock::time_point(std::chrono::milliseconds(0));
+    UTCTimestamp last_timestamp = UTCTimestamp();
+    std::chrono::system_clock::time_point last_update = std::chrono::system_clock::time_point(std::chrono::milliseconds(0));
 };
 
 } // namespace opendnp3

--- a/cpp/lib/include/opendnp3/outstation/DefaultOutstationApplication.h
+++ b/cpp/lib/include/opendnp3/outstation/DefaultOutstationApplication.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013-2019 Automatak, LLC
+ *
+ * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+ * LLC (www.automatak.com) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Green Energy Corp and Automatak LLC license
+ * this file to you under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef OPENDNP3_DEFAULTOUTSTATIONAPPLICATION_H
+#define OPENDNP3_DEFAULTOUTSTATIONAPPLICATION_H
+
+#include "opendnp3/outstation/IOutstationApplication.h"
+#include "opendnp3/util/TimeDuration.h"
+
+#include <chrono>
+#include <memory>
+
+namespace opendnp3
+{
+
+/**
+ * A singleton with default setting useful for examples
+ */
+class DefaultOutstationApplication : public IOutstationApplication
+{
+public:
+    static std::shared_ptr<IOutstationApplication> Create(TimeDuration timeSyncRefreshRate = TimeDuration::Minutes(1))
+    {
+        return std::make_shared<DefaultOutstationApplication>(timeSyncRefreshRate);
+    }
+
+    DefaultOutstationApplication(TimeDuration timeSyncRefreshRate = TimeDuration::Minutes(1));
+    virtual ~DefaultOutstationApplication() = default;
+
+    // IDnpTimeSource
+    virtual DNPTime Now() override;
+
+    // IOutstationApplication
+    virtual bool SupportsWriteAbsoluteTime() override { return true; }
+    virtual bool WriteAbsoluteTime(const UTCTimestamp& timestamp) override;
+
+    virtual bool SupportsWriteTimeAndInterval() override { return false; }
+    virtual bool WriteTimeAndInterval(const ICollection<Indexed<TimeAndInterval>>& values) override { return false; }
+
+    virtual bool SupportsAssignClass() override { return true; }
+    virtual void RecordClassAssignment(AssignClassType type, PointClass clazz, uint16_t start, uint16_t stop) override {}
+
+    virtual ApplicationIIN GetApplicationIIN() const override;
+
+    virtual RestartMode ColdRestartSupport() const override { return RestartMode::UNSUPPORTED; }
+    virtual RestartMode WarmRestartSupport() const override { return RestartMode::UNSUPPORTED; }
+    virtual uint16_t ColdRestart() { return 65535; }
+    virtual uint16_t WarmRestart() { return 65535; }
+
+private:
+    bool IsTimeValid() const;
+
+    TimeDuration refresh_rate;
+    UTCTimestamp last_timestamp;
+    std::chrono::steady_clock::time_point last_update = std::chrono::steady_clock::time_point(std::chrono::milliseconds(0));
+};
+
+} // namespace opendnp3
+
+#endif

--- a/cpp/lib/include/opendnp3/outstation/IDnpTimeSource.h
+++ b/cpp/lib/include/opendnp3/outstation/IDnpTimeSource.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2019 Automatak, LLC
+ *
+ * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+ * LLC (www.automatak.com) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Green Energy Corp and Automatak LLC license
+ * this file to you under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef OPENDNP3_IDNPTIMESOURCE_H
+#define OPENDNP3_IDNPTIMESOURCE_H
+
+#include "opendnp3/app/DNPTime.h"
+
+namespace opendnp3
+{
+
+/**
+ *  Interface that defines a method to get DNPTime source
+ */
+class IDnpTimeSource
+{
+
+public:
+    /**
+     * Returns a DNPTime of the current time.
+     * This value is used when freezing counters.
+     */
+    virtual DNPTime Now()
+    {
+        return DNPTime(0, TimestampQuality::INVALID);
+    }
+};
+
+} // namespace opendnp3
+
+#endif

--- a/cpp/lib/include/opendnp3/outstation/IOutstationApplication.h
+++ b/cpp/lib/include/opendnp3/outstation/IOutstationApplication.h
@@ -29,6 +29,7 @@
 #include "opendnp3/gen/RestartMode.h"
 #include "opendnp3/link/ILinkListener.h"
 #include "opendnp3/outstation/ApplicationIIN.h"
+#include "opendnp3/outstation/IDnpTimeSource.h"
 
 #include <memory>
 
@@ -38,7 +39,7 @@ namespace opendnp3
 /**
  * Interface for all outstation application callback info except for control requests
  */
-class IOutstationApplication : public ILinkListener
+class IOutstationApplication : public ILinkListener, public IDnpTimeSource
 {
 public:
     /// Queries whether the the outstation supports absolute time writes

--- a/cpp/lib/include/opendnp3/outstation/IOutstationApplication.h
+++ b/cpp/lib/include/opendnp3/outstation/IOutstationApplication.h
@@ -127,21 +127,7 @@ public:
         return 65535;
     }
 
-    virtual ~IOutstationApplication() {}
-};
-
-/**
- * A singleton with default setting useful for examples
- */
-class DefaultOutstationApplication : public IOutstationApplication
-{
-public:
-    static std::shared_ptr<IOutstationApplication> Create()
-    {
-        return std::make_shared<DefaultOutstationApplication>();
-    }
-
-    DefaultOutstationApplication() = default;
+    virtual ~IOutstationApplication() = default;
 };
 
 } // namespace opendnp3

--- a/cpp/lib/include/opendnp3/outstation/IUpdateHandler.h
+++ b/cpp/lib/include/opendnp3/outstation/IUpdateHandler.h
@@ -73,6 +73,15 @@ public:
     virtual bool Update(const Counter& meas, uint16_t index, EventMode mode = EventMode::Detect) = 0;
 
     /**
+     * Freeze a Counter measurement
+     * @param index index of the measurement
+     * @param clear clear the original counter
+     * @param mode Describes how event generation is handled for this method
+     * @return true if the value exists and it was updated
+     */
+    virtual bool FreezeCounter(uint16_t index, bool clear = false, EventMode mode = EventMode::Detect) = 0;
+
+    /**
      * Update a BinaryOutputStatus measurement
      * @param meas measurement to be processed
      * @param index index of the measurement

--- a/cpp/lib/include/opendnp3/outstation/IUpdateHandler.h
+++ b/cpp/lib/include/opendnp3/outstation/IUpdateHandler.h
@@ -73,15 +73,6 @@ public:
     virtual bool Update(const Counter& meas, uint16_t index, EventMode mode = EventMode::Detect) = 0;
 
     /**
-     * Update a FrozenCounter measurement
-     * @param meas measurement to be processed
-     * @param index index of the measurement
-     * @param mode Describes how event generation is handled for this method
-     * @return true if the value exists and it was updated
-     */
-    virtual bool Update(const FrozenCounter& meas, uint16_t index, EventMode mode = EventMode::Detect) = 0;
-
-    /**
      * Update a BinaryOutputStatus measurement
      * @param meas measurement to be processed
      * @param index index of the measurement

--- a/cpp/lib/include/opendnp3/outstation/UpdateBuilder.h
+++ b/cpp/lib/include/opendnp3/outstation/UpdateBuilder.h
@@ -33,7 +33,6 @@ public:
     UpdateBuilder& Update(const DoubleBitBinary& meas, uint16_t index, EventMode mode = EventMode::Detect);
     UpdateBuilder& Update(const Analog& meas, uint16_t index, EventMode mode = EventMode::Detect);
     UpdateBuilder& Update(const Counter& meas, uint16_t index, EventMode mode = EventMode::Detect);
-    UpdateBuilder& Update(const FrozenCounter& meas, uint16_t index, EventMode mode = EventMode::Detect);
     UpdateBuilder& Update(const BinaryOutputStatus& meas, uint16_t index, EventMode mode = EventMode::Detect);
     UpdateBuilder& Update(const AnalogOutputStatus& meas, uint16_t index, EventMode mode = EventMode::Detect);
     UpdateBuilder& Update(const OctetString& meas, uint16_t index, EventMode mode = EventMode::Detect);

--- a/cpp/lib/include/opendnp3/outstation/UpdateBuilder.h
+++ b/cpp/lib/include/opendnp3/outstation/UpdateBuilder.h
@@ -33,6 +33,7 @@ public:
     UpdateBuilder& Update(const DoubleBitBinary& meas, uint16_t index, EventMode mode = EventMode::Detect);
     UpdateBuilder& Update(const Analog& meas, uint16_t index, EventMode mode = EventMode::Detect);
     UpdateBuilder& Update(const Counter& meas, uint16_t index, EventMode mode = EventMode::Detect);
+    UpdateBuilder& FreezeCounter(uint16_t index, bool clear, EventMode mode = EventMode::Detect);
     UpdateBuilder& Update(const BinaryOutputStatus& meas, uint16_t index, EventMode mode = EventMode::Detect);
     UpdateBuilder& Update(const AnalogOutputStatus& meas, uint16_t index, EventMode mode = EventMode::Detect);
     UpdateBuilder& Update(const OctetString& meas, uint16_t index, EventMode mode = EventMode::Detect);

--- a/cpp/lib/src/outstation/Database.cpp
+++ b/cpp/lib/src/outstation/Database.cpp
@@ -359,6 +359,14 @@ bool Database::Update(const Counter& meas, uint16_t index, EventMode mode)
     return this->counter.update(meas, index, mode, event_receiver);
 }
 
+bool Database::FreezeCounter(uint16_t index, bool clear, EventMode mode)
+{
+    auto num_selected = this->counter.select(Range::From(index, index));
+    this->FreezeSelectedCounters(clear, mode);
+
+    return num_selected > 0;
+}
+
 bool Database::Update(const BinaryOutputStatus& meas, uint16_t index, EventMode mode)
 {
     return this->binary_output_status.update(meas, index, mode, event_receiver);
@@ -402,20 +410,22 @@ bool Database::Modify(FlagsType type, uint16_t start, uint16_t stop, uint8_t fla
     return false;
 }
 
-bool Database::FreezeSelectedCounters(bool clear)
+bool Database::FreezeSelectedCounters(bool clear, EventMode mode)
 {
     for(auto c : this->counter)
     {
         FrozenCounter new_value(c.second.value.value, c.second.value.flags, time_source.Now());
-        this->frozen_counter.update(new_value, c.first, EventMode::Detect, this->event_receiver);
+        this->frozen_counter.update(new_value, c.first, mode, this->event_receiver);
 
         if(clear)
         {
             c.second.value.value = 0;
             c.second.value.time = time_source.Now();
-            this->counter.update(c.second.value, c.first, EventMode::Detect, this->event_receiver);
+            this->counter.update(c.second.value, c.first, mode, this->event_receiver);
         }
     }
+
+    this->counter.clear_selection();
 
     return true;
 }

--- a/cpp/lib/src/outstation/Database.cpp
+++ b/cpp/lib/src/outstation/Database.cpp
@@ -404,7 +404,7 @@ bool Database::Modify(FlagsType type, uint16_t start, uint16_t stop, uint8_t fla
 
 bool Database::FreezeSelectedCounters(bool clear)
 {
-    for(auto& c : this->counter)
+    for(auto c : this->counter)
     {
         FrozenCounter new_value(c.second.value.value, c.second.value.flags, time_source.Now());
         this->frozen_counter.update(new_value, c.first, EventMode::Detect, this->event_receiver);

--- a/cpp/lib/src/outstation/Database.cpp
+++ b/cpp/lib/src/outstation/Database.cpp
@@ -47,8 +47,10 @@ template<class Spec> bool load_type(StaticDataMap<Spec>& map, HeaderWriter& writ
 
 Database::Database(const DatabaseConfig& config,
                    IEventReceiver& event_receiver,
+                   IDnpTimeSource& time_source,
                    StaticTypeBitField allowed_class_zero_types)
     : event_receiver(event_receiver),
+      time_source(time_source),
       allowed_class_zero_types(allowed_class_zero_types),
       binary_input(config.binary_input),
       double_binary(config.double_binary),
@@ -357,11 +359,6 @@ bool Database::Update(const Counter& meas, uint16_t index, EventMode mode)
     return this->counter.update(meas, index, mode, event_receiver);
 }
 
-bool Database::Update(const FrozenCounter& meas, uint16_t index, EventMode mode)
-{
-    return this->frozen_counter.update(meas, index, mode, event_receiver);
-}
-
 bool Database::Update(const BinaryOutputStatus& meas, uint16_t index, EventMode mode)
 {
     return this->binary_output_status.update(meas, index, mode, event_receiver);
@@ -403,6 +400,24 @@ bool Database::Modify(FlagsType type, uint16_t start, uint16_t stop, uint8_t fla
     }
 
     return false;
+}
+
+bool Database::FreezeSelectedCounters(bool clear)
+{
+    for(auto& c : this->counter)
+    {
+        FrozenCounter new_value(c.second.value.value, c.second.value.flags, time_source.Now());
+        this->frozen_counter.update(new_value, c.first, EventMode::Detect, this->event_receiver);
+
+        if(clear)
+        {
+            c.second.value.value = 0;
+            c.second.value.time = time_source.Now();
+            this->counter.update(c.second.value, c.first, EventMode::Detect, this->event_receiver);
+        }
+    }
+
+    return true;
 }
 
 template<class Spec> void Database::select_all_class_zero(StaticDataMap<Spec>& map)

--- a/cpp/lib/src/outstation/Database.h
+++ b/cpp/lib/src/outstation/Database.h
@@ -64,13 +64,14 @@ public:
     bool Update(const DoubleBitBinary& meas, uint16_t index, EventMode mode) override;
     bool Update(const Analog& meas, uint16_t index, EventMode mode) override;
     bool Update(const Counter& meas, uint16_t index, EventMode mode) override;
+    bool FreezeCounter(uint16_t index, bool clear, EventMode mode) override;
     bool Update(const BinaryOutputStatus& meas, uint16_t index, EventMode mode) override;
     bool Update(const AnalogOutputStatus& meas, uint16_t index, EventMode mode) override;
     bool Update(const OctetString& meas, uint16_t index, EventMode mode) override;
     bool Update(const TimeAndInterval& meas, uint16_t index) override;
     bool Modify(FlagsType type, uint16_t start, uint16_t stop, uint8_t flags) override;
 
-    bool FreezeSelectedCounters(bool clear);
+    bool FreezeSelectedCounters(bool clear, EventMode mode = EventMode::Detect);
 
 private:
 

--- a/cpp/lib/src/outstation/Database.h
+++ b/cpp/lib/src/outstation/Database.h
@@ -20,10 +20,11 @@
 #ifndef OPENDNP3_DATABASE_H
 #define OPENDNP3_DATABASE_H
 
-#include <opendnp3/outstation/DatabaseConfig.h>
-#include <opendnp3/outstation/StaticTypeBitfield.h>
-#include <opendnp3/outstation/IUpdateHandler.h>
-#include <opendnp3/gen/FlagsType.h>
+#include "opendnp3/outstation/DatabaseConfig.h"
+#include "opendnp3/outstation/IDnpTimeSource.h"
+#include "opendnp3/outstation/IUpdateHandler.h"
+#include "opendnp3/outstation/StaticTypeBitfield.h"
+#include "opendnp3/gen/FlagsType.h"
 
 #include "app/MeasurementTypeSpecs.h"
 #include "outstation/StaticDataMap.h"
@@ -42,6 +43,7 @@ public:
 
 	Database(const DatabaseConfig& config,
                    IEventReceiver& event_receiver,
+                   IDnpTimeSource& time_source,
 		           StaticTypeBitField allowed_class_zero_types);
 
     // ------- IStaticSelector -------------
@@ -62,19 +64,21 @@ public:
     bool Update(const DoubleBitBinary& meas, uint16_t index, EventMode mode) override;
     bool Update(const Analog& meas, uint16_t index, EventMode mode) override;
     bool Update(const Counter& meas, uint16_t index, EventMode mode) override;
-    bool Update(const FrozenCounter& meas, uint16_t index, EventMode mode) override;
     bool Update(const BinaryOutputStatus& meas, uint16_t index, EventMode mode) override;
     bool Update(const AnalogOutputStatus& meas, uint16_t index, EventMode mode) override;
     bool Update(const OctetString& meas, uint16_t index, EventMode mode) override;
     bool Update(const TimeAndInterval& meas, uint16_t index) override;
     bool Modify(FlagsType type, uint16_t start, uint16_t stop, uint8_t flags) override;
 
+    bool FreezeSelectedCounters(bool clear);
+
 private:
 
-	IEventReceiver& event_receiver;
-	StaticTypeBitField allowed_class_zero_types;
-    
-	StaticDataMap<BinarySpec> binary_input;
+    IEventReceiver& event_receiver;
+    IDnpTimeSource& time_source;
+    StaticTypeBitField allowed_class_zero_types;
+
+    StaticDataMap<BinarySpec> binary_input;
     StaticDataMap<DoubleBitBinarySpec> double_binary;
     StaticDataMap<AnalogSpec> analog_input;
     StaticDataMap<CounterSpec> counter;

--- a/cpp/lib/src/outstation/DefaultOutstationApplication.cpp
+++ b/cpp/lib/src/outstation/DefaultOutstationApplication.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2019 Automatak, LLC
+ *
+ * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+ * LLC (www.automatak.com) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Green Energy Corp and Automatak LLC license
+ * this file to you under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "opendnp3/outstation/DefaultOutstationApplication.h"
+
+namespace opendnp3
+{
+
+DefaultOutstationApplication::DefaultOutstationApplication(TimeDuration timeSyncRefreshRate)
+    : refresh_rate(timeSyncRefreshRate)
+{
+
+}
+
+DNPTime DefaultOutstationApplication::Now()
+{
+    auto result = DNPTime(last_timestamp.msSinceEpoch + std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - last_update).count());
+    result.quality = IsTimeValid() ? TimestampQuality::SYNCHRONIZED : TimestampQuality::UNSYNCHRONIZED;
+    return result;
+}
+
+bool DefaultOutstationApplication::WriteAbsoluteTime(const UTCTimestamp& timestamp)
+{
+    last_timestamp = timestamp;
+    last_update = std::chrono::steady_clock::now();
+    return true;
+}
+
+ApplicationIIN DefaultOutstationApplication::GetApplicationIIN() const
+{
+    ApplicationIIN result;
+    result.needTime = !IsTimeValid();
+    return result;
+}
+
+bool DefaultOutstationApplication::IsTimeValid() const
+{
+    return std::chrono::steady_clock::now() - last_update <= refresh_rate.value;
+}
+
+} // namespace opendnp3

--- a/cpp/lib/src/outstation/FreezeRequestHandler.cpp
+++ b/cpp/lib/src/outstation/FreezeRequestHandler.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2019 Automatak, LLC
+ *
+ * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+ * LLC (www.automatak.com) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Green Energy Corp and Automatak LLC license
+ * this file to you under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "outstation/FreezeRequestHandler.h"
+
+#include "gen/objects/Group12.h"
+#include "gen/objects/Group41.h"
+
+#include <ser4cpp/serialization/LittleEndian.h>
+
+namespace opendnp3
+{
+
+FreezeRequestHandler::FreezeRequestHandler(bool clear, Database& database)
+    : clear(clear),
+      database(database)
+{
+
+}
+
+bool FreezeRequestHandler::IsAllowed(uint32_t headerCount, GroupVariation gv, QualifierCode qc)
+{
+    if(gv == GroupVariation::Group20Var0 && qc == QualifierCode::ALL_OBJECTS)
+        return true;
+    
+    return false;
+}
+
+IINField FreezeRequestHandler::ProcessHeader(const AllObjectsHeader& record)
+{
+    this->database.SelectAll(GroupVariation::Group20Var0);
+    this->database.FreezeSelectedCounters(clear);
+    return IINField::Empty();
+}
+
+} // namespace opendnp3

--- a/cpp/lib/src/outstation/FreezeRequestHandler.cpp
+++ b/cpp/lib/src/outstation/FreezeRequestHandler.cpp
@@ -36,15 +36,30 @@ FreezeRequestHandler::FreezeRequestHandler(bool clear, Database& database)
 
 bool FreezeRequestHandler::IsAllowed(uint32_t headerCount, GroupVariation gv, QualifierCode qc)
 {
-    if(gv == GroupVariation::Group20Var0 && qc == QualifierCode::ALL_OBJECTS)
-        return true;
+    if(gv != GroupVariation::Group20Var0)
+        return false;
     
-    return false;
+    switch(qc)
+    {
+    case QualifierCode::ALL_OBJECTS:
+    case QualifierCode::UINT8_START_STOP:
+    case QualifierCode::UINT16_START_STOP:
+        return true;
+    default:
+        return false;
+    }
 }
 
 IINField FreezeRequestHandler::ProcessHeader(const AllObjectsHeader& record)
 {
-    this->database.SelectAll(GroupVariation::Group20Var0);
+    this->database.SelectAll(record.enumeration);
+    this->database.FreezeSelectedCounters(clear);
+    return IINField::Empty();
+}
+
+IINField FreezeRequestHandler::ProcessHeader(const RangeHeader& header)
+{
+    this->database.SelectRange(header.enumeration, header.range);
     this->database.FreezeSelectedCounters(clear);
     return IINField::Empty();
 }

--- a/cpp/lib/src/outstation/FreezeRequestHandler.h
+++ b/cpp/lib/src/outstation/FreezeRequestHandler.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2019 Automatak, LLC
+ *
+ * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+ * LLC (www.automatak.com) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Green Energy Corp and Automatak LLC license
+ * this file to you under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef OPENDNP3_FREEZEREQUESTHANDLER_H
+#define OPENDNP3_FREEZEREQUESTHANDLER_H
+
+#include "app/parsing/IAPDUHandler.h"
+#include "outstation/Database.h"
+
+namespace opendnp3
+{
+
+class FreezeRequestHandler final : public IAPDUHandler
+{
+public:
+    FreezeRequestHandler(bool clear, Database& database);
+
+    bool IsAllowed(uint32_t headerCount, GroupVariation gv, QualifierCode qc) final;
+
+private:
+    IINField ProcessHeader(const AllObjectsHeader& record) final;
+
+    bool clear;
+    Database& database;
+};
+
+} // namespace opendnp3
+
+#endif

--- a/cpp/lib/src/outstation/FreezeRequestHandler.h
+++ b/cpp/lib/src/outstation/FreezeRequestHandler.h
@@ -35,6 +35,7 @@ public:
 
 private:
     IINField ProcessHeader(const AllObjectsHeader& record) final;
+    IINField ProcessHeader(const RangeHeader& header) final;
 
     bool clear;
     Database& database;

--- a/cpp/lib/src/outstation/OutstationContext.cpp
+++ b/cpp/lib/src/outstation/OutstationContext.cpp
@@ -843,14 +843,14 @@ IINField OContext::HandleCommandWithConstant(const ser4cpp::rseq_t& objects, Hea
 IINField OContext::HandleFreeze(const ser4cpp::rseq_t& objects)
 {
     FreezeRequestHandler handler(false, database);
-    auto result = APDUParser::Parse(objects, handler, &this->logger);
+    auto result = APDUParser::Parse(objects, handler, &this->logger, ParserSettings::NoContents());
     return IINFromParseResult(result);
 }
 
 IINField OContext::HandleFreezeAndClear(const ser4cpp::rseq_t& objects)
 {
     FreezeRequestHandler handler(true, database);
-    auto result = APDUParser::Parse(objects, handler, &this->logger);
+    auto result = APDUParser::Parse(objects, handler, &this->logger, ParserSettings::NoContents());
     return IINFromParseResult(result);
 }
 

--- a/cpp/lib/src/outstation/OutstationContext.cpp
+++ b/cpp/lib/src/outstation/OutstationContext.cpp
@@ -30,6 +30,7 @@
 #include "outstation/CommandResponseHandler.h"
 #include "outstation/ConstantCommandAction.h"
 #include "outstation/IINHelpers.h"
+#include "outstation/FreezeRequestHandler.h"
 #include "outstation/ReadHandler.h"
 #include "outstation/WriteHandler.h"
 
@@ -59,7 +60,7 @@ OContext::OContext(const Addresses& addresses,
       commandHandler(std::move(commandHandler)),
       application(std::move(application)),
       eventBuffer(config.eventBufferConfig),
-      database(db_config, eventBuffer,  config.params.typesAllowedInClass0),
+      database(db_config, eventBuffer, *this->application, config.params.typesAllowedInClass0),
       rspContext(database, eventBuffer),
       params(config.params),
       isOnline(false),
@@ -523,6 +524,12 @@ bool OContext::ProcessBroadcastRequest(const ParsedRequest& request)
     case (FunctionCode::DIRECT_OPERATE_NR):
         this->HandleDirectOperate(request.objects, OperateType::DirectOperateNoAck, nullptr);
         return true;
+    case (FunctionCode::IMMED_FREEZE_NR):
+        this->HandleFreeze(request.objects);
+        return true;
+    case (FunctionCode::FREEZE_CLEAR_NR):
+        this->HandleFreezeAndClear(request.objects);
+        return true;
     case (FunctionCode::ASSIGN_CLASS):
     {
         if(this->application->SupportsAssignClass())
@@ -586,6 +593,12 @@ bool OContext::ProcessRequestNoAck(const ParsedRequest& request)
         this->HandleDirectOperate(request.objects, OperateType::DirectOperateNoAck,
                                   nullptr); // no object writer, this is a no ack code
         return true;
+    case (FunctionCode::IMMED_FREEZE_NR):
+        this->HandleFreeze(request.objects);
+        return true;
+    case (FunctionCode::FREEZE_CLEAR_NR):
+        this->HandleFreezeAndClear(request.objects);
+        return true;
     default:
         FORMAT_LOG_BLOCK(this->logger, flags::WARN, "Ignoring NR function code: %s",
                          FunctionCodeSpec::to_human_string(request.header.function));
@@ -621,6 +634,10 @@ IINField OContext::HandleNonReadResponse(const APDUHeader& header, const ser4cpp
     case (FunctionCode::ENABLE_UNSOLICITED):
         return this->params.allowUnsolicited ? this->HandleEnableUnsolicited(objects, &writer)
                                              : IINField(IINBit::FUNC_NOT_SUPPORTED);
+    case (FunctionCode::IMMED_FREEZE):
+        return this->HandleFreeze(objects);
+    case (FunctionCode::FREEZE_CLEAR):
+        return this->HandleFreezeAndClear(objects);
     default:
         return IINField(IINBit::FUNC_NOT_SUPPORTED);
     }
@@ -819,6 +836,20 @@ IINField OContext::HandleCommandWithConstant(const ser4cpp::rseq_t& objects, Hea
 {
     ConstantCommandAction constant(status);
     CommandResponseHandler handler(this->params.maxControlsPerRequest, &constant, &writer);
+    auto result = APDUParser::Parse(objects, handler, &this->logger);
+    return IINFromParseResult(result);
+}
+
+IINField OContext::HandleFreeze(const ser4cpp::rseq_t& objects)
+{
+    FreezeRequestHandler handler(false, database);
+    auto result = APDUParser::Parse(objects, handler, &this->logger);
+    return IINFromParseResult(result);
+}
+
+IINField OContext::HandleFreezeAndClear(const ser4cpp::rseq_t& objects)
+{
+    FreezeRequestHandler handler(true, database);
     auto result = APDUParser::Parse(objects, handler, &this->logger);
     return IINFromParseResult(result);
 }

--- a/cpp/lib/src/outstation/OutstationContext.h
+++ b/cpp/lib/src/outstation/OutstationContext.h
@@ -165,6 +165,8 @@ private:
     IINField HandleDisableUnsolicited(const ser4cpp::rseq_t& objects, HeaderWriter* writer);
     IINField HandleEnableUnsolicited(const ser4cpp::rseq_t& objects, HeaderWriter* writer);
     IINField HandleCommandWithConstant(const ser4cpp::rseq_t& objects, HeaderWriter& writer, CommandStatus status);
+    IINField HandleFreeze(const ser4cpp::rseq_t& objects);
+    IINField HandleFreezeAndClear(const ser4cpp::rseq_t& objects);
 
     // ------ resources --------
     const Addresses addresses;

--- a/cpp/lib/src/outstation/StaticDataMap.h
+++ b/cpp/lib/src/outstation/StaticDataMap.h
@@ -155,6 +155,8 @@ public:
 
     iterator end();
 
+    iterator find(uint16_t index);
+
 private:
     map_t map;
     Range selected;

--- a/cpp/lib/src/outstation/UpdateBuilder.cpp
+++ b/cpp/lib/src/outstation/UpdateBuilder.cpp
@@ -48,6 +48,12 @@ UpdateBuilder& UpdateBuilder::Update(const Counter& meas, uint16_t index, EventM
     return this->AddMeas(meas, index, mode);
 }
 
+UpdateBuilder& UpdateBuilder::FreezeCounter(uint16_t index, bool clear, EventMode mode)
+{
+    this->Add([=](IUpdateHandler& handler) { handler.FreezeCounter(index, clear, mode); });
+    return *this;
+}
+
 UpdateBuilder& UpdateBuilder::Update(const BinaryOutputStatus& meas, uint16_t index, EventMode mode)
 {
     return this->AddMeas(meas, index, mode);

--- a/cpp/lib/src/outstation/UpdateBuilder.cpp
+++ b/cpp/lib/src/outstation/UpdateBuilder.cpp
@@ -48,11 +48,6 @@ UpdateBuilder& UpdateBuilder::Update(const Counter& meas, uint16_t index, EventM
     return this->AddMeas(meas, index, mode);
 }
 
-UpdateBuilder& UpdateBuilder::Update(const FrozenCounter& meas, uint16_t index, EventMode mode)
-{
-    return this->AddMeas(meas, index, mode);
-}
-
 UpdateBuilder& UpdateBuilder::Update(const BinaryOutputStatus& meas, uint16_t index, EventMode mode)
 {
     return this->AddMeas(meas, index, mode);

--- a/cpp/tests/dnp3mocks/include/dnp3mocks/DatabaseHelpers.h
+++ b/cpp/tests/dnp3mocks/include/dnp3mocks/DatabaseHelpers.h
@@ -29,7 +29,7 @@ namespace by_count_of
 {
     opendnp3::DatabaseConfig all_types(uint16_t num);
     opendnp3::DatabaseConfig binary_input(uint16_t num);
-    opendnp3::DatabaseConfig counter(uint16_t num);
+    opendnp3::DatabaseConfig counter(uint16_t num, bool with_frozen=false);
     opendnp3::DatabaseConfig binary_output_status(uint16_t num);
     opendnp3::DatabaseConfig analog_input(uint16_t num);    
 	opendnp3::DatabaseConfig analog_output_status(uint16_t num);

--- a/cpp/tests/dnp3mocks/include/dnp3mocks/MockOutstationApplication.h
+++ b/cpp/tests/dnp3mocks/include/dnp3mocks/MockOutstationApplication.h
@@ -29,7 +29,8 @@ class MockOutstationApplication : public opendnp3::IOutstationApplication
 {
 public:
     MockOutstationApplication()
-        : supportsTimeWrite(true),
+        : currentTime(opendnp3::DNPTime(0, opendnp3::TimestampQuality::INVALID)),
+          supportsTimeWrite(true),
           supportsAssignClass(false),
           supportsWriteTimeAndInterval(false),
           allowTimeWrite(true),
@@ -38,6 +39,11 @@ public:
           warmRestartTimeDelay(0),
           coldRestartTimeDelay(0)
     {
+    }
+
+    opendnp3::DNPTime Now() final
+    {
+        return currentTime;
     }
 
     void OnStateChange(opendnp3::LinkStatus value) final {}
@@ -110,6 +116,13 @@ public:
     {
         return warmRestartTimeDelay;
     }
+
+    void SetTime(opendnp3::DNPTime time)
+    {
+        this->currentTime = time;
+    }
+
+    opendnp3::DNPTime currentTime;
 
     bool supportsTimeWrite;
     bool supportsAssignClass;

--- a/cpp/tests/dnp3mocks/src/DatabaseHelpers.cpp
+++ b/cpp/tests/dnp3mocks/src/DatabaseHelpers.cpp
@@ -35,9 +35,10 @@ namespace by_count_of
         return database_by_sizes(num, 0, 0, 0, 0, 0, 0, 0, 0);
     }
 
-    opendnp3::DatabaseConfig counter(uint16_t num)
+    opendnp3::DatabaseConfig counter(uint16_t num, bool with_frozen)
     {
-        return database_by_sizes(0, 0, 0, num, 0, 0, 0, 0, 0);
+        auto num_frozen = with_frozen ? num : 0;
+        return database_by_sizes(0, 0, 0, num, num_frozen, 0, 0, 0, 0);
     }
 
     opendnp3::DatabaseConfig binary_output_status(uint16_t num)

--- a/cpp/tests/integration/TestDNP3Manager.cpp
+++ b/cpp/tests/integration/TestDNP3Manager.cpp
@@ -22,7 +22,7 @@
 #include <opendnp3/LogLevels.h>
 #include <opendnp3/master/DefaultMasterApplication.h>
 #include <opendnp3/master/ISOEHandler.h>
-#include <opendnp3/outstation/IOutstationApplication.h>
+#include <opendnp3/outstation/DefaultOutstationApplication.h>
 #include <opendnp3/outstation/SimpleCommandHandler.h>
 
 #include "mocks/NullSOEHandler.h"

--- a/cpp/tests/integration/TestDeadlock.cpp
+++ b/cpp/tests/integration/TestDeadlock.cpp
@@ -25,6 +25,7 @@
 #include <opendnp3/channel/PrintingChannelListener.h>
 #include <opendnp3/master/DefaultMasterApplication.h>
 #include <opendnp3/master/PrintingCommandResultCallback.h>
+#include <opendnp3/outstation/DefaultOutstationApplication.h>
 
 #include <dnp3mocks/DatabaseHelpers.h>
 

--- a/cpp/tests/integration/TestMasterServerSmoke.cpp
+++ b/cpp/tests/integration/TestMasterServerSmoke.cpp
@@ -25,7 +25,7 @@
 #include <opendnp3/master/DefaultMasterApplication.h>
 #include <opendnp3/master/ISOEHandler.h>
 #include <opendnp3/master/PrintingSOEHandler.h>
-#include <opendnp3/outstation/IOutstationApplication.h>
+#include <opendnp3/outstation/DefaultOutstationApplication.h>
 #include <opendnp3/outstation/SimpleCommandHandler.h>
 
 #include "mocks/NullSOEHandler.h"

--- a/cpp/tests/integration/mocks/PerformanceStackPair.cpp
+++ b/cpp/tests/integration/mocks/PerformanceStackPair.cpp
@@ -78,7 +78,7 @@ void PerformanceStackPair::AddValue(uint32_t i, UpdateBuilder& builder)
 {
     const uint16_t index = i % NUM_POINTS_PER_TYPE;
 
-    switch (i % 7)
+    switch (i % 6)
     {
     case (0):
         builder.Update(Binary(i % 2 == 0), index, EventMode::Force);
@@ -94,9 +94,6 @@ void PerformanceStackPair::AddValue(uint32_t i, UpdateBuilder& builder)
         builder.Update(Counter(i), index, EventMode::Force);
         break;
     case (4):
-        builder.Update(FrozenCounter(i), index, EventMode::Force);
-        break;
-    case (5):
         builder.Update(BinaryOutputStatus(i % 2 == 0), index, EventMode::Force);
         break;
     default:

--- a/cpp/tests/integration/mocks/PerformanceStackPair.cpp
+++ b/cpp/tests/integration/mocks/PerformanceStackPair.cpp
@@ -21,6 +21,7 @@
 #include "mocks/PerformanceStackPair.h"
 
 #include <opendnp3/master/DefaultMasterApplication.h>
+#include <opendnp3/outstation/DefaultOutstationApplication.h>
 #include <opendnp3/outstation/SimpleCommandHandler.h>
 
 #include <dnp3mocks/DatabaseHelpers.h>

--- a/cpp/tests/integration/mocks/StackPair.cpp
+++ b/cpp/tests/integration/mocks/StackPair.cpp
@@ -47,7 +47,7 @@ StackPair::StackPair(log4cpp::LogLevels levels,
       outstation(CreateOutstation(
           levels, timeout, manager, port, numPointsPerType, 3 * eventsPerIteration, this->serverListener)),
       index_distribution(0, numPointsPerType - 1),
-      type_distribution(0, 6),
+      type_distribution(0, 5),
       bool_distribution(0, 1),
       int_distribution(0, 32767)
 {
@@ -150,12 +150,6 @@ ExpectedValue StackPair::AddRandomValue(UpdateBuilder& builder)
         return ExpectedValue(value, index);
     }
     case (4):
-    {
-        FrozenCounter value(int_distribution(generator));
-        builder.Update(value, index, EventMode::Force);
-        return ExpectedValue(value, index);
-    }
-    case (5):
     {
         BinaryOutputStatus value(bool_distribution(generator) == 0);
         builder.Update(value, index, EventMode::Force);

--- a/cpp/tests/integration/mocks/StackPair.cpp
+++ b/cpp/tests/integration/mocks/StackPair.cpp
@@ -21,6 +21,7 @@
 #include "mocks/StackPair.h"
 
 #include <opendnp3/master/DefaultMasterApplication.h>
+#include <opendnp3/outstation/DefaultOutstationApplication.h>
 #include <opendnp3/outstation/SimpleCommandHandler.h>
 
 #include <dnp3mocks/DatabaseHelpers.h>

--- a/cpp/tests/unit/CMakeLists.txt
+++ b/cpp/tests/unit/CMakeLists.txt
@@ -51,6 +51,7 @@ set(unittests_src
     ./TestOutstationCommandResponses.cpp
     ./TestOutstationDiscontiguousIndices.cpp
     ./TestOutstationEventResponses.cpp
+    ./TestOutstationFrozenCounters.cpp
     ./TestOutstationStateMachine.cpp
     ./TestOutstationUnsolicitedResponses.cpp
     ./TestShiftableBuffer.cpp

--- a/cpp/tests/unit/TestOutstationFrozenCounters.cpp
+++ b/cpp/tests/unit/TestOutstationFrozenCounters.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2013-2019 Automatak, LLC
+ *
+ * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+ * LLC (www.automatak.com) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Green Energy Corp and Automatak LLC license
+ * this file to you under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "utils/OutstationTestObject.h"
+#include "utils/APDUHexBuilders.h"
+
+#include <dnp3mocks/DatabaseHelpers.h>
+
+#include <ser4cpp/util/HexConversions.h>
+
+#include <catch.hpp>
+
+using namespace opendnp3;
+
+#define SUITE(name) "OutstationFrozenCounters - " name
+
+// "Go back to your oar, Forty-One."
+//   - Quintus Arrius
+const int counterValue = 41;
+const std::string counterValueHex = "29";
+
+// "Elvis has left the building!"
+const DNPTime freezeTimestamp(240607800000, TimestampQuality::SYNCHRONIZED);
+const std::string freezeTimestampHex = "C0 AA 57 05 38 00";
+
+void TestFreezeOperation(std::string func, std::function<std::string(uint8_t)> freezeResponse, bool clear)
+{
+    OutstationConfig config;
+    auto database = configure::by_count_of::counter(1, true);
+    database.frozen_counter[0].svariation = StaticFrozenCounterVariation::Group21Var5;
+    OutstationTestObject t(config, database);
+    t.Transaction([](IUpdateHandler& db) {
+        db.Modify(FlagsType::Counter, 0, 0, 0x01);
+        db.Modify(FlagsType::FrozenCounter, 0, 0, 0x01);
+    });
+    t.LowerLayerUp();
+
+    // Freeze all counters
+    t.SendToOutstation("C0 " + func + " 14 00 06");
+    REQUIRE(t.lower->PopWriteAsHex() == freezeResponse(0));
+    t.OnTxReady();
+
+    // Read all frozen counters
+    t.SendToOutstation("C1 01 15 00 06");
+    REQUIRE(t.lower->PopWriteAsHex() == "C1 81 80 00 15 05 00 00 00 01 00 00 00 00 00 00 00 00 00 00"); // Frozen value at 0
+    t.OnTxReady();
+
+    // Update the counters
+    t.Transaction([=](IUpdateHandler& db) { db.Update(Counter(counterValue), 0); });
+
+    // Read all frozen counters
+    t.SendToOutstation("C2 01 15 00 06");
+    REQUIRE(t.lower->PopWriteAsHex() == "C2 81 80 00 15 05 00 00 00 01 00 00 00 00 00 00 00 00 00 00"); // Frozen value still at 0
+    t.OnTxReady();
+
+    // Change time of application
+    t.application->SetTime(freezeTimestamp);
+
+    // Freeze all counters
+    t.SendToOutstation("C3 " + func + " 14 00 06");
+    REQUIRE(t.lower->PopWriteAsHex() == freezeResponse(3));
+    t.OnTxReady();
+
+    // Read all frozen counters
+    t.SendToOutstation("C4 01 15 00 06");
+    REQUIRE(t.lower->PopWriteAsHex() == "C4 81 80 00 15 05 00 00 00 01 29 00 00 00 " + freezeTimestampHex); // Frozen value now at 41
+    t.OnTxReady();
+
+    std::string expectedCounterValue = clear ? "00" : counterValueHex;
+
+    // Read all counters
+    t.SendToOutstation("C5 01 14 00 06");
+    REQUIRE(t.lower->PopWriteAsHex() == "C5 81 80 00 14 01 00 00 00 01 " + expectedCounterValue + " 00 00 00"); // Check if counter value is reset (if necessary)
+    t.OnTxReady();
+}
+
+std::string NullResponse(uint8_t seq)
+{
+    return hex::EmptyResponse(seq, IINField(IINBit::DEVICE_RESTART));
+}
+
+std::string NoResponse(uint8_t seq)
+{
+    return "";
+}
+
+TEST_CASE(SUITE("Freeze 0x07"))
+{
+    TestFreezeOperation("07", NullResponse, false);
+}
+
+TEST_CASE(SUITE("Freeze No Ack 0x08"))
+{
+    TestFreezeOperation("08", NoResponse, false);
+}
+
+TEST_CASE(SUITE("Freeze And Clear 0x09"))
+{
+    TestFreezeOperation("09", NullResponse, true);
+}
+
+TEST_CASE(SUITE("Freeze And Clear No Ack 0x0A"))
+{
+    TestFreezeOperation("0A", NoResponse, true);
+}
+
+TEST_CASE(SUITE("Broadcast Support"))
+{
+    OutstationConfig config;
+    auto database = configure::by_count_of::counter(1, true);
+    database.frozen_counter[0].svariation = StaticFrozenCounterVariation::Group21Var5;
+    OutstationTestObject t(config, database);
+    t.Transaction([](IUpdateHandler& db) {
+        db.Modify(FlagsType::Counter, 0, 0, 0x01);
+        db.Modify(FlagsType::FrozenCounter, 0, 0, 0x01);
+    });
+    t.LowerLayerUp();
+
+    // Freeze all counters
+    t.BroadcastToOutstation(LinkBroadcastAddress::DontConfirm, "C0 0A 14 00 06");
+    REQUIRE(t.lower->PopWriteAsHex() == ""); // No response
+    t.OnTxReady();
+
+    // Read all frozen counters
+    t.SendToOutstation("C1 01 15 00 06");
+    REQUIRE(t.lower->PopWriteAsHex() == "C1 81 81 00 15 05 00 00 00 01 00 00 00 00 00 00 00 00 00 00"); // Frozen value at 0
+    t.OnTxReady();
+
+    // Update the counters
+    t.Transaction([=](IUpdateHandler& db) { db.Update(Counter(counterValue), 0); });
+
+    // Read all frozen counters
+    t.SendToOutstation("C2 01 15 00 06");
+    REQUIRE(t.lower->PopWriteAsHex() == "C2 81 80 00 15 05 00 00 00 01 00 00 00 00 00 00 00 00 00 00"); // Frozen value still at 0
+    t.OnTxReady();
+
+    // Change time of application
+    t.application->SetTime(freezeTimestamp);
+
+    // Freeze all counters
+    t.BroadcastToOutstation(LinkBroadcastAddress::DontConfirm, "C3 0A 14 00 06");
+    REQUIRE(t.lower->PopWriteAsHex() == ""); // No response
+    t.OnTxReady();
+
+    // Read all frozen counters
+    t.SendToOutstation("C4 01 15 00 06");
+    REQUIRE(t.lower->PopWriteAsHex() == "C4 81 81 00 15 05 00 00 00 01 29 00 00 00 " + freezeTimestampHex); // Frozen value now at 41
+    t.OnTxReady();
+
+    // Read all counters
+    t.SendToOutstation("C5 01 14 00 06");
+    REQUIRE(t.lower->PopWriteAsHex() == "C5 81 80 00 14 01 00 00 00 01 00 00 00 00"); // Counter is now reset
+    t.OnTxReady();
+}

--- a/dotnet/CLRAdapter/src/ChangeSetAdapter.cpp
+++ b/dotnet/CLRAdapter/src/ChangeSetAdapter.cpp
@@ -2,7 +2,7 @@
  * Copyright 2013-2019 Automatak, LLC
  *
  * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
- * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * LLC (www.automatak.com) under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Green Energy Corp and Automatak LLC license
  * this file to you under the Apache License, Version 2.0 (the "License"); you
@@ -23,69 +23,73 @@
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+namespace DNP3
+{
+    namespace Adapter
+    {
 
-			ChangeSetAdapter::ChangeSetAdapter() : builder(new opendnp3::UpdateBuilder())
-			{}
+        ChangeSetAdapter::ChangeSetAdapter() : builder(new opendnp3::UpdateBuilder()) {}
 
-			ChangeSetAdapter::~ChangeSetAdapter()
-			{
-				this->!ChangeSetAdapter();
-			}
+        ChangeSetAdapter::~ChangeSetAdapter()
+        {
+            this->!ChangeSetAdapter();
+        }
 
-			ChangeSetAdapter::!ChangeSetAdapter()
-			{
-				delete builder;
-			}
-		
-			void ChangeSetAdapter::Apply(opendnp3::IOutstation& proxy)
-			{
-				proxy.Apply(builder->Build());				
-			}
+        ChangeSetAdapter::!ChangeSetAdapter()
+        {
+            delete builder;
+        }
 
-			void ChangeSetAdapter::Update(Binary^ update, System::UInt16 index, EventMode mode)
-			{
-				builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode) mode);
-			}
-			
-			void ChangeSetAdapter::Update(DoubleBitBinary^ update, System::UInt16 index, EventMode mode)
-			{
-				builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode) mode);
-			}
+        void ChangeSetAdapter::Apply(opendnp3::IOutstation& proxy)
+        {
+            proxy.Apply(builder->Build());
+        }
 
-			void ChangeSetAdapter::Update(Analog^ update, System::UInt16 index, EventMode mode)
-			{
-				builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode) mode);
-			}
+        void ChangeSetAdapter::Update(Binary ^ update, System::UInt16 index, EventMode mode)
+        {
+            builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode)mode);
+        }
 
-			void ChangeSetAdapter::Update(Counter^ update, System::UInt16 index, EventMode mode)
-			{
-				builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode) mode);
-			}
-			
-			void ChangeSetAdapter::Update(BinaryOutputStatus^ update, System::UInt16 index, EventMode mode)
-			{
-				builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode) mode);
-			}
+        void ChangeSetAdapter::Update(DoubleBitBinary ^ update, System::UInt16 index, EventMode mode)
+        {
+            builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode)mode);
+        }
 
-			void ChangeSetAdapter::Update(AnalogOutputStatus^ update, System::UInt16 index, EventMode mode)
-			{
-				builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode) mode);
-			}
+        void ChangeSetAdapter::Update(Analog ^ update, System::UInt16 index, EventMode mode)
+        {
+            builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode)mode);
+        }
 
-			void ChangeSetAdapter::Update(OctetString^ update, System::UInt16 index, EventMode mode)
-			{				
-				builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode) mode);
-			}
+        void ChangeSetAdapter::Update(Counter ^ update, System::UInt16 index, EventMode mode)
+        {
+            builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode)mode);
+        }
 
-			void ChangeSetAdapter::Update(TimeAndInterval^ update, System::UInt16 index)
-			{
-				builder->Update(Conversions::ConvertMeas(update), index);
-			}
+        void ChangeSetAdapter::FreezeCounter(System::UInt16 index, System::Boolean clear, EventMode mode)
+        {
+            builder->FreezeCounter(index, clear, (opendnp3::EventMode)mode);
+        }
 
-		}
-	}
-}
+        void ChangeSetAdapter::Update(BinaryOutputStatus ^ update, System::UInt16 index, EventMode mode)
+        {
+            builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode)mode);
+        }
+
+        void ChangeSetAdapter::Update(AnalogOutputStatus ^ update, System::UInt16 index, EventMode mode)
+        {
+            builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode)mode);
+        }
+
+        void ChangeSetAdapter::Update(OctetString ^ update, System::UInt16 index, EventMode mode)
+        {
+            builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode)mode);
+        }
+
+        void ChangeSetAdapter::Update(TimeAndInterval ^ update, System::UInt16 index)
+        {
+            builder->Update(Conversions::ConvertMeas(update), index);
+        }
+
+    } // namespace Adapter
+} // namespace DNP3
+} // namespace Automatak

--- a/dotnet/CLRAdapter/src/ChangeSetAdapter.cpp
+++ b/dotnet/CLRAdapter/src/ChangeSetAdapter.cpp
@@ -65,11 +65,6 @@ namespace Automatak
 			{
 				builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode) mode);
 			}
-
-			void ChangeSetAdapter::Update(FrozenCounter^ update, System::UInt16 index, EventMode mode)
-			{
-				builder->Update(Conversions::ConvertMeas(update), index, (opendnp3::EventMode) mode);
-			}
 			
 			void ChangeSetAdapter::Update(BinaryOutputStatus^ update, System::UInt16 index, EventMode mode)
 			{

--- a/dotnet/CLRAdapter/src/ChangeSetAdapter.h
+++ b/dotnet/CLRAdapter/src/ChangeSetAdapter.h
@@ -47,6 +47,7 @@ namespace Automatak
 				virtual void Update(DoubleBitBinary^ update, System::UInt16 index, EventMode mode);				
 				virtual void Update(Analog^ update, System::UInt16 index, EventMode mode);
 				virtual void Update(Counter^ update, System::UInt16 index, EventMode mode);
+                virtual void FreezeCounter(System::UInt16 index, System::Boolean clear, EventMode mode);
 				virtual void Update(BinaryOutputStatus^ update, System::UInt16 index, EventMode mode);
 				virtual void Update(AnalogOutputStatus^ update, System::UInt16 index, EventMode mode);
 				virtual void Update(OctetString^ update, System::UInt16 index, EventMode mode);

--- a/dotnet/CLRAdapter/src/ChangeSetAdapter.h
+++ b/dotnet/CLRAdapter/src/ChangeSetAdapter.h
@@ -47,7 +47,6 @@ namespace Automatak
 				virtual void Update(DoubleBitBinary^ update, System::UInt16 index, EventMode mode);				
 				virtual void Update(Analog^ update, System::UInt16 index, EventMode mode);
 				virtual void Update(Counter^ update, System::UInt16 index, EventMode mode);
-				virtual void Update(FrozenCounter^ update, System::UInt16 index, EventMode mode);
 				virtual void Update(BinaryOutputStatus^ update, System::UInt16 index, EventMode mode);
 				virtual void Update(AnalogOutputStatus^ update, System::UInt16 index, EventMode mode);
 				virtual void Update(OctetString^ update, System::UInt16 index, EventMode mode);

--- a/dotnet/CLRInterface/src/ChangeSet.cs
+++ b/dotnet/CLRInterface/src/ChangeSet.cs
@@ -89,6 +89,11 @@ namespace Automatak.DNP3.Interface
             updates.Add((IDatabase db) => db.Update(update, index, mode));
         }
 
+        public void FreezeCounter(ushort index, bool clear, EventMode mode = EventMode.Detect)
+        {
+            updates.Add((IDatabase db) => db.FreezeCounter(index, clear, mode));
+        }
+
         public void Update(BinaryOutputStatus update, ushort index, EventMode mode = EventMode.Detect)
         {
             updates.Add((IDatabase db) => db.Update(update, index, mode));

--- a/dotnet/CLRInterface/src/ChangeSet.cs
+++ b/dotnet/CLRInterface/src/ChangeSet.cs
@@ -89,11 +89,6 @@ namespace Automatak.DNP3.Interface
             updates.Add((IDatabase db) => db.Update(update, index, mode));
         }
 
-        public void Update(FrozenCounter update, ushort index, EventMode mode = EventMode.Detect)
-        {
-            updates.Add((IDatabase db) => db.Update(update, index, mode));
-        }
-
         public void Update(BinaryOutputStatus update, ushort index, EventMode mode = EventMode.Detect)
         {
             updates.Add((IDatabase db) => db.Update(update, index, mode));

--- a/dotnet/CLRInterface/src/IDatabase.cs
+++ b/dotnet/CLRInterface/src/IDatabase.cs
@@ -28,22 +28,22 @@ namespace Automatak.DNP3.Interface
     /// </summary>
     public interface IDatabase
 	{
-        
-        /// <summary>
-        /// Update a Binary input
-        /// </summary>
-        /// <param name="update">measurement to update</param>
-        /// <param name="index">index of measurement</param>        
-        /// <param name="forceEvent"> if true, an event is created regardess of the last reported value</param>
-        /// <returns> true if the point exists </returns>
-		void Update(Binary update, System.UInt16 index, EventMode mode = EventMode.Detect);
 
         /// <summary>
         /// Update a Binary input
         /// </summary>
         /// <param name="update">measurement to update</param>
         /// <param name="index">index of measurement</param>        
-        /// <param name="forceEvent"> if true, an event is created regardess of the last reported value</param>
+        /// <param name="mode"> EventMode to use</param>
+        /// <returns> true if the point exists </returns>
+        void Update(Binary update, System.UInt16 index, EventMode mode = EventMode.Detect);
+
+        /// <summary>
+        /// Update a Binary input
+        /// </summary>
+        /// <param name="update">measurement to update</param>
+        /// <param name="index">index of measurement</param>        
+        /// <param name="mode"> EventMode to use</param>
         /// <returns> true if the point exists </returns>
         void Update(DoubleBitBinary update, System.UInt16 index, EventMode mode = EventMode.Detect);
 
@@ -52,7 +52,7 @@ namespace Automatak.DNP3.Interface
         /// </summary>
         /// <param name="update">measurement to update</param>
         /// <param name="index">index of measurement</param>
-        /// <param name="forceEvent"> if true, an event is created regardess of the last reported value</param>
+        /// <param name="mode"> EventMode to use</param>
         /// <returns> true if the point exists </returns>
         void Update(Analog update, System.UInt16 index, EventMode mode = EventMode.Detect);
 
@@ -61,16 +61,25 @@ namespace Automatak.DNP3.Interface
         /// </summary>
         /// <param name="update">measurement to update</param>
         /// <param name="index">index of measurement</param>
-        /// <param name="forceEvent"> if true, an event is created regardess of the last reported value</param>
+        /// <param name="mode"> EventMode to use</param>
         /// <returns> true if the point exists </returns>
         void Update(Counter update, System.UInt16 index, EventMode mode = EventMode.Detect);
+
+        /// <summary>
+        /// Freeze a Counter
+        /// </summary>
+        /// <param name="index">index of measurement</param>
+        /// <param name="clear">clear original counter</param>
+        /// <param name="mode"> EventMode to use</param>
+        /// <returns> true if the point exists </returns>
+        void FreezeCounter(System.UInt16 index, bool clear, EventMode mode = EventMode.Detect);
 
         /// <summary>
         /// Update a BinaryOutputStatus
         /// </summary>
         /// <param name="update">measurement to update</param>
         /// <param name="index">index of measurement</param>
-        /// <param name="forceEvent"> if true, an event is created regardess of the last reported value</param>
+        /// <param name="mode"> EventMode to use</param>
         /// <returns> true if the point exists </returns>
         void Update(BinaryOutputStatus update, System.UInt16 index, EventMode mode = EventMode.Detect);
 
@@ -79,7 +88,7 @@ namespace Automatak.DNP3.Interface
         /// </summary>
         /// <param name="update">measurement to update</param>
         /// <param name="index">index of measurement</param>
-        /// <param name="forceEvent"> if true, an event is created regardess of the last reported value</param>
+        /// <param name="mode"> EventMode to use</param>
         /// <returns> true if the point exists </returns>
         void Update(AnalogOutputStatus update, System.UInt16 index, EventMode mode = EventMode.Detect);
 
@@ -88,7 +97,7 @@ namespace Automatak.DNP3.Interface
         /// </summary>
         /// <param name="update">measurement to update</param>
         /// <param name="index">index of measurement</param>
-        /// <param name="forceEvent"> if true, an event is created regardess of the last reported value</param>
+        /// <param name="mode"> EventMode to use</param>
         /// <returns> true if the point exists </returns>
         void Update(OctetString update, System.UInt16 index, EventMode mode = EventMode.Detect);
 
@@ -97,7 +106,7 @@ namespace Automatak.DNP3.Interface
         /// </summary>
         /// <param name="update"></param>
         /// <param name="index"></param>
-        /// <param name="forceEvent"> if true, an event is created regardess of the last reported value</param>
+        /// <param name="mode"> EventMode to use</param>
         /// <returns> true if the point exists </returns>
         void Update(TimeAndInterval update, System.UInt16 index);                
 	}

--- a/dotnet/CLRInterface/src/IDatabase.cs
+++ b/dotnet/CLRInterface/src/IDatabase.cs
@@ -66,15 +66,6 @@ namespace Automatak.DNP3.Interface
         void Update(Counter update, System.UInt16 index, EventMode mode = EventMode.Detect);
 
         /// <summary>
-        /// Update a FrozenCounter
-        /// </summary>
-        /// <param name="update">measurement to update</param>
-        /// <param name="index">index of measurement</param>
-        /// <param name="forceEvent"> if true, an event is created regardess of the last reported value</param>
-        /// <returns> true if the point exists </returns>
-        void Update(FrozenCounter update, System.UInt16 index, EventMode mode = EventMode.Detect);
-
-        /// <summary>
         /// Update a BinaryOutputStatus
         /// </summary>
         /// <param name="update">measurement to update</param>

--- a/java/bindings/src/main/java/com/automatak/dnp3/Database.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/Database.java
@@ -59,13 +59,6 @@ public interface Database
      * @param value measurement to update
      * @param index index of measurement
      */
-    void update(FrozenCounter value, int index);
-
-    /**
-     * Update a value in the database
-     * @param value measurement to update
-     * @param index index of measurement
-     */
     void update(BinaryOutputStatus value, int index);
 
     /**
@@ -106,14 +99,6 @@ public interface Database
      * @param mode EventMode to use
      */
     void update(Counter value, int index, EventMode mode);
-
-    /**
-     * Update a value in the database
-     * @param value measurement to update
-     * @param index index of measurement
-     * @param mode EventMode to use
-     */
-    void update(FrozenCounter value, int index, EventMode mode);
 
     /**
      * Update a value in the database

--- a/java/bindings/src/main/java/com/automatak/dnp3/Database.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/Database.java
@@ -56,6 +56,13 @@ public interface Database
 
     /**
      * Update a value in the database
+     * @param index index of measurement
+     * @param clear clear the original counter
+     */
+    void freezeCounter(int index, boolean clear);
+
+    /**
+     * Update a value in the database
      * @param value measurement to update
      * @param index index of measurement
      */
@@ -99,6 +106,14 @@ public interface Database
      * @param mode EventMode to use
      */
     void update(Counter value, int index, EventMode mode);
+
+    /**
+     * Update a value in the database
+     * @param index index of measurement
+     * @param clear clear the original counter
+     * @param mode EventMode to use
+     */
+    void freezeCounter(int index, boolean clear, EventMode mode);
 
     /**
      * Update a value in the database

--- a/java/bindings/src/main/java/com/automatak/dnp3/OutstationChangeSet.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/OutstationChangeSet.java
@@ -61,6 +61,11 @@ public class OutstationChangeSet implements Database, ChangeSet {
     }
 
     @Override
+    public void freezeCounter(int index, boolean clear) {
+        updates.add((Database db) -> db.freezeCounter(index, clear, EventMode.Detect));
+    }
+
+    @Override
     public void update(BinaryOutputStatus update, int index) {
         updates.add((Database db) -> db.update(update, index, EventMode.Detect));
     }
@@ -88,6 +93,11 @@ public class OutstationChangeSet implements Database, ChangeSet {
     @Override
     public void update(Counter update, int index, EventMode mode) {
         updates.add((Database db) -> db.update(update, index, mode));
+    }
+
+    @Override
+    public void freezeCounter(int index, boolean clear, EventMode mode) {
+        updates.add((Database db) -> db.freezeCounter(index, clear, mode));
     }
 
     @Override

--- a/java/bindings/src/main/java/com/automatak/dnp3/OutstationChangeSet.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/OutstationChangeSet.java
@@ -61,11 +61,6 @@ public class OutstationChangeSet implements Database, ChangeSet {
     }
 
     @Override
-    public void update(FrozenCounter update, int index) {
-        updates.add((Database db) -> db.update(update, index, EventMode.Detect));
-    }
-
-    @Override
     public void update(BinaryOutputStatus update, int index) {
         updates.add((Database db) -> db.update(update, index, EventMode.Detect));
     }
@@ -92,11 +87,6 @@ public class OutstationChangeSet implements Database, ChangeSet {
 
     @Override
     public void update(Counter update, int index, EventMode mode) {
-        updates.add((Database db) -> db.update(update, index, mode));
-    }
-
-    @Override
-    public void update(FrozenCounter update, int index, EventMode mode) {
         updates.add((Database db) -> db.update(update, index, mode));
     }
 

--- a/java/bindings/src/main/java/com/automatak/dnp3/impl/ChangeSetImpl.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/impl/ChangeSetImpl.java
@@ -63,12 +63,6 @@ class ChangeSetImpl implements Database {
     }
 
     @Override
-    public void update(FrozenCounter value, int index)
-    {
-        this.update(value, index, EventMode.Detect);
-    }
-
-    @Override
     public void update(BinaryOutputStatus value, int index)
     {
         this.update(value, index, EventMode.Detect);
@@ -106,12 +100,6 @@ class ChangeSetImpl implements Database {
     }
 
     @Override
-    public void update(FrozenCounter value, int index, EventMode mode)
-    {
-        this.update_frozen_counter_native(this.nativePointer, value.value, value.quality, value.timestamp, index, mode.toType());
-    }
-
-    @Override
     public void update(BinaryOutputStatus value, int index, EventMode mode)
     {
         this.update_bo_status_native(this.nativePointer, value.value, value.quality, value.timestamp, index, mode.toType());
@@ -130,7 +118,6 @@ class ChangeSetImpl implements Database {
     private native void update_double_binary_native(long nativePointer, int value, byte flags, long time, int index, int mode);
     private native void update_analog_native(long nativePointer, double value, byte flags, long time, int index, int mode);
     private native void update_counter_native(long nativePointer, long value, byte flags, long time, int index, int mode);
-    private native void update_frozen_counter_native(long nativePointer, long value, byte flags, long time, int index, int mode);
     private native void update_bo_status_native(long nativePointer, boolean value, byte flags, long time, int index, int mode);
     private native void update_ao_status_native(long nativePointer, double value, byte flags, long time, int index, int mode);
 }

--- a/java/bindings/src/main/java/com/automatak/dnp3/impl/ChangeSetImpl.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/impl/ChangeSetImpl.java
@@ -63,6 +63,12 @@ class ChangeSetImpl implements Database {
     }
 
     @Override
+    public void freezeCounter(int index, boolean clear)
+    {
+        this.freezeCounter(index, clear, EventMode.Detect);
+    }
+
+    @Override
     public void update(BinaryOutputStatus value, int index)
     {
         this.update(value, index, EventMode.Detect);
@@ -100,6 +106,12 @@ class ChangeSetImpl implements Database {
     }
 
     @Override
+    public void freezeCounter(int index, boolean clear, EventMode mode)
+    {
+        this.freeze_counter_native(this.nativePointer, index, clear, mode.toType());
+    }
+
+    @Override
     public void update(BinaryOutputStatus value, int index, EventMode mode)
     {
         this.update_bo_status_native(this.nativePointer, value.value, value.quality, value.timestamp, index, mode.toType());
@@ -118,6 +130,7 @@ class ChangeSetImpl implements Database {
     private native void update_double_binary_native(long nativePointer, int value, byte flags, long time, int index, int mode);
     private native void update_analog_native(long nativePointer, double value, byte flags, long time, int index, int mode);
     private native void update_counter_native(long nativePointer, long value, byte flags, long time, int index, int mode);
+    private native void freeze_counter_native(long nativePointer, int index, boolean clear, int mode);
     private native void update_bo_status_native(long nativePointer, boolean value, byte flags, long time, int index, int mode);
     private native void update_ao_status_native(long nativePointer, double value, byte flags, long time, int index, int mode);
 }

--- a/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/ExpectedValue.java
+++ b/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/ExpectedValue.java
@@ -28,7 +28,6 @@ public class ExpectedValue {
         DoubleBinaryType,
         AnalogType,
         CounterType,
-        FrozenCounterType,
         BOStatusType,
         AOStatusType
     }
@@ -57,11 +56,6 @@ public class ExpectedValue {
     public ExpectedValue(Counter measurement, int index)
     {
         this(measurement.value, index, Type.CounterType);
-    }
-
-    public ExpectedValue(FrozenCounter measurement, int index)
-    {
-        this(measurement.value, index, Type.FrozenCounterType);
     }
 
     public ExpectedValue(BinaryOutputStatus measurement, int index)

--- a/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/ExpectedValue.java
+++ b/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/ExpectedValue.java
@@ -21,6 +21,8 @@ package com.automatak.dnp3.impl.mocks;
 
 import com.automatak.dnp3.*;
 
+import java.util.Objects;
+
 public class ExpectedValue {
 
     enum Type {
@@ -28,6 +30,7 @@ public class ExpectedValue {
         DoubleBinaryType,
         AnalogType,
         CounterType,
+        FrozenCounterType,
         BOStatusType,
         AOStatusType
     }
@@ -35,7 +38,7 @@ public class ExpectedValue {
     public static final ExpectedValue.Type[] ALL_TYPES = ExpectedValue.Type.values();
 
     final int index;
-    final long value;
+    final Long value;
     final Type type;
 
     public ExpectedValue(BinaryInput measurement, int index)
@@ -76,9 +79,16 @@ public class ExpectedValue {
         this.type = type;
     }
 
+    ExpectedValue(int index, Type type)
+    {
+        this.value = null;
+        this.index = index;
+        this.type = type;
+    }
+
     public boolean isEqual(ExpectedValue other)
     {
-        return (this.type == other.type) && (this.index == other.index) && (this.value == other.value);
+        return (this.type == other.type) && (this.index == other.index) && (Objects.equals(this.value, other.value));
     }
 
     @Override

--- a/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/QueuedSOEHandler.java
+++ b/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/QueuedSOEHandler.java
@@ -92,7 +92,7 @@ public class QueuedSOEHandler implements SOEHandler {
     @Override
     public void processFC(HeaderInfo info, Iterable<IndexedValue<FrozenCounter>> values)
     {
-        this.add(values, v -> new ExpectedValue(v.value, v.index));
+        
     }
 
     @Override

--- a/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/QueuedSOEHandler.java
+++ b/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/QueuedSOEHandler.java
@@ -92,7 +92,7 @@ public class QueuedSOEHandler implements SOEHandler {
     @Override
     public void processFC(HeaderInfo info, Iterable<IndexedValue<FrozenCounter>> values)
     {
-
+        this.add(values, v -> new ExpectedValue(v.index, ExpectedValue.Type.FrozenCounterType));
     }
 
     @Override

--- a/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/QueuedSOEHandler.java
+++ b/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/QueuedSOEHandler.java
@@ -92,7 +92,7 @@ public class QueuedSOEHandler implements SOEHandler {
     @Override
     public void processFC(HeaderInfo info, Iterable<IndexedValue<FrozenCounter>> values)
     {
-        
+
     }
 
     @Override

--- a/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/StackPair.java
+++ b/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/StackPair.java
@@ -191,11 +191,6 @@ public class StackPair {
                 set.update(v, index, EventMode.Force);
                 return new ExpectedValue(v, index);
             }
-            case FrozenCounterType: {
-                FrozenCounter v = new FrozenCounter(random.nextInt(65535), (byte) 0x01, 0);
-                set.update(v, index, EventMode.Force);
-                return new ExpectedValue(v, index);
-            }
             case AnalogType: {
                 AnalogInput v = new AnalogInput(random.nextInt(65535), (byte) 0x01, 0);
                 set.update(v, index, EventMode.Force);

--- a/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/StackPair.java
+++ b/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/StackPair.java
@@ -33,6 +33,8 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+import static com.automatak.dnp3.impl.mocks.ExpectedValue.Type.FrozenCounterType;
+
 public class StackPair {
 
     public static final int LEVELS = LogLevels.INFO;
@@ -190,6 +192,10 @@ public class StackPair {
                 Counter v = new Counter(random.nextInt(65535), (byte) 0x01, 0);
                 set.update(v, index, EventMode.Force);
                 return new ExpectedValue(v, index);
+            }
+            case FrozenCounterType: {
+                set.freezeCounter(index, false, EventMode.Force);
+                return new ExpectedValue(index, FrozenCounterType);
             }
             case AnalogType: {
                 AnalogInput v = new AnalogInput(random.nextInt(65535), (byte) 0x01, 0);

--- a/java/cpp/com_automatak_dnp3_impl_ChangeSetImpl.cpp
+++ b/java/cpp/com_automatak_dnp3_impl_ChangeSetImpl.cpp
@@ -67,14 +67,6 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1counte
                     static_cast<EventMode>(mode));
 }
 
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1frozen_1counter_1native(
-    JNIEnv* /*env*/, jobject /*unused*/, jlong native, jlong value, jbyte flags, jlong time, jint index, jint mode)
-{
-    const auto changes = (UpdateBuilder*)native;
-    changes->Update(FrozenCounter(static_cast<uint32_t>(value), Flags(flags), DNPTime(time)), static_cast<uint16_t>(index),
-                    static_cast<EventMode>(mode));
-}
-
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1bo_1status_1native(
     JNIEnv* /*env*/, jobject /*unused*/, jlong native, jboolean value, jbyte flags, jlong time, jint index, jint mode)
 {

--- a/java/cpp/com_automatak_dnp3_impl_ChangeSetImpl.cpp
+++ b/java/cpp/com_automatak_dnp3_impl_ChangeSetImpl.cpp
@@ -67,6 +67,13 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1counte
                     static_cast<EventMode>(mode));
 }
 
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_freeze_1counter_1native(
+    JNIEnv * /*env*/, jobject /*unused*/, jlong native, jint index, jboolean clear, jint mode)
+{
+    const auto changes = (UpdateBuilder*)native;
+    changes->FreezeCounter(static_cast<uint16_t>(index), clear, static_cast<EventMode>(mode));
+}
+
 JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1bo_1status_1native(
     JNIEnv* /*env*/, jobject /*unused*/, jlong native, jboolean value, jbyte flags, jlong time, jint index, jint mode)
 {

--- a/java/cpp/com_automatak_dnp3_impl_ChangeSetImpl.h
+++ b/java/cpp/com_automatak_dnp3_impl_ChangeSetImpl.h
@@ -57,6 +57,14 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1counte
 
 /*
  * Class:     com_automatak_dnp3_impl_ChangeSetImpl
+ * Method:    freeze_counter_native
+ * Signature: (JIZI)V
+ */
+JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_freeze_1counter_1native
+  (JNIEnv *, jobject, jlong, jint, jboolean, jint);
+
+/*
+ * Class:     com_automatak_dnp3_impl_ChangeSetImpl
  * Method:    update_bo_status_native
  * Signature: (JZBJII)V
  */

--- a/java/cpp/com_automatak_dnp3_impl_ChangeSetImpl.h
+++ b/java/cpp/com_automatak_dnp3_impl_ChangeSetImpl.h
@@ -57,14 +57,6 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1counte
 
 /*
  * Class:     com_automatak_dnp3_impl_ChangeSetImpl
- * Method:    update_frozen_counter_native
- * Signature: (JJBJII)V
- */
-JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ChangeSetImpl_update_1frozen_1counter_1native
-  (JNIEnv *, jobject, jlong, jlong, jbyte, jlong, jint, jint);
-
-/*
- * Class:     com_automatak_dnp3_impl_ChangeSetImpl
  * Method:    update_bo_status_native
  * Signature: (JZBJII)V
  */


### PR DESCRIPTION
Closes #319.

- Add support for `IMMED_FREEZE` (0x07), `IMMED_FREEZE_NR` (0x08), `FREEZE_CLEAR` (0x09) and `FREEZE_CLEAR_NR` (0x0A).
- The No Acknowledgment versions are available through the broadcast addresses
- Support qualifier all (0x06) and start-stop 8-bit/16-bit (0x00, 0x01)
- `IOutstationApplication` now must implement `IDnpTimeSource`, so it must be able to return the current time.
- When a freeze operation occurs, the current value and flags of the counter is copied to the frozen value (if it exists). The current time (returned by `IOutstationApplication`) is used as a timestamp.
- When a clear is done, the current time (returned by `IOutstationApplication`) is used as a timestamp for the counter.
- The `UpdateBuilder` does not have an update member function to update the frozen counters, since all is done automatically now.
- Manual freezing is available in `UpdateBuilder`, also in the C# and Java bindings.
- A new `DefaultOutstationApplication` is available and it handles basic time synchronisation with `std::chrono::system_clock`.
- The outstation demo was reverted (I had copied the TLS outstation by mistake...)