### PR TITLE
Add support for configurable unsolicited response retries

### DIFF
--- a/cpp/lib/CMakeLists.txt
+++ b/cpp/lib/CMakeLists.txt
@@ -155,6 +155,7 @@ set(opendnp3_public_headers
     ./include/opendnp3/outstation/IOutstationApplication.h
     ./include/opendnp3/outstation/IUpdateHandler.h
     ./include/opendnp3/outstation/MeasurementConfig.h
+    ./include/opendnp3/outstation/NumRetries.h
     ./include/opendnp3/outstation/OutstationConfig.h
     ./include/opendnp3/outstation/OutstationParams.h
     ./include/opendnp3/outstation/OutstationStackConfig.h
@@ -634,6 +635,7 @@ set(opendnp3_src
     ./src/outstation/EventBufferConfig.cpp
     ./src/outstation/IINHelpers.cpp
     ./src/outstation/IOutstationApplication.cpp
+    ./src/outstation/NumRetries.cpp
     ./src/outstation/OctetStringSerializer.cpp
     ./src/outstation/OutstationContext.cpp
     ./src/outstation/OutstationStack.cpp

--- a/cpp/lib/include/opendnp3/outstation/NumRetries.h
+++ b/cpp/lib/include/opendnp3/outstation/NumRetries.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2019 Automatak, LLC
+ *
+ * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+ * LLC (www.automatak.com) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Green Energy Corp and Automatak LLC license
+ * this file to you under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef OPENDNP3_NUMRETRIES_H
+#define OPENDNP3_NUMRETRIES_H
+
+#include <cstddef>
+
+namespace opendnp3
+{
+
+/**
+ *	Unsolicited response number of retries
+ */
+class NumRetries final
+{
+public:
+    static NumRetries Fixed(std::size_t maxNumRetries);
+    static NumRetries Infinite();
+
+    bool Retry();
+    void Reset();
+
+private:
+    NumRetries(std::size_t maxNumRetries, bool isInfinite);
+
+    std::size_t numRetries;
+    std::size_t maxNumRetries;
+    bool isInfinite;
+};
+
+} // namespace opendnp3
+
+#endif

--- a/cpp/lib/include/opendnp3/outstation/OutstationParams.h
+++ b/cpp/lib/include/opendnp3/outstation/OutstationParams.h
@@ -23,6 +23,7 @@
 #include "opendnp3/util/TimeDuration.h"
 #include "opendnp3/app/AppConstants.h"
 #include "opendnp3/app/ClassField.h"
+#include "opendnp3/outstation/NumRetries.h"
 #include "opendnp3/outstation/StaticTypeBitfield.h"
 
 namespace opendnp3
@@ -45,8 +46,7 @@ struct OutstationParams
     /// Timeout for unsolicited confirms
     TimeDuration unsolConfirmTimeout = DEFAULT_APP_TIMEOUT;
 
-    /// Timeout for unsolicited retries
-    TimeDuration unsolRetryTimeout = DEFAULT_APP_TIMEOUT;
+    NumRetries numUnsolRetries = NumRetries::Infinite();
 
     /// The maximum fragment size the outstation will use for fragments it sends
     uint32_t maxTxFragSize = DEFAULT_MAX_APDU_SIZE;

--- a/cpp/lib/src/outstation/NumRetries.cpp
+++ b/cpp/lib/src/outstation/NumRetries.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2013-2019 Automatak, LLC
+ *
+ * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+ * LLC (www.automatak.com) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Green Energy Corp and Automatak LLC license
+ * this file to you under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "opendnp3/outstation/NumRetries.h"
+
+namespace opendnp3
+{
+
+NumRetries::NumRetries(std::size_t maxNumRetries, bool isInfinite)
+    : numRetries(0),
+      maxNumRetries(maxNumRetries),
+      isInfinite(isInfinite)
+{
+
+}
+
+NumRetries NumRetries::Fixed(std::size_t maxNumRetries)
+{
+    return NumRetries(maxNumRetries, false);
+}
+
+NumRetries NumRetries::Infinite()
+{
+    return NumRetries(0, true);
+}
+
+bool NumRetries::Retry()
+{
+    this->numRetries++;
+
+    return this->isInfinite || this->numRetries <= this->maxNumRetries;
+}
+
+void NumRetries::Reset()
+{
+    this->numRetries = 0;
+}
+
+}; // namespace opendnp3

--- a/cpp/lib/src/outstation/OutstationContext.cpp
+++ b/cpp/lib/src/outstation/OutstationContext.cpp
@@ -327,6 +327,7 @@ bool OContext::CheckForUnsolicited()
                 auto response = this->unsol.tx.Start();
                 auto writer = response.GetWriter();
 
+                this->unsolRetries.Reset();
                 this->eventBuffer.Unselect();
                 this->eventBuffer.SelectAllByClass(this->params.unsolClassMask);
                 this->eventBuffer.Load(writer);

--- a/cpp/lib/src/outstation/OutstationContext.cpp
+++ b/cpp/lib/src/outstation/OutstationContext.cpp
@@ -312,7 +312,7 @@ void OContext::CheckForUnsolicitedNull()
     }
 }
 
