### PR TITLE
Reconnection delay

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,4 +1,5 @@
 ### 2.x ###
+* :star: Added optional reconnection delay parameter to `ChannelRetry`. When a connection is lost, this parameter is used to wait before reattempting to establish a connection. Then, the same reconnection strategy as before is used for retries. See issue [#354](https://github.com/dnp3/opendnp3/issues/354).
 * :beetle: Fix conformance issue with data-link confirmations. See PR [#359](https://github.com/dnp3/opendnp3/pull/359).
 * :beetle: Fix conformance issue select & operate behaviour. See PR [#359](https://github.com/dnp3/opendnp3/pull/359).
 * :beetle: Fix issue when compiling with MingW. See PR [#345](https://github.com/dnp3/opendnp3/pull/345).

--- a/cpp/libs/include/asiopal/ChannelRetry.h
+++ b/cpp/libs/include/asiopal/ChannelRetry.h
@@ -40,6 +40,7 @@ public:
      */
     ChannelRetry(openpal::TimeDuration minOpenRetry,
                  openpal::TimeDuration maxOpenRetry,
+                 openpal::TimeDuration reconnectDelay = openpal::TimeDuration::Zero(),
                  IOpenDelayStrategy& strategy = ExponentialBackoffStrategy::Instance());
 
     /// Return the default configuration of exponential backoff from 1 sec to 1 minute
@@ -49,6 +50,8 @@ public:
     openpal::TimeDuration minOpenRetry;
     /// maximum connection retry interval on failure
     openpal::TimeDuration maxOpenRetry;
+    /// reconnect delay (defaults to zero)
+    openpal::TimeDuration reconnectDelay;
 
     openpal::TimeDuration NextDelay(const openpal::TimeDuration& current) const
     {

--- a/cpp/libs/src/asiodnp3/SerialIOHandler.cpp
+++ b/cpp/libs/src/asiodnp3/SerialIOHandler.cpp
@@ -59,7 +59,9 @@ void SerialIOHandler::SuspendChannelAccept()
 
 void SerialIOHandler::OnChannelShutdown()
 {
-    this->BeginChannelAccept();
+    this->retrytimer.Start(this->retry.reconnectDelay, [this, self = shared_from_this()]() {
+        this->BeginChannelAccept();
+    });
 }
 
 void SerialIOHandler::TryOpen(const openpal::TimeDuration& timeout)
@@ -75,7 +77,7 @@ void SerialIOHandler::TryOpen(const openpal::TimeDuration& timeout)
 
         ++this->statistics.numOpenFail;
 
-        auto callback = [this, timeout]() { this->TryOpen(this->retry.NextDelay(timeout)); };
+        auto callback = [this, timeout, self = shared_from_this()]() { this->TryOpen(this->retry.NextDelay(timeout)); };
 
         this->retrytimer.Start(timeout, callback);
     }

--- a/cpp/libs/src/asiodnp3/TCPClientIOHandler.cpp
+++ b/cpp/libs/src/asiodnp3/TCPClientIOHandler.cpp
@@ -62,7 +62,12 @@ void TCPClientIOHandler::SuspendChannelAccept()
 
 void TCPClientIOHandler::OnChannelShutdown()
 {
-    this->BeginChannelAccept();
+    if (!client) return;
+
+    this->retrytimer.Start(this->retry.reconnectDelay, [this, self = shared_from_this()]() {
+        if (!client) return;
+        this->BeginChannelAccept();
+    });
 }
 
 bool TCPClientIOHandler::StartConnect(const openpal::TimeDuration& delay)

--- a/cpp/libs/src/asiodnp3/tls/TLSClientIOHandler.h
+++ b/cpp/libs/src/asiodnp3/tls/TLSClientIOHandler.h
@@ -64,7 +64,7 @@ protected:
     virtual void OnChannelShutdown() override;
 
 private:
-    void StartConnect(const std::shared_ptr<asiopal::TLSClient>& client, const openpal::TimeDuration& delay);
+    void StartConnect(const openpal::TimeDuration& delay);
 
     void ResetState();
 

--- a/cpp/libs/src/asiopal/ChannelRetry.cpp
+++ b/cpp/libs/src/asiopal/ChannelRetry.cpp
@@ -27,8 +27,9 @@ namespace asiopal
 
 ChannelRetry::ChannelRetry(openpal::TimeDuration minOpenRetry_,
                            openpal::TimeDuration maxOpenRetry_,
+                           openpal::TimeDuration reconnectDelay_,
                            IOpenDelayStrategy& strategy_)
-    : minOpenRetry(minOpenRetry_), maxOpenRetry(maxOpenRetry_), strategy(strategy_)
+    : minOpenRetry(minOpenRetry_), maxOpenRetry(maxOpenRetry_), reconnectDelay(reconnectDelay_), strategy(strategy_)
 {
 }
 

--- a/dotnet/CLRAdapter/src/DNP3ManagerAdapter.cpp
+++ b/dotnet/CLRAdapter/src/DNP3ManagerAdapter.cpp
@@ -216,7 +216,7 @@ namespace Automatak
 
 			asiopal::ChannelRetry DNP3ManagerAdapter::Convert(Interface::ChannelRetry^ retry)
 			{
-				return asiopal::ChannelRetry(Conversions::ConvertTimespan(retry->minRetryDelay), Conversions::ConvertTimespan(retry->maxRetryDelay));
+				return asiopal::ChannelRetry(Conversions::ConvertTimespan(retry->minRetryDelay), Conversions::ConvertTimespan(retry->maxRetryDelay), Conversions::ConvertTimespan(retry->reconnectDelay));
 			}
 		}
 	}

--- a/dotnet/CLRInterface/src/ChannelRetry.cs
+++ b/dotnet/CLRInterface/src/ChannelRetry.cs
@@ -33,10 +33,12 @@ namespace Automatak.DNP3.Interface
         /// </summary>
         /// <param name="minRetryDelay">the minimum (first) retry delay</param>
         /// <param name="maxRetryDelay">the maximum delay</param>
-        public ChannelRetry(TimeSpan minRetryDelay, TimeSpan maxRetryDelay)
+        /// <param name="reconnectDelay">delay between reconnections when a read/write fails</param>
+        public ChannelRetry(TimeSpan minRetryDelay, TimeSpan maxRetryDelay, TimeSpan reconnectDelay)
         {
             this.minRetryDelay = minRetryDelay;
             this.maxRetryDelay = maxRetryDelay;
+            this.reconnectDelay = reconnectDelay;
         }
 
         /// <summary>
@@ -46,11 +48,12 @@ namespace Automatak.DNP3.Interface
         {
             get
             {
-                return new ChannelRetry(TimeSpan.FromSeconds(1), TimeSpan.FromMinutes(1));
+                return new ChannelRetry(TimeSpan.FromSeconds(1), TimeSpan.FromMinutes(1), TimeSpan.Zero);
             }
         }
 
         public readonly TimeSpan minRetryDelay;
         public readonly TimeSpan maxRetryDelay;
+        public readonly TimeSpan reconnectDelay;
     }
 }

