### PR TITLE
Refactor/remove verify depth

### DIFF
--- a/cpp/lib/include/opendnp3/channel/TLSConfig.h
+++ b/cpp/lib/include/opendnp3/channel/TLSConfig.h
@@ -50,8 +50,7 @@ struct TLSConfig
      */
     TLSConfig(const std::string& peerCertFilePath,
               const std::string& localCertFilePath,
-              const std::string& privateKeyFilePath,
-              int maxVerifyDepth = 0,
+              const std::string& privateKeyFilePath,              
               bool allowTLSv10 = false,
               bool allowTLSv11 = false,
               bool allowTLSv12 = true,

--- a/cpp/lib/include/opendnp3/channel/TLSConfig.h
+++ b/cpp/lib/include/opendnp3/channel/TLSConfig.h
@@ -38,8 +38,7 @@ struct TLSConfig
      * provided by other party.
      * @param localCertFilePath File that contains the certificate (or certificate chain) that will be presented to the
      * remote side of the connection
-     * @param privateKeyFilePath File that contains the private key corresponding to the local certificate
-     * @param maxVerifyDepth The maximum certificate chain verification depth (0 == self-signed only)
+     * @param privateKeyFilePath File that contains the private key corresponding to the local certificate     
      * @param allowTLSv10 Allow TLS version 1.0 (default false)
      * @param allowTLSv11 Allow TLS version 1.1 (default false)
      * @param allowTLSv12 Allow TLS version 1.2 (default true)
@@ -59,8 +58,7 @@ struct TLSConfig
               const std::string& cipherList = "")
         : peerCertFilePath(peerCertFilePath),
           localCertFilePath(localCertFilePath),
-          privateKeyFilePath(privateKeyFilePath),
-          maxVerifyDepth(maxVerifyDepth),
+          privateKeyFilePath(privateKeyFilePath),          
           allowTLSv10(allowTLSv10),
           allowTLSv11(allowTLSv11),
           allowTLSv12(allowTLSv12),
@@ -78,9 +76,6 @@ struct TLSConfig
 
     /// File that contains the private key corresponding to the local certificate
     std::string privateKeyFilePath;
-
-    /// max verification depth (defaults to 0 - peer certificate only)
-    int maxVerifyDepth;
 
     /// Allow TLS version 1.0 (default false)
     bool allowTLSv10;

--- a/cpp/lib/src/channel/tls/SSLContext.cpp
+++ b/cpp/lib/src/channel/tls/SSLContext.cpp
@@ -64,14 +64,7 @@ std::error_code SSLContext::ApplyConfig(const TLSConfig& config, bool server, st
     {
         FORMAT_LOG_BLOCK(logger, flags::ERR, "Error calling ssl::context::set_options(..): %s", ec.message().c_str());
         return ec;
-    }
-
-    if (value.set_verify_depth(config.maxVerifyDepth, ec))
-    {
-        FORMAT_LOG_BLOCK(logger, flags::ERR, "Error calling ssl::context::set_verify_depth(..): %s",
-                         ec.message().c_str());
-        return ec;
-    }
+    }   
 
     // optionally, configure the cipher-list
     if (!config.cipherList.empty())

--- a/dotnet/CLRAdapter/src/Conversions.cpp
+++ b/dotnet/CLRAdapter/src/Conversions.cpp
@@ -355,7 +355,7 @@ namespace DNP3
         {
             return opendnp3::TLSConfig(Conversions::ConvertString(config->peerCertFilePath),
                                        Conversions::ConvertString(config->localCertFilePath),
-                                       Conversions::ConvertString(config->privateKeyFilePath), config->maxVerifyDepth,
+                                       Conversions::ConvertString(config->privateKeyFilePath),
                                        config->allowTLSv10, config->allowTLSv11, config->allowTLSv12,
                                        Conversions::ConvertString(config->cipherList));
         }

--- a/dotnet/CLRInterface/src/TLSConfig.cs
+++ b/dotnet/CLRInterface/src/TLSConfig.cs
@@ -30,8 +30,7 @@ namespace Automatak.DNP3.Interface
         /// </summary>
         /// <param name="peerCertFilePath">Certificate file used to verify the server. Can be CA file or a self - signed cert provided by other party</param>
         /// <param name="localCertFilePath">File that contains the certificate that will be presented to the remote side of the connection</param>
