### PR TITLE
Add `typesAllowedInClass0` in `OutstationParams` of the Java bindings.

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -236,6 +236,8 @@ set(all_sources
     ./cpp/jni/JNIStaticDoubleBinaryVariation.h
     ./cpp/jni/JNIStaticFrozenCounterVariation.cpp
     ./cpp/jni/JNIStaticFrozenCounterVariation.h
+    ./cpp/jni/JNIStaticTypeBitField.cpp
+    ./cpp/jni/JNIStaticTypeBitField.h
     ./cpp/jni/JNITaskCompletion.cpp
     ./cpp/jni/JNITaskCompletion.h
     ./cpp/jni/JNITaskConfig.cpp

--- a/java/bindings/src/main/java/com/automatak/dnp3/OutstationConfig.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/OutstationConfig.java
@@ -67,4 +67,9 @@ public class OutstationConfig {
      * Global enabled / disable for unsolicited messages. If false, the NULL unsolicited message is not even sent
      */
     public boolean allowUnsolicited = true;
+
+    /**
+     * A bitmask type that specifies the types allowed in a class 0 reponse
+     */
+    public StaticTypeBitField typesAllowedInClass0 = StaticTypeBitField.all();
 }

--- a/java/bindings/src/main/java/com/automatak/dnp3/StaticTypeBitField.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/StaticTypeBitField.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013-2019 Automatak, LLC
+ *
+ * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+ * LLC (www.automatak.com) under one or more contributor license agreements. 
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Green Energy Corp and Automatak LLC license
+ * this file to you under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.automatak.dnp3;
+
+
+import com.automatak.dnp3.enums.StaticTypeBitmask;
+
+/**
+ * A bitfield that describes a subset of all static types, e.g. { Binary, Analog } or {Analog, Counter, FrozenCounter }
+ */
+public class StaticTypeBitField {
+
+    public int bitfield;
+
+    private StaticTypeBitField(int mask) {
+        this.bitfield = mask;
+    }
+
+    public static StaticTypeBitField from(StaticTypeBitmask... types) {
+        byte mask = 0;
+        for (StaticTypeBitmask type : types) {
+            mask |= type.toType();
+        }
+        return new StaticTypeBitField(mask);
+    }
+
+    public boolean isSet(StaticTypeBitmask type)
+    {
+        return (type.toType() & bitfield) != 0;
+    }
+
+    public void set(StaticTypeBitmask type, boolean value)
+    {
+        if(value)
+        {
+            this.bitfield |= type.toType();
+        }
+        else
+        {
+            this.bitfield &= ~type.toType();
+        }
+    }
+
+    public static StaticTypeBitField none() {
+        return new StaticTypeBitField(0);
+    }
+
+    public static StaticTypeBitField all() {
+        return new StaticTypeBitField(~0);
+    }
+
+    public StaticTypeBitField except(StaticTypeBitmask type) {
+        return new StaticTypeBitField(this.bitfield & ~type.toType());
+    }
+
+}

--- a/java/codegen/src/main/scala/com/automatak/dnp3/codegen/Classes.scala
+++ b/java/codegen/src/main/scala/com/automatak/dnp3/codegen/Classes.scala
@@ -107,6 +107,7 @@ object Classes {
     ClassConfig(classOf[LinkLayerConfig], Set(Features.Fields)),
     ClassConfig(classOf[LogEntry], Set(Features.Constructors)),
     ClassConfig(classOf[ClassField], Set(Features.Fields)),
+    ClassConfig(classOf[StaticTypeBitField], Set(Features.Fields)),
     ClassConfig(classOf[HeaderInfo], Set(Features.Constructors)),
     ClassConfig(classOf[ResponseInfo], Set(Features.Constructors)),
     ClassConfig(classOf[IndexedValue[_]], Set(Features.Constructors, Features.Fields)),

--- a/java/cpp/adapters/ConfigReader.cpp
+++ b/java/cpp/adapters/ConfigReader.cpp
@@ -148,6 +148,12 @@ opendnp3::ClassField ConfigReader::Convert(JNIEnv* env, jni::JClassField jclassf
     return ClassField(static_cast<uint8_t>(value));
 }
 
+opendnp3::StaticTypeBitField ConfigReader::Convert(JNIEnv* env, jni::JStaticTypeBitField jbitfield)
+{
+    jint value = jni::JCache::StaticTypeBitField.getbitfield(env, jbitfield);
+    return opendnp3::StaticTypeBitField(static_cast<uint8_t>(value));
+}
+
 opendnp3::EventBufferConfig ConfigReader::Convert(JNIEnv* env, jni::JEventBufferConfig jeventconfig)
 {
     return opendnp3::EventBufferConfig(
@@ -174,6 +180,7 @@ opendnp3::OutstationParams ConfigReader::Convert(JNIEnv* env, jni::JOutstationCo
     config.maxTxFragSize = cfg.getmaxTxFragSize(env, jconfig);
     config.maxRxFragSize = cfg.getmaxRxFragSize(env, jconfig);
     config.allowUnsolicited = !(cfg.getallowUnsolicited(env, jconfig) == 0u);
+    config.typesAllowedInClass0 = Convert(env, cfg.gettypesAllowedInClass0(env, jconfig));
 
     return config;
 }

--- a/java/cpp/adapters/ConfigReader.h
+++ b/java/cpp/adapters/ConfigReader.h
@@ -38,6 +38,7 @@ private:
     static opendnp3::MasterParams Convert(JNIEnv* apEnv, jni::JMasterConfig jcfg);
 
     static opendnp3::ClassField Convert(JNIEnv* env, jni::JClassField jclassmask);
+    static opendnp3::StaticTypeBitField Convert(JNIEnv* env, jni::JStaticTypeBitField jbitfield);
     static opendnp3::EventBufferConfig Convert(JNIEnv* env, jni::JEventBufferConfig jeventconfig);
     static opendnp3::OutstationParams Convert(JNIEnv* env, jni::JOutstationConfig jconfig);
     static opendnp3::DatabaseConfig Convert(JNIEnv* env, jni::JDatabaseConfig jdb);

--- a/java/cpp/jni/JCache.cpp
+++ b/java/cpp/jni/JCache.cpp
@@ -131,6 +131,7 @@ namespace jni
     cache::StaticCounterVariation JCache::StaticCounterVariation;
     cache::StaticDoubleBinaryVariation JCache::StaticDoubleBinaryVariation;
     cache::StaticFrozenCounterVariation JCache::StaticFrozenCounterVariation;
+    cache::StaticTypeBitField JCache::StaticTypeBitField;
     cache::TLSConfig JCache::TLSConfig;
     cache::TaskCompletion JCache::TaskCompletion;
     cache::TaskId JCache::TaskId;
@@ -239,6 +240,7 @@ namespace jni
         && StaticCounterVariation.init(env)
         && StaticDoubleBinaryVariation.init(env)
         && StaticFrozenCounterVariation.init(env)
+        && StaticTypeBitField.init(env)
         && TLSConfig.init(env)
         && TaskCompletion.init(env)
         && TaskId.init(env)
@@ -349,6 +351,7 @@ namespace jni
         StaticCounterVariation.cleanup(env);
         StaticDoubleBinaryVariation.cleanup(env);
         StaticFrozenCounterVariation.cleanup(env);
+        StaticTypeBitField.cleanup(env);
         TLSConfig.cleanup(env);
         TaskCompletion.cleanup(env);
         TaskId.cleanup(env);

--- a/java/cpp/jni/JCache.h
+++ b/java/cpp/jni/JCache.h
@@ -132,6 +132,7 @@
 #include "JNIStaticCounterVariation.h"
 #include "JNIStaticDoubleBinaryVariation.h"
 #include "JNIStaticFrozenCounterVariation.h"
+#include "JNIStaticTypeBitField.h"
 #include "JNITLSConfig.h"
 #include "JNITaskCompletion.h"
 #include "JNITaskId.h"
@@ -245,6 +246,7 @@ namespace jni
         static cache::StaticCounterVariation StaticCounterVariation;
         static cache::StaticDoubleBinaryVariation StaticDoubleBinaryVariation;
         static cache::StaticFrozenCounterVariation StaticFrozenCounterVariation;
+        static cache::StaticTypeBitField StaticTypeBitField;
         static cache::TLSConfig TLSConfig;
         static cache::TaskCompletion TaskCompletion;
         static cache::TaskId TaskId;

--- a/java/cpp/jni/JNIOutstationConfig.cpp
+++ b/java/cpp/jni/JNIOutstationConfig.cpp
@@ -66,6 +66,9 @@ namespace jni
             this->allowUnsolicitedField = env->GetFieldID(this->clazz, "allowUnsolicited", "Z");
             if(!this->allowUnsolicitedField) return false;
 
+            this->typesAllowedInClass0Field = env->GetFieldID(this->clazz, "typesAllowedInClass0", "Lcom/automatak/dnp3/StaticTypeBitField;");
+            if(!this->typesAllowedInClass0Field) return false;
+
             return true;
         }
 
@@ -107,6 +110,11 @@ namespace jni
         LocalRef<JDuration> OutstationConfig::getsolConfirmTimeout(JNIEnv* env, JOutstationConfig instance)
         {
             return LocalRef<JDuration>(env, env->GetObjectField(instance, this->solConfirmTimeoutField));
+        }
+
+        LocalRef<JStaticTypeBitField> OutstationConfig::gettypesAllowedInClass0(JNIEnv* env, JOutstationConfig instance)
+        {
+            return LocalRef<JStaticTypeBitField>(env, env->GetObjectField(instance, this->typesAllowedInClass0Field));
         }
 
         LocalRef<JDuration> OutstationConfig::getunsolConfirmTimeout(JNIEnv* env, JOutstationConfig instance)

--- a/java/cpp/jni/JNIStaticTypeBitField.cpp
+++ b/java/cpp/jni/JNIStaticTypeBitField.cpp
@@ -1,0 +1,61 @@
+//
+//  _   _         ______    _ _ _   _             _ _ _
+// | \ | |       |  ____|  | (_) | (_)           | | | |
+// |  \| | ___   | |__   __| |_| |_ _ _ __   __ _| | | |
+// | . ` |/ _ \  |  __| / _` | | __| | '_ \ / _` | | | |
+// | |\  | (_) | | |___| (_| | | |_| | | | | (_| |_|_|_|
+// |_| \_|\___/  |______\__,_|_|\__|_|_| |_|\__, (_|_|_)
+//                                           __/ |
+//                                          |___/
+// 
+// This file is auto-generated. Do not edit manually
+// 
+// Copyright 2013-2019 Automatak, LLC
+// 
+// Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+// LLC (www.automatak.com) under one or more contributor license agreements.
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership. Green Energy Corp and Automatak LLC license
+// this file to you under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License. You may obtain
+// a copy of the License at:
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "JNIStaticTypeBitField.h"
+
+namespace jni
+{
+    namespace cache
+    {
+        bool StaticTypeBitField::init(JNIEnv* env)
+        {
+            auto clazzTemp = env->FindClass("Lcom/automatak/dnp3/StaticTypeBitField;");
+            if(!clazzTemp) return false;
+            this->clazz = (jclass) env->NewGlobalRef(clazzTemp);
+            env->DeleteLocalRef(clazzTemp);
+
+            this->bitfieldField = env->GetFieldID(this->clazz, "bitfield", "I");
+            if(!this->bitfieldField) return false;
+
+            return true;
+        }
+
+        void StaticTypeBitField::cleanup(JNIEnv* env)
+        {
+            env->DeleteGlobalRef(this->clazz);
+        }
+
+        jint StaticTypeBitField::getbitfield(JNIEnv* env, JStaticTypeBitField instance)
+        {
+            return env->GetIntField(instance, this->bitfieldField);
+        }
+    }
+}

--- a/java/cpp/jni/JNIStaticTypeBitField.h
+++ b/java/cpp/jni/JNIStaticTypeBitField.h
@@ -29,8 +29,8 @@
 // limitations under the License.
 //
 
-#ifndef OPENDNP3JAVA_JNIOUTSTATIONCONFIG_H
-#define OPENDNP3JAVA_JNIOUTSTATIONCONFIG_H
+#ifndef OPENDNP3JAVA_JNISTATICTYPEBITFIELD_H
+#define OPENDNP3JAVA_JNISTATICTYPEBITFIELD_H
 
 #include "../adapters/LocalRef.h"
 
@@ -42,7 +42,7 @@ namespace jni
 
     namespace cache
     {
-        class OutstationConfig
+        class StaticTypeBitField
         {
             friend struct jni::JCache;
 
@@ -52,30 +52,14 @@ namespace jni
             public:
 
             // field getter methods
-            jboolean getallowUnsolicited(JNIEnv* env, JOutstationConfig instance);
-            jshort getmaxControlsPerRequest(JNIEnv* env, JOutstationConfig instance);
-            jint getmaxRxFragSize(JNIEnv* env, JOutstationConfig instance);
-            jint getmaxTxFragSize(JNIEnv* env, JOutstationConfig instance);
-            LocalRef<JNumRetries> getnumUnsolRetries(JNIEnv* env, JOutstationConfig instance);
-            LocalRef<JDuration> getselectTimeout(JNIEnv* env, JOutstationConfig instance);
-            LocalRef<JDuration> getsolConfirmTimeout(JNIEnv* env, JOutstationConfig instance);
-            LocalRef<JStaticTypeBitField> gettypesAllowedInClass0(JNIEnv* env, JOutstationConfig instance);
-            LocalRef<JDuration> getunsolConfirmTimeout(JNIEnv* env, JOutstationConfig instance);
+            jint getbitfield(JNIEnv* env, JStaticTypeBitField instance);
 
             private:
 
             jclass clazz = nullptr;
 
             // field ids
-            jfieldID maxControlsPerRequestField = nullptr;
-            jfieldID selectTimeoutField = nullptr;
-            jfieldID solConfirmTimeoutField = nullptr;
-            jfieldID unsolConfirmTimeoutField = nullptr;
-            jfieldID numUnsolRetriesField = nullptr;
-            jfieldID maxTxFragSizeField = nullptr;
-            jfieldID maxRxFragSizeField = nullptr;
-            jfieldID allowUnsolicitedField = nullptr;
-            jfieldID typesAllowedInClass0Field = nullptr;
+            jfieldID bitfieldField = nullptr;
         };
     }
 }

--- a/java/cpp/jni/JNIWrappers.h
+++ b/java/cpp/jni/JNIWrappers.h
@@ -918,6 +918,15 @@ namespace jni
         jobject value;
     };
 
+    struct JStaticTypeBitField
+    {
+        JStaticTypeBitField(jobject value) : value(value) {}
+
+        operator jobject() const { return value; }
+
+        jobject value;
+    };
+
     struct JTLSConfig
     {
         JTLSConfig(jobject value) : value(value) {}


### PR DESCRIPTION
Add `typesAllowedInClass0` in `OutstationParams` of the Java bindings. It is necessary for conformance testing (in order to not report DBBI on Class 0 polls).

It was already present in the C# bindings.