--- a/dotnet/examples/master/Program.cs
+++ b/dotnet/examples/master/Program.cs
@@ -47,7 +47,7 @@ namespace DotNetMasterDemo
             var channel = mgr.AddTCPClient(
                 "client",
                 LogLevels.NORMAL | LogLevels.APP_COMMS,
-                ChannelRetry.Default,
+                new ChannelRetry(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(5)),
                 new List<IPEndpoint> { new IPEndpoint("127.0.0.1", 20000) },
                 ChannelListener.Print()
             );

--- a/java/bindings/src/main/java/com/automatak/dnp3/ChannelRetry.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/ChannelRetry.java
@@ -31,11 +31,13 @@ public class ChannelRetry
      * Construct a channel retry class
      * @param minRetryDelay minimum retry delay
      * @param maxRetryDelay maximum retry delay
+     * @param reconnectDelay delay between reconnections when a read/write fails
      */
-    public ChannelRetry(Duration minRetryDelay, Duration maxRetryDelay)
+    public ChannelRetry(Duration minRetryDelay, Duration maxRetryDelay, Duration reconnectDelay)
     {
         this.minRetryDelay = minRetryDelay;
         this.maxRetryDelay = maxRetryDelay;
+        this.reconnectDelay = reconnectDelay;
     }
 
     /// <summary>
@@ -43,9 +45,10 @@ public class ChannelRetry
     /// </summary>
     public static ChannelRetry getDefault()
     {
-        return new ChannelRetry(Duration.ofSeconds(1), Duration.ofMinutes(1));
+        return new ChannelRetry(Duration.ofSeconds(1), Duration.ofMinutes(1), Duration.ofSeconds(0));
     }
 
     public final Duration minRetryDelay;
     public final Duration maxRetryDelay;
+    public final Duration reconnectDelay;
 }

--- a/java/bindings/src/main/java/com/automatak/dnp3/impl/ManagerImpl.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/impl/ManagerImpl.java
@@ -54,7 +54,17 @@ class ManagerImpl implements DNP3Manager {
             throw new DNP3Exception("Manager has been shutdown");
         }
 