-        /// <param name="privateKeyFilePath">File that contains the private key corresponding to the local certificate</param>
-        /// <param name="maxVerifyDepth">Maximum certificate verify depth (defaults 0, self signed)</param>
+        /// <param name="privateKeyFilePath">File that contains the private key corresponding to the local certificate</param>        
         /// <param name="allowTLSv10">Allow TLS version 1.0 (default true)</param>
         /// <param name="allowTLSv11">Allow TLS version 1.1 (default true)</param>
         /// <param name="allowTLSv12">Allow TLS version 1.2 (default true)</param>
@@ -40,8 +39,7 @@ namespace Automatak.DNP3.Interface
         public TLSConfig(
             string peerCertFilePath,
             string localCertFilePath,
-            string privateKeyFilePath,
-            int maxVerifyDepth = 0,
+            string privateKeyFilePath,            
             bool allowTLSv10 = false,
             bool allowTLSv11 = false,
             bool allowTLSv12 = true,
@@ -50,8 +48,7 @@ namespace Automatak.DNP3.Interface
         {
             this.peerCertFilePath = peerCertFilePath;
             this.localCertFilePath = localCertFilePath;
-            this.privateKeyFilePath = privateKeyFilePath;
-            this.maxVerifyDepth = maxVerifyDepth;
+            this.privateKeyFilePath = privateKeyFilePath;            
             this.allowTLSv10 = allowTLSv10;
             this.allowTLSv11 = allowTLSv11;
             this.allowTLSv12 = allowTLSv12;
@@ -60,9 +57,7 @@ namespace Automatak.DNP3.Interface
 
         public readonly string peerCertFilePath;
         public readonly string localCertFilePath;
-        public readonly string privateKeyFilePath;
-        
-        public readonly int maxVerifyDepth;
+        public readonly string privateKeyFilePath;               
 
         /// Allow TLS version 1.0 (default false)
         public readonly bool allowTLSv10;

--- a/dotnet/examples/master-gprs-tls/Program.cs
+++ b/dotnet/examples/master-gprs-tls/Program.cs
@@ -46,7 +46,7 @@ namespace DotNetMasterGPRSDemo
                 "listener", 
                 LogLevels.ALL,
                 IPEndpoint.Localhost(20001),
-                new TLSConfig(caCertificate, certificateChain, privateKey, 2),
+                new TLSConfig(caCertificate, certificateChain, privateKey),
                 new DefaultListenCallbacks()
             );
 

--- a/java/bindings/src/main/java/com/automatak/dnp3/TLSConfig.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/TLSConfig.java
@@ -30,7 +30,6 @@ public class TLSConfig
      * @param peerCertFilePath Certificate file used to verify the peer or server. Can be CA file or a self-signed cert provided by other party.
      * @param localCertFilePath File that contains the certificate (or certificate chain) that will be presented to the remote side of the connection
      * @param privateKeyFilePath File that contains the private key corresponding to the local certificate
-     * @param maxVerifyDepth The maximum certificate chain verification depth (0 == self-signed only)
      * @param allowTLSv10 Allow TLS version 1.0 (default false)
      * @param allowTLSv11 Allow TLS version 1.1 (default false)
      * @param allowTLSv12 Allow TLS version 1.2 (default true)
@@ -43,7 +42,6 @@ public class TLSConfig
 	    String peerCertFilePath,
 	    String localCertFilePath,
 	    String privateKeyFilePath,
-        int maxVerifyDepth,
         boolean allowTLSv10,
         boolean allowTLSv11,
         boolean allowTLSv12,
@@ -53,7 +51,6 @@ public class TLSConfig
         this.peerCertFilePath = peerCertFilePath;
         this.localCertFilePath = localCertFilePath;
         this.privateKeyFilePath = privateKeyFilePath;
-        this.maxVerifyDepth = maxVerifyDepth;
         this.allowTLSv10 = allowTLSv10;
         this.allowTLSv11 = allowTLSv11;
         this.allowTLSv12 = allowTLSv12;
@@ -68,9 +65,6 @@ public class TLSConfig
 
     /// File that contains the private key corresponding to the local certificate
     public final String privateKeyFilePath;
-
-    /// max verification depth (defaults to 0 - peer certificate only)
-    public final int maxVerifyDepth;
 
     /// Allow TLS version 1.0 (default false)
     public final boolean allowTLSv10;

--- a/java/cpp/com_automatak_dnp3_impl_ManagerImpl.cpp
+++ b/java/cpp/com_automatak_dnp3_impl_ManagerImpl.cpp
@@ -37,8 +37,7 @@ opendnp3::TLSConfig ConvertTLSConfig(JNIEnv* env, jobject jconfig)
     CString private_key_file_path(env, ref.getprivateKeyFilePath(env, jconfig));
     CString cipher_list(env, ref.getcipherList(env, jconfig));
 
-    return opendnp3::TLSConfig(peer_cert_file_path.str(), local_cert_file_path.str(), private_key_file_path.str(),
-                              ref.getmaxVerifyDepth(env, jconfig),
+    return opendnp3::TLSConfig(peer_cert_file_path.str(), local_cert_file_path.str(), private_key_file_path.str(),                              
                               ref.getallowTLSv10(env, jconfig) != 0,
                               ref.getallowTLSv11(env, jconfig) != 0,
                               ref.getallowTLSv12(env, jconfig) != 0,

--- a/java/cpp/jni/JNICommandHandler.cpp
+++ b/java/cpp/jni/JNICommandHandler.cpp
@@ -48,19 +48,19 @@ namespace jni
             this->method1 = env->GetMethodID(this->clazz, "end", "()V");
             if(!this->method1) return false;
 
-            this->method2 = env->GetMethodID(this->clazz, "operate", "(Lcom/automatak/dnp3/AnalogOutputDouble64;ILcom/automatak/dnp3/Database;Lcom/automatak/dnp3/enums/OperateType;)Lcom/automatak/dnp3/enums/CommandStatus;");
+            this->method2 = env->GetMethodID(this->clazz, "operate", "(Lcom/automatak/dnp3/AnalogOutputInt16;ILcom/automatak/dnp3/Database;Lcom/automatak/dnp3/enums/OperateType;)Lcom/automatak/dnp3/enums/CommandStatus;");
             if(!this->method2) return false;
 
-            this->method3 = env->GetMethodID(this->clazz, "operate", "(Lcom/automatak/dnp3/AnalogOutputFloat32;ILcom/automatak/dnp3/Database;Lcom/automatak/dnp3/enums/OperateType;)Lcom/automatak/dnp3/enums/CommandStatus;");
+            this->method3 = env->GetMethodID(this->clazz, "operate", "(Lcom/automatak/dnp3/AnalogOutputInt32;ILcom/automatak/dnp3/Database;Lcom/automatak/dnp3/enums/OperateType;)Lcom/automatak/dnp3/enums/CommandStatus;");
             if(!this->method3) return false;
 
-            this->method4 = env->GetMethodID(this->clazz, "operate", "(Lcom/automatak/dnp3/AnalogOutputInt16;ILcom/automatak/dnp3/Database;Lcom/automatak/dnp3/enums/OperateType;)Lcom/automatak/dnp3/enums/CommandStatus;");
+            this->method4 = env->GetMethodID(this->clazz, "operate", "(Lcom/automatak/dnp3/AnalogOutputFloat32;ILcom/automatak/dnp3/Database;Lcom/automatak/dnp3/enums/OperateType;)Lcom/automatak/dnp3/enums/CommandStatus;");
             if(!this->method4) return false;
 
-            this->method5 = env->GetMethodID(this->clazz, "operate", "(Lcom/automatak/dnp3/AnalogOutputInt32;ILcom/automatak/dnp3/Database;Lcom/automatak/dnp3/enums/OperateType;)Lcom/automatak/dnp3/enums/CommandStatus;");
+            this->method5 = env->GetMethodID(this->clazz, "operate", "(Lcom/automatak/dnp3/ControlRelayOutputBlock;ILcom/automatak/dnp3/Database;Lcom/automatak/dnp3/enums/OperateType;)Lcom/automatak/dnp3/enums/CommandStatus;");
             if(!this->method5) return false;
 
-            this->method6 = env->GetMethodID(this->clazz, "operate", "(Lcom/automatak/dnp3/ControlRelayOutputBlock;ILcom/automatak/dnp3/Database;Lcom/automatak/dnp3/enums/OperateType;)Lcom/automatak/dnp3/enums/CommandStatus;");
+            this->method6 = env->GetMethodID(this->clazz, "operate", "(Lcom/automatak/dnp3/AnalogOutputDouble64;ILcom/automatak/dnp3/Database;Lcom/automatak/dnp3/enums/OperateType;)Lcom/automatak/dnp3/enums/CommandStatus;");
             if(!this->method6) return false;
 
             this->method7 = env->GetMethodID(this->clazz, "select", "(Lcom/automatak/dnp3/AnalogOutputInt32;I)Lcom/automatak/dnp3/enums/CommandStatus;");
@@ -96,27 +96,27 @@ namespace jni
             env->CallVoidMethod(instance, this->method1);
         }
 
-        LocalRef<JCommandStatus> CommandHandler::operate(JNIEnv* env, JCommandHandler instance, JAnalogOutputDouble64 arg0, jint arg1, JDatabase arg2, JOperateType arg3)
+        LocalRef<JCommandStatus> CommandHandler::operate(JNIEnv* env, JCommandHandler instance, JAnalogOutputInt16 arg0, jint arg1, JDatabase arg2, JOperateType arg3)
         {
             return LocalRef<JCommandStatus>(env, env->CallObjectMethod(instance, this->method2, arg0, arg1, arg2, arg3));
         }
 
-        LocalRef<JCommandStatus> CommandHandler::operate(JNIEnv* env, JCommandHandler instance, JAnalogOutputFloat32 arg0, jint arg1, JDatabase arg2, JOperateType arg3)
+        LocalRef<JCommandStatus> CommandHandler::operate(JNIEnv* env, JCommandHandler instance, JAnalogOutputInt32 arg0, jint arg1, JDatabase arg2, JOperateType arg3)
         {
             return LocalRef<JCommandStatus>(env, env->CallObjectMethod(instance, this->method3, arg0, arg1, arg2, arg3));
         }
 
-        LocalRef<JCommandStatus> CommandHandler::operate(JNIEnv* env, JCommandHandler instance, JAnalogOutputInt16 arg0, jint arg1, JDatabase arg2, JOperateType arg3)
+        LocalRef<JCommandStatus> CommandHandler::operate(JNIEnv* env, JCommandHandler instance, JAnalogOutputFloat32 arg0, jint arg1, JDatabase arg2, JOperateType arg3)
         {
             return LocalRef<JCommandStatus>(env, env->CallObjectMethod(instance, this->method4, arg0, arg1, arg2, arg3));
         }
 
-        LocalRef<JCommandStatus> CommandHandler::operate(JNIEnv* env, JCommandHandler instance, JAnalogOutputInt32 arg0, jint arg1, JDatabase arg2, JOperateType arg3)
+        LocalRef<JCommandStatus> CommandHandler::operate(JNIEnv* env, JCommandHandler instance, JControlRelayOutputBlock arg0, jint arg1, JDatabase arg2, JOperateType arg3)
         {
             return LocalRef<JCommandStatus>(env, env->CallObjectMethod(instance, this->method5, arg0, arg1, arg2, arg3));
         }
 
-        LocalRef<JCommandStatus> CommandHandler::operate(JNIEnv* env, JCommandHandler instance, JControlRelayOutputBlock arg0, jint arg1, JDatabase arg2, JOperateType arg3)
+        LocalRef<JCommandStatus> CommandHandler::operate(JNIEnv* env, JCommandHandler instance, JAnalogOutputDouble64 arg0, jint arg1, JDatabase arg2, JOperateType arg3)
         {
             return LocalRef<JCommandStatus>(env, env->CallObjectMethod(instance, this->method6, arg0, arg1, arg2, arg3));
         }

--- a/java/cpp/jni/JNICommandHandler.h
+++ b/java/cpp/jni/JNICommandHandler.h
@@ -54,11 +54,11 @@ namespace jni
             // methods
             void begin(JNIEnv* env, JCommandHandler instance);
             void end(JNIEnv* env, JCommandHandler instance);
-            LocalRef<JCommandStatus> operate(JNIEnv* env, JCommandHandler instance, JAnalogOutputDouble64 arg0, jint arg1, JDatabase arg2, JOperateType arg3);
-            LocalRef<JCommandStatus> operate(JNIEnv* env, JCommandHandler instance, JAnalogOutputFloat32 arg0, jint arg1, JDatabase arg2, JOperateType arg3);
             LocalRef<JCommandStatus> operate(JNIEnv* env, JCommandHandler instance, JAnalogOutputInt16 arg0, jint arg1, JDatabase arg2, JOperateType arg3);
             LocalRef<JCommandStatus> operate(JNIEnv* env, JCommandHandler instance, JAnalogOutputInt32 arg0, jint arg1, JDatabase arg2, JOperateType arg3);
+            LocalRef<JCommandStatus> operate(JNIEnv* env, JCommandHandler instance, JAnalogOutputFloat32 arg0, jint arg1, JDatabase arg2, JOperateType arg3);
             LocalRef<JCommandStatus> operate(JNIEnv* env, JCommandHandler instance, JControlRelayOutputBlock arg0, jint arg1, JDatabase arg2, JOperateType arg3);
+            LocalRef<JCommandStatus> operate(JNIEnv* env, JCommandHandler instance, JAnalogOutputDouble64 arg0, jint arg1, JDatabase arg2, JOperateType arg3);
             LocalRef<JCommandStatus> select(JNIEnv* env, JCommandHandler instance, JAnalogOutputInt32 arg0, jint arg1);
             LocalRef<JCommandStatus> select(JNIEnv* env, JCommandHandler instance, JAnalogOutputInt16 arg0, jint arg1);
             LocalRef<JCommandStatus> select(JNIEnv* env, JCommandHandler instance, JAnalogOutputFloat32 arg0, jint arg1);

--- a/java/cpp/jni/JNITLSConfig.cpp
+++ b/java/cpp/jni/JNITLSConfig.cpp
@@ -51,9 +51,6 @@ namespace jni
             this->privateKeyFilePathField = env->GetFieldID(this->clazz, "privateKeyFilePath", "Ljava/lang/String;");
             if(!this->privateKeyFilePathField) return false;
 
-            this->maxVerifyDepthField = env->GetFieldID(this->clazz, "maxVerifyDepth", "I");
-            if(!this->maxVerifyDepthField) return false;
-
             this->allowTLSv10Field = env->GetFieldID(this->clazz, "allowTLSv10", "Z");
             if(!this->allowTLSv10Field) return false;
 
@@ -97,11 +94,6 @@ namespace jni
         LocalRef<JString> TLSConfig::getlocalCertFilePath(JNIEnv* env, JTLSConfig instance)
         {
             return LocalRef<JString>(env, (jstring) env->GetObjectField(instance, this->localCertFilePathField));
-        }
-
-        jint TLSConfig::getmaxVerifyDepth(JNIEnv* env, JTLSConfig instance)
-        {
-            return env->GetIntField(instance, this->maxVerifyDepthField);
         }
 
         LocalRef<JString> TLSConfig::getpeerCertFilePath(JNIEnv* env, JTLSConfig instance)

--- a/java/cpp/jni/JNITLSConfig.h
+++ b/java/cpp/jni/JNITLSConfig.h
@@ -57,7 +57,6 @@ namespace jni
             jboolean getallowTLSv12(JNIEnv* env, JTLSConfig instance);
             LocalRef<JString> getcipherList(JNIEnv* env, JTLSConfig instance);
             LocalRef<JString> getlocalCertFilePath(JNIEnv* env, JTLSConfig instance);
-            jint getmaxVerifyDepth(JNIEnv* env, JTLSConfig instance);
             LocalRef<JString> getpeerCertFilePath(JNIEnv* env, JTLSConfig instance);
             LocalRef<JString> getprivateKeyFilePath(JNIEnv* env, JTLSConfig instance);
 
@@ -69,7 +68,6 @@ namespace jni
             jfieldID peerCertFilePathField = nullptr;
             jfieldID localCertFilePathField = nullptr;
             jfieldID privateKeyFilePathField = nullptr;
-            jfieldID maxVerifyDepthField = nullptr;
             jfieldID allowTLSv10Field = nullptr;
             jfieldID allowTLSv11Field = nullptr;
             jfieldID allowTLSv12Field = nullptr;


### PR DESCRIPTION
The max verification depth doesn't really add any security, but can serve as a massive roadblock for TLS users using a CA since the default was set to 0. The decision was made to remove this property in 3.0 and not enforce a max verification depth.