-bool OContext::CheckForUnsolicited()
+void OContext::CheckForUnsolicited()
 {
     if (this->shouldCheckForUnsolicited && this->CanTransmit() && this->state->IsIdle() && this->params.allowUnsolicited)
     {
@@ -336,8 +336,6 @@ bool OContext::CheckForUnsolicited()
                 this->RestartUnsolConfirmTimer();
                 this->state = &StateUnsolicitedConfirmWait::Inst();
                 this->BeginUnsolTx(response);
-
-                return true;
             }
         }
     }

--- a/cpp/lib/src/outstation/OutstationContext.h
+++ b/cpp/lib/src/outstation/OutstationContext.h
@@ -81,7 +81,7 @@ public:
 
     /// --- Other public members ----
 
-    void CheckForTaskStart();
+    void HandleNewEvents();
 
     IUpdateHandler& GetUpdateHandler();    
 
@@ -120,17 +120,25 @@ private:
 
     void BeginRetransmitLastResponse(uint16_t destination);
 
+    void BeginRetransmitLastUnsolicitedResponse();
+
     void BeginUnsolTx(APDUResponse& response);
 
     void BeginTx(uint16_t destination, const ser4cpp::rseq_t& message);
 
+    void CheckForTaskStart();
+
     void CheckForDeferredRequest();
+
+    void CheckForUnsolicitedNull();
+
+    bool CheckForUnsolicited();
 
     bool ProcessDeferredRequest(const ParsedRequest& request);
 
-    void RestartConfirmTimer();
+    void RestartSolConfirmTimer();
 
-    void CheckForUnsolicited();
+    void RestartUnsolConfirmTimer();
 
     bool CanTransmit() const;
 
@@ -199,6 +207,8 @@ private:
     // ------ Dynamic state related to solicited and unsolicited modes ------
     OutstationSolState sol;
     OutstationUnsolState unsol;
+    NumRetries unsolRetries;
+    bool shouldCheckForUnsolicited;
     OutstationState* state = &StateIdle::Inst();
 
     // ------ Dynamic state related to broadcast messages ------

--- a/cpp/lib/src/outstation/OutstationContext.h
+++ b/cpp/lib/src/outstation/OutstationContext.h
@@ -132,7 +132,7 @@ private:
 
     void CheckForUnsolicitedNull();
 
-    bool CheckForUnsolicited();
+    void CheckForUnsolicited();
 
     bool ProcessDeferredRequest(const ParsedRequest& request);
 

--- a/cpp/lib/src/outstation/OutstationStack.cpp
+++ b/cpp/lib/src/outstation/OutstationStack.cpp
@@ -93,7 +93,7 @@ void OutstationStack::Apply(const Updates& updates)
 
     auto task = [self = this->shared_from_this(), updates]() {
         updates.Apply(self->ocontext.GetUpdateHandler());
-        self->ocontext.CheckForTaskStart(); // force the outstation to check for updates
+        self->ocontext.HandleNewEvents(); // force the outstation to check for updates
     };
 
     this->executor->post(task);

