### PR TITLE
Conformance fixes [develop]

### DIFF
--- a/cpp/lib/src/link/PriLinkLayerStates.cpp
+++ b/cpp/lib/src/link/PriLinkLayerStates.cpp
@@ -265,6 +265,7 @@ PriStateBase& PLLS_ConfDataWait::OnNack(LinkContext& ctx, bool rxBuffFull)
 
 PriStateBase& PLLS_ConfDataWait::Failure(LinkContext& ctx)
 {
+    ctx.isRemoteReset = false;
     ctx.CancelTimer();
     ctx.CompleteSendOperation();
     return PLLS_Idle::Instance();
@@ -284,8 +285,7 @@ PriStateBase& PLLS_ConfDataWait::OnTimeout(LinkContext& ctx)
 
     SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "Confirmed data final timeout, no retries remain");
     ctx.listener->OnStateChange(LinkStatus::UNRESET);
-    ctx.CompleteSendOperation();
-    return PLLS_Idle::Instance();
+    return Failure(ctx);
 }
 
 ////////////////////////////////////////////////////////

--- a/cpp/lib/src/outstation/ControlState.h
+++ b/cpp/lib/src/outstation/ControlState.h
@@ -43,7 +43,7 @@ public:
                                     const TimeDuration& timeout,
                                     const ser4cpp::rseq_t& objects) const
     {
-        if (expectedSeq.Equals(seq))
+        if (selected && expectedSeq.Equals(seq))
         {
             if (selectTime <= now)
             {
@@ -77,13 +77,20 @@ public:
 
     void Select(const AppSeqNum& currentSeqN, const Timestamp& now, const ser4cpp::rseq_t& objects)
     {
+        selected = true;
         selectTime = now;
         expectedSeq = currentSeqN.Next();
         digest = CRC::CalcCrc(objects);
         length = objects.length();
     }
 
+    void Unselect()
+    {
+        selected = false;
+    }
+
 private:
+    bool selected = false;
     AppSeqNum expectedSeq;
     Timestamp selectTime;
     uint16_t digest = 0;

--- a/cpp/lib/src/outstation/OutstationContext.cpp
+++ b/cpp/lib/src/outstation/OutstationContext.cpp
@@ -775,6 +775,10 @@ IINField OContext::HandleOperate(const ser4cpp::rseq_t& objects, HeaderWriter& w
         this->shouldCheckForUnsolicited = true;
         return (result == ParseResult::OK) ? handler.Errors() : IINFromParseResult(result);
     }
+    else
+    {
+        this->control.Unselect();
+    }
 
     return this->HandleCommandWithConstant(objects, writer, result);
 }

--- a/cpp/tests/unit/TestOutstationCommandResponses.cpp
+++ b/cpp/tests/unit/TestOutstationCommandResponses.cpp
@@ -148,12 +148,21 @@ TEST_CASE(SUITE("SelectOperateGapInSequenceNumber"))
     t.SendToOutstation("C0 03 0C 01 17 01 03 01 01 01 00 00 00 01 00 00 00 00");
     REQUIRE(t.lower->PopWriteAsHex()
             == "C0 81 80 00 0C 01 17 01 03 01 01 01 00 00 00 01 00 00 00 00"); // 0x00 status == CommandStatus::SUCCESS
+    REQUIRE(1 == t.cmdHandler->NumInvocations());
     t.OnTxReady();
 
     // operate
     t.SendToOutstation("C2 04 0C 01 17 01 03 01 01 01 00 00 00 01 00 00 00 00");
     REQUIRE(t.lower->PopWriteAsHex()
             == "C2 81 80 00 0C 01 17 01 03 01 01 01 00 00 00 01 00 00 00 02"); // 0x02 no select
+    REQUIRE(1 == t.cmdHandler->NumInvocations());
+    t.OnTxReady();
+
+    // Proper operate should not be accepted
+    t.SendToOutstation("C1 04 0C 01 17 01 03 01 01 01 00 00 00 01 00 00 00 00");
+    REQUIRE(t.lower->PopWriteAsHex()
+            == "C1 81 80 00 0C 01 17 01 03 01 01 01 00 00 00 01 00 00 00 02"); // 0x02 no select
+    REQUIRE(1 == t.cmdHandler->NumInvocations());
     t.OnTxReady();
 }
 


### PR DESCRIPTION
Fix two conformance issues that were found. These issues are not severe and will be merged in the 2.x branch shortly.

- When using data-link confirmations (which you should not use btw), on timeout the link was not considered unreset, meaning a subsequent request wouldn't ask for a `RESET_LINK_STATES`.
- In a Select & Operate command, when a incorrect operate was received, the master could still send a proper operate afterwards and it would invoke the command handler.