-        long ptr = get_native_channel_tcp_client(this.pointer, id, levels, retry.minRetryDelay.toMillis(), retry.maxRetryDelay.toMillis(), remotes, adapter, listener);
+        long ptr = get_native_channel_tcp_client(
+                this.pointer,
+                id,
+                levels,
+                retry.minRetryDelay.toMillis(),
+                retry.maxRetryDelay.toMillis(),
+                retry.reconnectDelay.toMillis(),
+                remotes,
+                adapter,
+                listener
+        );
 
         if(ptr == 0) {
             throw new DNP3Exception("Unable to create channel");
@@ -94,7 +104,18 @@ class ManagerImpl implements DNP3Manager {
             throw new DNP3Exception("Manager has been shutdown");
         }
 
-        long ptr = get_native_channel_tls_client(this.pointer, id, levels, retry.minRetryDelay.toMillis(), retry.maxRetryDelay.toMillis(), remotes, adapter, config, listener);
+        long ptr = get_native_channel_tls_client(
+                this.pointer,
+                id,
+                levels,
+                retry.minRetryDelay.toMillis(),
+                retry.maxRetryDelay.toMillis(),
+                retry.reconnectDelay.toMillis(),
+                remotes,
+                adapter,
+                config,
+                listener
+        );
 
         if(ptr == 0) {
             throw new DNP3Exception("Unable to create TLS client. Did you compile opendnp3 w/ TLS support?");
@@ -134,6 +155,7 @@ class ManagerImpl implements DNP3Manager {
                 levels,
                 retry.minRetryDelay.toMillis(),
                 retry.maxRetryDelay.toMillis(),
+                retry.reconnectDelay.toMillis(),
                 settings.port,
                 settings.baudRate,
                 settings.dataBits,
@@ -163,11 +185,11 @@ class ManagerImpl implements DNP3Manager {
     private native long create_native_manager(int concurrency, LogHandler handler);
     private native void shutdown_native_manager(long nativePointer);
 
-    private native long get_native_channel_tcp_client(long nativePointer, String id, int level, long minRetryMs, long maxRetryMs, List<IPEndpoint> remotes, String adapter, ChannelListener listener);
+    private native long get_native_channel_tcp_client(long nativePointer, String id, int level, long minRetryMs, long maxRetryMs, long reconnectDelayMs, List<IPEndpoint> remotes, String adapter, ChannelListener listener);
     private native long get_native_channel_tcp_server(long nativePointer, String id, int level, int acceptMode, String endpoint, int port, ChannelListener listener);
-    private native long get_native_channel_tls_client(long nativePointer, String id, int level, long minRetryMs, long maxRetryMs, List<IPEndpoint> remotes, String adapter, TLSConfig config, ChannelListener listener);
+    private native long get_native_channel_tls_client(long nativePointer, String id, int level, long minRetryMs, long maxRetryMs, long reconnectDelayMs, List<IPEndpoint> remotes, String adapter, TLSConfig config, ChannelListener listener);
     private native long get_native_channel_tls_server(long nativePointer, String id, int level, int acceptMode, String endpoint, int port, TLSConfig config, ChannelListener listener);
-    private native long get_native_channel_serial(long nativePointer, String id, int level, long minRetryMs, long maxRetryMs, String port, int baudRate, int dataBits, int parity, int stopBits, int flowControl, ChannelListener listener);
+    private native long get_native_channel_serial(long nativePointer, String id, int level, long minRetryMs, long maxRetryMs, long reconnectDelayMs, String port, int baudRate, int dataBits, int parity, int stopBits, int flowControl, ChannelListener listener);
 
 
 }

--- a/java/cpp/com_automatak_dnp3_impl_ManagerImpl.cpp
+++ b/java/cpp/com_automatak_dnp3_impl_ManagerImpl.cpp
@@ -73,6 +73,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
                                                                                                    jint jlevels,
                                                                                                    jlong jminRetry,
                                                                                                    jlong jmaxRetry,
+                                                                                                   jlong jreconnectDelay,
                                                                                                    jobject jremotes,
                                                                                                    jstring jadapter,
                                                                                                    jobject jlistener)
@@ -81,7 +82,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
 
     CString id(env, jid);
     CString adapter(env, jadapter);
-    ChannelRetry retry(TimeDuration::Milliseconds(jminRetry), TimeDuration::Milliseconds(jmaxRetry));
+    ChannelRetry retry(TimeDuration::Milliseconds(jminRetry), TimeDuration::Milliseconds(jmaxRetry), TimeDuration::Milliseconds(jreconnectDelay));
     auto listener = jlistener != nullptr ? std::make_shared<ChannelListenerAdapter>(jlistener) : nullptr;
 
     // Convert endpoints
@@ -130,6 +131,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
                                                                                                    jint jlevels,
                                                                                                    jlong jminRetry,
                                                                                                    jlong jmaxRetry,
+                                                                                                   jlong jreconnectDelay,
                                                                                                    jobject jremotes,
                                                                                                    jstring jadapter,
                                                                                                    jobject jtlsconfig,
@@ -139,7 +141,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
 
     CString id(env, jid);
     CString adapter(env, jadapter);
-    ChannelRetry retry(TimeDuration::Milliseconds(jminRetry), TimeDuration::Milliseconds(jmaxRetry));
+    ChannelRetry retry(TimeDuration::Milliseconds(jminRetry), TimeDuration::Milliseconds(jmaxRetry), TimeDuration::Milliseconds(jreconnectDelay));
     auto tlsconf = ConvertTLSConfig(env, jtlsconfig);
     auto listener = jlistener != nullptr ? std::make_shared<ChannelListenerAdapter>(jlistener) : nullptr;
 
@@ -196,6 +198,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
                                                                                               jint jlevels,
                                                                                               jlong jminRetry,
                                                                                               jlong jmaxRetry,
+                                                                                              jlong jreconnectDelay,
                                                                                               jstring jsdevice,
                                                                                               jint jbaudRate,
                                                                                               jint jdatabits,
@@ -207,7 +210,7 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
     const auto manager = (DNP3Manager*)native;
 
     CString id(env, jid);
-    ChannelRetry retry(TimeDuration::Milliseconds(jminRetry), TimeDuration::Milliseconds(jmaxRetry));
+    ChannelRetry retry(TimeDuration::Milliseconds(jminRetry), TimeDuration::Milliseconds(jmaxRetry), TimeDuration::Milliseconds(jreconnectDelay));
     CString sdevice(env, jsdevice);
 
     asiopal::SerialSettings settings;

--- a/java/cpp/com_automatak_dnp3_impl_ManagerImpl.h
+++ b/java/cpp/com_automatak_dnp3_impl_ManagerImpl.h
@@ -26,10 +26,10 @@ JNIEXPORT void JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_shutdown_1native
 /*
  * Class:     com_automatak_dnp3_impl_ManagerImpl
  * Method:    get_native_channel_tcp_client
- * Signature: (JLjava/lang/String;IJJLjava/util/List;Ljava/lang/String;Lcom/automatak/dnp3/ChannelListener;)J
+ * Signature: (JLjava/lang/String;IJJJLjava/util/List;Ljava/lang/String;Lcom/automatak/dnp3/ChannelListener;)J
  */
 JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1channel_1tcp_1client
-  (JNIEnv *, jobject, jlong, jstring, jint, jlong, jlong, jobject, jstring, jobject);
+  (JNIEnv *, jobject, jlong, jstring, jint, jlong, jlong, jlong, jobject, jstring, jobject);
 
 /*
  * Class:     com_automatak_dnp3_impl_ManagerImpl
@@ -42,10 +42,10 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
 /*
  * Class:     com_automatak_dnp3_impl_ManagerImpl
  * Method:    get_native_channel_tls_client
- * Signature: (JLjava/lang/String;IJJLjava/util/List;Ljava/lang/String;Lcom/automatak/dnp3/TLSConfig;Lcom/automatak/dnp3/ChannelListener;)J
+ * Signature: (JLjava/lang/String;IJJJLjava/util/List;Ljava/lang/String;Lcom/automatak/dnp3/TLSConfig;Lcom/automatak/dnp3/ChannelListener;)J
  */
 JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1channel_1tls_1client
-  (JNIEnv *, jobject, jlong, jstring, jint, jlong, jlong, jobject, jstring, jobject, jobject);
+  (JNIEnv *, jobject, jlong, jstring, jint, jlong, jlong, jlong, jobject, jstring, jobject, jobject);
 
 /*
  * Class:     com_automatak_dnp3_impl_ManagerImpl
@@ -58,10 +58,10 @@ JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1ch
 /*
  * Class:     com_automatak_dnp3_impl_ManagerImpl
  * Method:    get_native_channel_serial
- * Signature: (JLjava/lang/String;IJJLjava/lang/String;IIIIILcom/automatak/dnp3/ChannelListener;)J
+ * Signature: (JLjava/lang/String;IJJJLjava/lang/String;IIIIILcom/automatak/dnp3/ChannelListener;)J
  */
 JNIEXPORT jlong JNICALL Java_com_automatak_dnp3_impl_ManagerImpl_get_1native_1channel_1serial
-  (JNIEnv *, jobject, jlong, jstring, jint, jlong, jlong, jstring, jint, jint, jint, jint, jint, jobject);
+  (JNIEnv *, jobject, jlong, jstring, jint, jlong, jlong, jlong, jstring, jint, jint, jint, jint, jint, jobject);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fix #354.

- `ChannelRetry` now has a `reconnectDelay` parameter to add a delay before trying to re-establish a connection. It is defaulted to 0ms.
- I did not go with the `IOpenStrategy` modification I suggested in the mailing list, because it is not exposed in the Java and C# bindings.