### PR TITLE
Fix issue #350.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,6 @@
+### 2.3.2 ###
+* :beetle: Fix C# exception on time conversion upon restart command not supported. See issue [#350](https://github.com/dnp3/opendnp3/issues/350).
+
 ### 2.3.1 ###
 * :beetle: Fix final case for issue [#216](https://github.com/dnp3/opendnp3/issues/216#issuecomment-500637263). See [PR #310](https://github.com/dnp3/opendnp3/pull/310).
 * :beetle: Add missing include for usage with `ASIO_DYN_LINK` (see [PR #311](https://github.com/dnp3/opendnp3/pull/311))

--- a/cpp/libs/src/opendnp3/master/RestartOperationTask.h
+++ b/cpp/libs/src/opendnp3/master/RestartOperationTask.h
@@ -72,7 +72,7 @@ private:
 
     const FunctionCode function;
     RestartOperationCallbackT callback;
-    openpal::TimeDuration duration = openpal::TimeDuration::Min();
+    openpal::TimeDuration duration = openpal::TimeDuration::Zero();
 
     IMasterTask::ResponseResult ProcessResponse(const opendnp3::APDUResponseHeader& header,
                                                 const openpal::RSlice& objects) override;


### PR DESCRIPTION
Fix issue #350.

**Cause**: The `RestartOperationTask` duration was initialized to `openpal::TimeDuration::Min()`, which is the minimal value of an Int64. When the restart operation was denied, this value was sent to the C# adapter that was trying to produce a `System::TimeSpan` with it, causing an overflow catched by an exception.

**Fix**: The `RestartOperationTask` duration is now initialized with `openpal::TimeDuration::Zero()`, so it can be represented in C# (and it makes more sense). I've searched for other uses of `openpal::TimeDuration::Min()` and none can create this behaviour. The codebase generally just use the default constructor of `openpal::TimeDuration` which initialize itself to zero.

**3.0 branch**: This does not affect the 3.0 branch. The TimeDuration was modernized and in the process, `RestartOperationTask` uses a default constructor that sets the value to zero.