--- a/cpp/lib/src/outstation/OutstationStates.cpp
+++ b/cpp/lib/src/outstation/OutstationStates.cpp
@@ -192,7 +192,7 @@ OutstationState& StateUnsolicitedConfirmWait::OnConfirmTimeout(OContext& ctx)
     if (ctx.unsol.completedNull)
     {
         auto shouldRetry = ctx.unsolRetries.Retry();
-        if(shouldRetry)
+        if(shouldRetry && !ctx.deferred.IsSet())
         {
             ctx.RestartUnsolConfirmTimer();
             ctx.BeginRetransmitLastUnsolicitedResponse();

--- a/cpp/tests/unit/utils/OutstationTestObject.h
+++ b/cpp/tests/unit/utils/OutstationTestObject.h
@@ -62,7 +62,7 @@ public:
     {
         // auto& handler = context.GetUpdateHandler();
         apply(context.GetUpdateHandler());
-        context.CheckForTaskStart();
+        context.HandleNewEvents();
     }
 
 private:

--- a/dotnet/CLRAdapter/src/Conversions.cpp
+++ b/dotnet/CLRAdapter/src/Conversions.cpp
@@ -398,8 +398,8 @@ namespace DNP3
             params.selectTimeout = ConvertTimespan(config->selectTimeout);
             params.solConfirmTimeout = ConvertTimespan(config->solicitedConfirmTimeout);
             params.unsolClassMask = ConvertClassField(config->unsolClassMask);
-            params.unsolConfirmTimeout = ConvertTimespan(config->unsolicitedConfirmTimeout);
-            params.unsolRetryTimeout = ConvertTimespan(config->unsolicitedRetryPeriod);
+            params.unsolConfirmTimeout = ConvertTimespan(config->unsolConfirmTimeout);
+            params.numUnsolRetries = ConvertNumRetries(config->numUnsolRetries);
             params.respondToAnyMaster = config->respondToAnyMaster;
 
             return params;
@@ -442,6 +442,18 @@ namespace DNP3
             return cfg;
         }
 
+        opendnp3::NumRetries Conversions::ConvertNumRetries(NumRetries ^ numRetries)
+        {
+            if (numRetries->isInfinite)
+            {
+                return opendnp3::NumRetries::Infinite();
+            }
+            else
+            {
+                return opendnp3::NumRetries::Fixed(numRetries->maxNumRetries);
+            }
+        }
+
         opendnp3::DatabaseConfig Conversions::Convert(DatabaseTemplate ^ lhs)
         {
             opendnp3::DatabaseConfig config;
@@ -476,7 +488,7 @@ namespace DNP3
         }
 
         array<System::Byte> ^ Conversions::Convert(const opendnp3::Buffer& bytes)
-        {           
+        {
             array<System::Byte> ^ ret = gcnew array<System::Byte>(static_cast<int>(bytes.length));
 
             for (int i = 0; i < ret->Length; ++i)

--- a/dotnet/CLRAdapter/src/Conversions.h
+++ b/dotnet/CLRAdapter/src/Conversions.h
@@ -147,23 +147,24 @@ namespace Automatak
 				static opendnp3::AnalogCommandEvent ConvertMeas(AnalogCommandEvent^ meas);
 
 				static LinkHeader^ Conversions::Convert(const opendnp3::LinkHeaderFields& fields);
-				static opendnp3::IPEndpoint Convert(IPEndpoint^ endpoint);				
+				static opendnp3::IPEndpoint Convert(IPEndpoint^ endpoint);
 
 				static X509Info^ Convert(const opendnp3::X509Info& info);
 
 				//Convert the configuration types
 				static opendnp3::SerialSettings ConvertSerialSettings(SerialSettings^ settings);
-				static opendnp3::EventBufferConfig ConvertConfig(EventBufferConfig^ cm);				
+				static opendnp3::EventBufferConfig ConvertConfig(EventBufferConfig^ cm);
 
 				static opendnp3::LinkConfig ConvertConfig(LinkConfig^ config);
 				static opendnp3::MasterParams ConvertConfig(MasterConfig^ config);
 				static opendnp3::OutstationConfig ConvertConfig(OutstationConfig^ config);
 				static opendnp3::OutstationParams ConvertConfig(OutstationParams^ config);
 				static opendnp3::MasterStackConfig ConvertConfig(MasterStackConfig^ config);
-				static opendnp3::OutstationStackConfig ConvertConfig(OutstationStackConfig^ config);				
+				static opendnp3::OutstationStackConfig ConvertConfig(OutstationStackConfig^ config);
+                static opendnp3::NumRetries ConvertNumRetries(NumRetries^ numRetries);
 
-				static opendnp3::PointClass Convert(PointClass clazz);				
-				static array<System::Byte>^ Convert(const opendnp3::Buffer& bytes);				
+				static opendnp3::PointClass Convert(PointClass clazz);
+				static array<System::Byte>^ Convert(const opendnp3::Buffer& bytes);
 
 				template <class Target, class Source>
 				static IndexedValue<Target>^ ConvertIndexValue(const opendnp3::Indexed<Source>& pair)

--- a/dotnet/CLRInterface/CMakeLists.txt
+++ b/dotnet/CLRInterface/CMakeLists.txt
@@ -46,6 +46,7 @@ src/LinkHeader.cs
 src/LogLevels.cs
 src/MeasurementTypes.cs
 src/NamespaceDoc.cs
+src/NumRetries.cs
 src/PrintingSOEHandler.cs
 src/RestartResultType.cs
 src/SimpleCommandHandler.cs

--- a/dotnet/CLRInterface/src/NumRetries.cs
+++ b/dotnet/CLRInterface/src/NumRetries.cs
@@ -1,0 +1,50 @@
+// Copyright 2013-2019 Automatak, LLC
+//
+// Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+// LLC (www.automatak.com) under one or more contributor license agreements. 
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership. Green Energy Corp and Automatak LLC license
+// this file to you under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License. You may obtain
+// a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Automatak.DNP3.Interface
+{
+    /// <summary>
+    /// An address-port pair
+    /// </summary>
+    public class NumRetries
+    {
+        public static NumRetries Fixed(int maxNumRetries)
+        {
+            return new NumRetries(maxNumRetries, false);
+        }
+
+        public static NumRetries Infinite()
+        {
+            return new NumRetries(0, true);
+        }
+
+        private NumRetries(int maxNumRetries, bool isInfinite)
+        {
+            this.maxNumRetries = maxNumRetries;
+            this.isInfinite = isInfinite;
+        }
+
+        public readonly int maxNumRetries;
+        public readonly bool isInfinite;
+    }
+}

--- a/dotnet/CLRInterface/src/config/OutstationParams.cs
+++ b/dotnet/CLRInterface/src/config/OutstationParams.cs
@@ -49,12 +49,12 @@ namespace Automatak.DNP3.Interface
         /// <summary>
         /// Timeout for unsolicited confirms
         /// </summary>
-        public TimeSpan unsolicitedConfirmTimeout = TimeSpan.FromSeconds(5);
+        public TimeSpan unsolConfirmTimeout = TimeSpan.FromSeconds(5);
 
         /// <summary>
-        /// Retry period for unsolicited failures
+        /// Number of unsolicited response retries
         /// </summary>
-        public TimeSpan unsolicitedRetryPeriod = TimeSpan.FromSeconds(5);
+        public NumRetries numUnsolRetries = NumRetries.Infinite();
 
         /// <summary>
         /// The maximum fragment size the outstation will use for fragments it sends
@@ -69,7 +69,7 @@ namespace Automatak.DNP3.Interface
         /// <summary>
         /// Global enabled / disable for unsolicted messages. If false, the NULL unsolicited message is not even sent
         /// </summary>
-        public bool allowUnsolicited = false;
+        public bool allowUnsolicited = true;
 
         /// <summary>
         /// Specifies which types are allowed in Class0 repsones. Defaults to all types.

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -182,6 +182,8 @@ set(all_sources
 	./cpp/jni/JNIMasterStackConfig.h
 	./cpp/jni/JNIMasterTaskType.cpp
 	./cpp/jni/JNIMasterTaskType.h
+	./cpp/jni/JNINumRetries.cpp
+	./cpp/jni/JNINumRetries.h
 	./cpp/jni/JNIOperateType.cpp
 	./cpp/jni/JNIOperateType.h
 	./cpp/jni/JNIOutstationApplication.cpp

--- a/java/bindings/src/main/java/com/automatak/dnp3/NumRetries.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/NumRetries.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2019 Automatak, LLC
+ *
+ * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+ * LLC (www.automatak.com) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Green Energy Corp and Automatak LLC license
+ * this file to you under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.automatak.dnp3;
+
+/**
+ * Number of unsolicited response retries
+ */
+public class NumRetries {
+
+    /**
+     * Create a fixed number of maximum unsolicited response retries
+     * @param maxNumRetries Maximum number of retries
+     */
+    static public NumRetries Fixed(int maxNumRetries)
+    {
+        return new NumRetries(maxNumRetries, false);
+    }
+
+    /**
+     * Create an infinite number of unsolicited response retries
+     */
+    static public NumRetries Infinite()
+    {
+        return new NumRetries(0, false);
+    }
+
+    private NumRetries(int maxNumRetries, boolean isInfinite)
+    {
+        this.maxNumRetries = maxNumRetries;
+        this.isInfinite = isInfinite;
+    }
+
+    public final int maxNumRetries;
+    public final boolean isInfinite;
+}

--- a/java/bindings/src/main/java/com/automatak/dnp3/OutstationConfig.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/OutstationConfig.java
@@ -50,9 +50,14 @@ public class OutstationConfig {
     public Duration solConfirmTimeout = Duration.ofSeconds(5);
 
     /**
-     * Timeout for unsolicited retries
+     * Timeout for unsolicited confirms
      */
-    public Duration unsolRetryTimeout = Duration.ofSeconds(5);
+    public Duration unsolConfirmTimeout = Duration.ofSeconds(5);
+
+    /**
+     * Number of unsolicited response retries
+     */
+    public NumRetries numUnsolRetries = NumRetries.Infinite();
 
     /**
      * The maximum fragment size the outstation will use for fragments it sends
@@ -67,5 +72,5 @@ public class OutstationConfig {
     /**
      * Global enabled / disable for unsolicited messages. If false, the NULL unsolicited message is not even sent
      */
-    public boolean allowUnsolicited = false;
+    public boolean allowUnsolicited = true;
 }

--- a/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/StackPair.java
+++ b/java/bindings/src/test/java/com/automatak/dnp3/impl/mocks/StackPair.java
@@ -46,7 +46,7 @@ public class StackPair {
                 DatabaseConfig.allValues(numPointsPerType), EventBufferConfig.allTypes(eventBufferSize)
         );
 
-        config.outstationConfig.unsolRetryTimeout = Duration.ofSeconds(1);
+        config.outstationConfig.unsolConfirmTimeout = Duration.ofSeconds(1);
 
         config.outstationConfig.allowUnsolicited = true;
 

--- a/java/codegen/src/main/scala/com/automatak/dnp3/codegen/Classes.scala
+++ b/java/codegen/src/main/scala/com/automatak/dnp3/codegen/Classes.scala
@@ -147,7 +147,8 @@ object Classes {
     ClassConfig(classOf[LinkLayerStatistics], Set(Features.Constructors)),
     ClassConfig(classOf[TransportStatistics], Set(Features.Constructors)),
     ClassConfig(classOf[StackStatistics], Set(Features.Constructors)),
-    ClassConfig(classOf[IPEndpoint], Set(Features.Fields))
+    ClassConfig(classOf[IPEndpoint], Set(Features.Fields)),
+    ClassConfig(classOf[NumRetries], Set(Features.Fields))
   )
 
 

--- a/java/cpp/adapters/ConfigReader.cpp
+++ b/java/cpp/adapters/ConfigReader.cpp
@@ -169,7 +169,8 @@ opendnp3::OutstationParams ConfigReader::ConvertOutstationConfig(JNIEnv* env, jo
     config.maxControlsPerRequest = static_cast<uint8_t>(cfg.getmaxControlsPerRequest(env, jconfig));
     config.selectTimeout = ConvertDuration(env, cfg.getselectTimeout(env, jconfig));
     config.solConfirmTimeout = ConvertDuration(env, cfg.getsolConfirmTimeout(env, jconfig));
-    config.unsolRetryTimeout = ConvertDuration(env, cfg.getunsolRetryTimeout(env, jconfig));
+    config.unsolConfirmTimeout = ConvertDuration(env, cfg.getunsolConfirmTimeout(env, jconfig));
+    config.numUnsolRetries = ConvertNumRetries(env, cfg.getnumUnsolRetries(env, jconfig));
     config.maxTxFragSize = cfg.getmaxTxFragSize(env, jconfig);
     config.maxRxFragSize = cfg.getmaxRxFragSize(env, jconfig);
     config.allowUnsolicited = !(cfg.getallowUnsolicited(env, jconfig) == 0u);
@@ -177,11 +178,21 @@ opendnp3::OutstationParams ConfigReader::ConvertOutstationConfig(JNIEnv* env, jo
     return config;
 }
 
-
-
 opendnp3::TimeDuration ConfigReader::ConvertDuration(JNIEnv* env, jobject jduration)
 {
     return opendnp3::TimeDuration::Milliseconds(jni::JCache::Duration.toMillis(env, jduration));
+}
+
+opendnp3::NumRetries ConfigReader::ConvertNumRetries(JNIEnv* env, jobject jnumretries)
+{
+    if(jni::JCache::NumRetries.getisInfinite(env, jnumretries))
+    {
+        return opendnp3::NumRetries::Infinite();
+    }
+    else
+    {
+        return opendnp3::NumRetries::Fixed(jni::JCache::NumRetries.getmaxNumRetries(env, jnumretries));
+    }
 }
 
 template<class Info, class ConfigType, class ConfigCache, class StaticVariation, class EventVariation>

--- a/java/cpp/adapters/ConfigReader.h
+++ b/java/cpp/adapters/ConfigReader.h
@@ -42,6 +42,7 @@ private:
     static opendnp3::OutstationParams ConvertOutstationConfig(JNIEnv* env, jobject jconfig);
     static opendnp3::DatabaseConfig ConvertDatavaseConfig(JNIEnv* env, jobject jdb);
     static opendnp3::TimeDuration ConvertDuration(JNIEnv* env, jobject jduration);
+    static opendnp3::NumRetries ConvertNumRetries(JNIEnv* env, jobject jnumretries);
     
 
     static opendnp3::BinaryConfig ConvertBinaryConfig(JNIEnv* env, jobject jconfig);

--- a/java/cpp/jni/JCache.cpp
+++ b/java/cpp/jni/JCache.cpp
@@ -104,6 +104,7 @@ namespace jni
     cache::MasterConfig JCache::MasterConfig;
     cache::MasterStackConfig JCache::MasterStackConfig;
     cache::MasterTaskType JCache::MasterTaskType;
+    cache::NumRetries JCache::NumRetries;
     cache::OperateType JCache::OperateType;
     cache::OutstationApplication JCache::OutstationApplication;
     cache::OutstationConfig JCache::OutstationConfig;
@@ -205,6 +206,7 @@ namespace jni
         && MasterConfig.init(env)
         && MasterStackConfig.init(env)
         && MasterTaskType.init(env)
+        && NumRetries.init(env)
         && OperateType.init(env)
         && OutstationApplication.init(env)
         && OutstationConfig.init(env)
@@ -308,6 +310,7 @@ namespace jni
         MasterConfig.cleanup(env);
         MasterStackConfig.cleanup(env);
         MasterTaskType.cleanup(env);
+        NumRetries.cleanup(env);
         OperateType.cleanup(env);
         OutstationApplication.cleanup(env);
         OutstationConfig.cleanup(env);

--- a/java/cpp/jni/JCache.h
+++ b/java/cpp/jni/JCache.h
@@ -105,6 +105,7 @@
 #include "JNIMasterConfig.h"
 #include "JNIMasterStackConfig.h"
 #include "JNIMasterTaskType.h"
+#include "JNINumRetries.h"
 #include "JNIOperateType.h"
 #include "JNIOutstationApplication.h"
 #include "JNIOutstationConfig.h"
@@ -211,6 +212,7 @@ namespace jni
         static cache::MasterConfig MasterConfig;
         static cache::MasterStackConfig MasterStackConfig;
         static cache::MasterTaskType MasterTaskType;
+        static cache::NumRetries NumRetries;
         static cache::OperateType OperateType;
         static cache::OutstationApplication OutstationApplication;
         static cache::OutstationConfig OutstationConfig;

--- a/java/cpp/jni/JNINumRetries.cpp
+++ b/java/cpp/jni/JNINumRetries.cpp
@@ -1,0 +1,69 @@
+//
+//  _   _         ______    _ _ _   _             _ _ _
+// | \ | |       |  ____|  | (_) | (_)           | | | |
+// |  \| | ___   | |__   __| |_| |_ _ _ __   __ _| | | |
+// | . ` |/ _ \  |  __| / _` | | __| | '_ \ / _` | | | |
+// | |\  | (_) | | |___| (_| | | |_| | | | | (_| |_|_|_|
+// |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
+//                                           __/ |
+//                                          |___/
+// 
+// This file is auto-generated. Do not edit manually
+// 
+// Copyright 2013-2019 Automatak, LLC
+// 
+// Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+// LLC (www.automatak.com) under one or more contributor license agreements.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership. Green Energy Corp and Automatak LLC license
+// this file to you under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License. You may obtain
+// a copy of the License at:
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "JNINumRetries.h"
+
+namespace jni
+{
+    namespace cache
+    {
+        bool NumRetries::init(JNIEnv* env)
+        {
+            auto clazzTemp = env->FindClass("Lcom/automatak/dnp3/NumRetries;");
+            if(!clazzTemp) return false;
+            this->clazz = (jclass) env->NewGlobalRef(clazzTemp);
+            env->DeleteLocalRef(clazzTemp);
+
+            this->maxNumRetriesField = env->GetFieldID(this->clazz, "maxNumRetries", "I");
+            if(!this->maxNumRetriesField) return false;
+
+            this->isInfiniteField = env->GetFieldID(this->clazz, "isInfinite", "Z");
+            if(!this->isInfiniteField) return false;
+
+            return true;
+        }
+
+        void NumRetries::cleanup(JNIEnv* env)
+        {
+            env->DeleteGlobalRef(this->clazz);
+        }
+
+        jboolean NumRetries::getisInfinite(JNIEnv* env, jobject instance)
+        {
+            return env->GetBooleanField(instance, this->isInfiniteField);
+        }
+
+        jint NumRetries::getmaxNumRetries(JNIEnv* env, jobject instance)
+        {
+            return env->GetIntField(instance, this->maxNumRetriesField);
+        }
+    }
+}

--- a/java/cpp/jni/JNINumRetries.h
+++ b/java/cpp/jni/JNINumRetries.h
@@ -29,8 +29,8 @@
 // limitations under the License.
 //
 
-#ifndef OPENDNP3JAVA_JNIOUTSTATIONCONFIG_H
-#define OPENDNP3JAVA_JNIOUTSTATIONCONFIG_H
+#ifndef OPENDNP3JAVA_JNINUMRETRIES_H
+#define OPENDNP3JAVA_JNINUMRETRIES_H
 
 #include <jni.h>
 
@@ -42,7 +42,7 @@ namespace jni
 
     namespace cache
     {
-        class OutstationConfig
+        class NumRetries
         {
             friend struct jni::JCache;
 
@@ -52,30 +52,16 @@ namespace jni
             public:
 
             // field getter methods
-            jboolean getallowUnsolicited(JNIEnv* env, jobject instance);
-            LocalRef<jobject> getindexMode(JNIEnv* env, jobject instance);
-            jshort getmaxControlsPerRequest(JNIEnv* env, jobject instance);
-            jint getmaxRxFragSize(JNIEnv* env, jobject instance);
-            jint getmaxTxFragSize(JNIEnv* env, jobject instance);
-            LocalRef<jobject> getnumUnsolRetries(JNIEnv* env, jobject instance);
-            LocalRef<jobject> getselectTimeout(JNIEnv* env, jobject instance);
-            LocalRef<jobject> getsolConfirmTimeout(JNIEnv* env, jobject instance);
-            LocalRef<jobject> getunsolConfirmTimeout(JNIEnv* env, jobject instance);
+            jboolean getisInfinite(JNIEnv* env, jobject instance);
+            jint getmaxNumRetries(JNIEnv* env, jobject instance);
 
             private:
 
             jclass clazz = nullptr;
 
             // field ids
-            jfieldID indexModeField = nullptr;
-            jfieldID maxControlsPerRequestField = nullptr;
-            jfieldID selectTimeoutField = nullptr;
-            jfieldID solConfirmTimeoutField = nullptr;
-            jfieldID unsolConfirmTimeoutField = nullptr;
-            jfieldID numUnsolRetriesField = nullptr;
-            jfieldID maxTxFragSizeField = nullptr;
-            jfieldID maxRxFragSizeField = nullptr;
-            jfieldID allowUnsolicitedField = nullptr;
+            jfieldID maxNumRetriesField = nullptr;
+            jfieldID isInfiniteField = nullptr;
         };
     }
 }

--- a/java/cpp/jni/JNIOutstationConfig.cpp
+++ b/java/cpp/jni/JNIOutstationConfig.cpp
@@ -54,8 +54,11 @@ namespace jni
             this->solConfirmTimeoutField = env->GetFieldID(this->clazz, "solConfirmTimeout", "Ljava/time/Duration;");
             if(!this->solConfirmTimeoutField) return false;
 
-            this->unsolRetryTimeoutField = env->GetFieldID(this->clazz, "unsolRetryTimeout", "Ljava/time/Duration;");
-            if(!this->unsolRetryTimeoutField) return false;
+            this->unsolConfirmTimeoutField = env->GetFieldID(this->clazz, "unsolConfirmTimeout", "Ljava/time/Duration;");
+            if(!this->unsolConfirmTimeoutField) return false;
+
+            this->numUnsolRetriesField = env->GetFieldID(this->clazz, "numUnsolRetries", "Lcom/automatak/dnp3/NumRetries;");
+            if(!this->numUnsolRetriesField) return false;
 
             this->maxTxFragSizeField = env->GetFieldID(this->clazz, "maxTxFragSize", "I");
             if(!this->maxTxFragSizeField) return false;
@@ -99,6 +102,11 @@ namespace jni
             return env->GetIntField(instance, this->maxTxFragSizeField);
         }
 
+        LocalRef<jobject> OutstationConfig::getnumUnsolRetries(JNIEnv* env, jobject instance)
+        {
+            return LocalRef<jobject>(env, env->GetObjectField(instance, this->numUnsolRetriesField));
+        }
+
         LocalRef<jobject> OutstationConfig::getselectTimeout(JNIEnv* env, jobject instance)
         {
             return LocalRef<jobject>(env, env->GetObjectField(instance, this->selectTimeoutField));
@@ -109,9 +117,9 @@ namespace jni
             return LocalRef<jobject>(env, env->GetObjectField(instance, this->solConfirmTimeoutField));
         }
 
-        LocalRef<jobject> OutstationConfig::getunsolRetryTimeout(JNIEnv* env, jobject instance)
+        LocalRef<jobject> OutstationConfig::getunsolConfirmTimeout(JNIEnv* env, jobject instance)
         {
-            return LocalRef<jobject>(env, env->GetObjectField(instance, this->unsolRetryTimeoutField));
+            return LocalRef<jobject>(env, env->GetObjectField(instance, this->unsolConfirmTimeoutField));
         }
     }
 }


### PR DESCRIPTION
Closes #322 and #321.

- Add configuration number of unsolicited response retries
- The `NumRetries` has two static member functions to create a fixed number of maximum retries or an infinite number of retries.
- The unused `unsolRetryTimeout` was removed.
- Updated the Java and C# bindings accordingly.
  - The default value for `allowUnsolicited ` is now `true`, to better reflect the C++ API.
  - In the C# bindings, renamed `unsolicitedConfirmTimeout` for `unsolConfirmTimeout` to better reflect the C++ API
- A bug was also fixed, where the `solConfirmTimeout` was never used. The `unsolConfirmTimeout` was used for both solicited and unsolicited responses. Now, the appropriate values are used. A test case was also added for this bug.