### PR TITLE
Conformance fixes [2.x]

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+### 2.3.4 ###
+* :beetle: Fix conformance issue with data-link confirmations. See PR [#359](https://github.com/dnp3/opendnp3/pull/359).
+* :beetle: Fix conformance issue select & operate behaviour. See PR [#359](https://github.com/dnp3/opendnp3/pull/359).
+
 ### 2.3.3 ###
 * :beetle: Fix C# exception on time conversion upon restart command not supported. See issue [#350](https://github.com/dnp3/opendnp3/issues/350).
 

--- a/cpp/libs/src/opendnp3/link/PriLinkLayerStates.cpp
+++ b/cpp/libs/src/opendnp3/link/PriLinkLayerStates.cpp
@@ -266,6 +266,7 @@ PriStateBase& PLLS_ConfDataWait::OnNack(LinkContext& ctx, bool rxBuffFull)
 
 PriStateBase& PLLS_ConfDataWait::Failure(LinkContext& ctx)
 {
+    ctx.isRemoteReset = false;
     ctx.CancelTimer();
     ctx.CompleteSendOperation();
     return PLLS_Idle::Instance();
@@ -285,8 +286,7 @@ PriStateBase& PLLS_ConfDataWait::OnTimeout(LinkContext& ctx)
 
     SIMPLE_LOG_BLOCK(ctx.logger, flags::WARN, "Confirmed data final timeout, no retries remain");
     ctx.listener->OnStateChange(opendnp3::LinkStatus::UNRESET);
-    ctx.CompleteSendOperation();
-    return PLLS_Idle::Instance();
+    return Failure(ctx);
 }
 
 ////////////////////////////////////////////////////////

--- a/cpp/libs/src/opendnp3/outstation/ControlState.h
+++ b/cpp/libs/src/opendnp3/outstation/ControlState.h
@@ -43,7 +43,7 @@ public:
                                     const openpal::TimeDuration& timeout,
                                     const openpal::RSlice& objects) const
     {
-        if (expectedSeq.Equals(seq))
+        if (selected && expectedSeq.Equals(seq))
         {
             if (selectTime.milliseconds <= now.milliseconds)
             {
@@ -77,13 +77,20 @@ public:
 
     void Select(const AppSeqNum& currentSeqN, const openpal::MonotonicTimestamp& now, const openpal::RSlice& objects)
     {
+        selected = true;
         selectTime = now;
         expectedSeq = currentSeqN.Next();
         digest = CRC::CalcCrc(objects);
         length = objects.Size();
     }
 
+    void Unselect()
+    {
+        selected = false;
+    }
+
 private:
+    bool selected = false;
     AppSeqNum expectedSeq;
     openpal::MonotonicTimestamp selectTime;
     uint16_t digest;

--- a/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
+++ b/cpp/libs/src/opendnp3/outstation/OutstationContext.cpp
@@ -605,6 +605,10 @@ IINField OContext::HandleOperate(const openpal::RSlice& objects, HeaderWriter& w
         auto result = APDUParser::Parse(objects, handler, &this->logger);
         return (result == ParseResult::OK) ? handler.Errors() : IINFromParseResult(result);
     }
+    else
+    {
+        this->control.Unselect();
+    }
 
     return this->HandleCommandWithConstant(objects, writer, result);
 }

--- a/cpp/tests/opendnp3/src/TestLinkLayer.cpp
+++ b/cpp/tests/opendnp3/src/TestLinkLayer.cpp
@@ -407,6 +407,46 @@ TEST_CASE(SUITE("ConfirmedDataRetry"))
     REQUIRE(t.upper->GetCounters().numTxReady == 1);
 }
 
+TEST_CASE(SUITE("ConfirmedDataFailureResetsLink"))
+{
+    LinkConfig cfg = LinkLayerTest::DefaultConfig();
+    cfg.NumRetry = 1;
+    cfg.UseConfirms = true;
+
+    LinkLayerTest t(cfg);
+    t.link.OnLowerLayerUp();
+
+    BufferSegment segments(250, IncrementHex(0, 250), cfg.GetAddresses());
+    t.link.Send(segments);
+    t.link.OnTxReady();
+    REQUIRE(t.NumTotalWrites() == 1); // Should now be waiting for an ACK with active timer
+
+    t.OnFrame(LinkFunction::SEC_ACK, false, false, false, 1, 1024);
+    REQUIRE(t.NumTotalWrites() == 2);
+
+    REQUIRE(t.PopLastWriteAsHex() == LinkHex::ConfirmedUserData(true, true, 1024, 1, IncrementHex(0x00, 250)));
+    t.link.OnTxReady();
+
+    // Timeout original transmission
+    t.exe->AdvanceTime(cfg.Timeout);
+    REQUIRE(t.exe->RunMany() > 0);
+    REQUIRE(t.NumTotalWrites() == 3);
+
+    REQUIRE(t.PopLastWriteAsHex() == LinkHex::ConfirmedUserData(true, true, 1024, 1, IncrementHex(0x00, 250)));
+    t.link.OnTxReady();
+
+    // Timeout retransmission, no more retransmission
+    t.exe->AdvanceTime(cfg.Timeout);
+    REQUIRE(t.exe->RunMany() > 0);
+    REQUIRE(t.NumTotalWrites() == 3);
+
+    // When sending something else, then reset link state
+    t.link.Send(segments);
+    t.link.OnTxReady();
+    REQUIRE(t.NumTotalWrites() == 4); // Should now be waiting for an ACK with active timer
+    REQUIRE(t.PopLastWriteAsHex() == LinkHex::ResetLinkStates(true, 1024, 1));
+}
+
 TEST_CASE(SUITE("ResetLinkRetries"))
 {
     LinkConfig cfg = LinkLayerTest::DefaultConfig();

--- a/cpp/tests/opendnp3/src/TestOutstationCommandResponses.cpp
+++ b/cpp/tests/opendnp3/src/TestOutstationCommandResponses.cpp
@@ -150,12 +150,21 @@ TEST_CASE(SUITE("SelectOperateGapInSequenceNumber"))
     t.SendToOutstation("C0 03 0C 01 17 01 03 01 01 01 00 00 00 01 00 00 00 00");
     REQUIRE(t.lower->PopWriteAsHex()
             == "C0 81 80 00 0C 01 17 01 03 01 01 01 00 00 00 01 00 00 00 00"); // 0x00 status == CommandStatus::SUCCESS
+    REQUIRE(1 == t.cmdHandler->NumInvocations());
     t.OnTxReady();
 
     // operate
     t.SendToOutstation("C2 04 0C 01 17 01 03 01 01 01 00 00 00 01 00 00 00 00");
     REQUIRE(t.lower->PopWriteAsHex()
             == "C2 81 80 00 0C 01 17 01 03 01 01 01 00 00 00 01 00 00 00 02"); // 0x02 no select
+    REQUIRE(1 == t.cmdHandler->NumInvocations());
+    t.OnTxReady();
+
+    // Proper operate should not be accepted
+    t.SendToOutstation("C1 04 0C 01 17 01 03 01 01 01 00 00 00 01 00 00 00 00");
+    REQUIRE(t.lower->PopWriteAsHex()
+            == "C1 81 80 00 0C 01 17 01 03 01 01 01 00 00 00 01 00 00 00 02"); // 0x02 no select
+    REQUIRE(1 == t.cmdHandler->NumInvocations());
     t.OnTxReady();
 }
 


### PR DESCRIPTION
Fix two conformance issues that were found. These issues are not severe and were originally done in the develop branch (see #356).

- When using data-link confirmations (which you should not use btw), on timeout the link was not considered unreset, meaning a subsequent request wouldn't ask for a `RESET_LINK_STATES`.
- In a Select & Operate command, when a incorrect operate was received, the master could still send a proper operate afterwards and it would invoke the command handler.