### PR TITLE
Fix issue in TaskCallbackAdapter that was deleted twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.0.1 ###
+* :beetle: Fix double-delete issue in C# adapter. See PR
+  [#376](https://github.com/dnp3/opendnp3/pull/376).
+
 ### 3.0.0 ###
 
 New features:

--- a/dotnet/CLRAdapter/src/CallbackAdapters.cpp
+++ b/dotnet/CLRAdapter/src/CallbackAdapters.cpp
@@ -25,34 +25,34 @@
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			opendnp3::CommandResultCallbackT CallbackAdapters::Get(TaskCompletionSource<CommandTaskResult^>^ tcs)
-			{
-				gcroot<TaskCompletionSource<CommandTaskResult^>^> handle(tcs);
+            opendnp3::CommandResultCallbackT CallbackAdapters::Get(TaskCompletionSource<CommandTaskResult^>^ tcs)
+            {
+                gcroot<TaskCompletionSource<CommandTaskResult^>^> handle(tcs);
 
-				return [handle](const opendnp3::ICommandTaskResult& res) -> void
-				{
-					auto result = Conversions::ConvertCommandTaskResult(res);
-					handle->SetResult(result);
-				};
-			}
+                return [handle](const opendnp3::ICommandTaskResult& res) -> void
+                {
+                    auto result = Conversions::ConvertCommandTaskResult(res);
+                    handle->SetResult(result);
+                };
+            }
 
-			opendnp3::RestartOperationCallbackT CallbackAdapters::Get(TaskCompletionSource<RestartResultType^>^ tcs)
-			{
-				gcroot<TaskCompletionSource<RestartResultType^>^> handle(tcs);
+            opendnp3::RestartOperationCallbackT CallbackAdapters::Get(TaskCompletionSource<RestartResultType^>^ tcs)
+            {
+                gcroot<TaskCompletionSource<RestartResultType^>^> handle(tcs);
 
-				return [handle](const opendnp3::RestartOperationResult& res) -> void
-				{
-					auto result = gcnew RestartResultType((TaskCompletion)res.summary, Conversions::ConvertTimeDuration(res.restartTime));
+                return [handle](const opendnp3::RestartOperationResult& res) -> void
+                {
+                    auto result = gcnew RestartResultType((TaskCompletion)res.summary, Conversions::ConvertTimeDuration(res.restartTime));
 
-					handle->SetResult(result);
-				};
-			}
+                    handle->SetResult(result);
+                };
+            }
 
-		}
-	}
+        }
+    }
 }

--- a/dotnet/CLRAdapter/src/CallbackAdapters.h
+++ b/dotnet/CLRAdapter/src/CallbackAdapters.h
@@ -32,21 +32,21 @@ using namespace System::Threading::Tasks;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			class CallbackAdapters : private opendnp3::StaticOnly
-			{
-			public:
+            class CallbackAdapters : private opendnp3::StaticOnly
+            {
+            public:
 
-				static opendnp3::CommandResultCallbackT Get(TaskCompletionSource<CommandTaskResult ^> ^ tcs);
-				static opendnp3::RestartOperationCallbackT Get(TaskCompletionSource<RestartResultType^>^ tcs);
-			};
+                static opendnp3::CommandResultCallbackT Get(TaskCompletionSource<CommandTaskResult ^> ^ tcs);
+                static opendnp3::RestartOperationCallbackT Get(TaskCompletionSource<RestartResultType^>^ tcs);
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/ChangeSetAdapter.h
+++ b/dotnet/CLRAdapter/src/ChangeSetAdapter.h
@@ -29,39 +29,39 @@ using namespace Automatak::DNP3::Interface;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private ref class DatabaseAdapter : public Automatak::DNP3::Interface::IDatabase
-			{
-			public:
+            private ref class DatabaseAdapter : public Automatak::DNP3::Interface::IDatabase
+            {
+            public:
 
-				DatabaseAdapter();
+                DatabaseAdapter();
 
-				~DatabaseAdapter();
+                ~DatabaseAdapter();
                 !DatabaseAdapter();
-				
-				virtual void Update(Binary^ update, System::UInt16 index, EventMode mode);
-				virtual void Update(DoubleBitBinary^ update, System::UInt16 index, EventMode mode);				
-				virtual void Update(Analog^ update, System::UInt16 index, EventMode mode);
-				virtual void Update(Counter^ update, System::UInt16 index, EventMode mode);
+                
+                virtual void Update(Binary^ update, System::UInt16 index, EventMode mode);
+                virtual void Update(DoubleBitBinary^ update, System::UInt16 index, EventMode mode);
+                virtual void Update(Analog^ update, System::UInt16 index, EventMode mode);
+                virtual void Update(Counter^ update, System::UInt16 index, EventMode mode);
                 virtual void FreezeCounter(System::UInt16 index, System::Boolean clear, EventMode mode);
-				virtual void Update(BinaryOutputStatus^ update, System::UInt16 index, EventMode mode);
-				virtual void Update(AnalogOutputStatus^ update, System::UInt16 index, EventMode mode);
-				virtual void Update(OctetString^ update, System::UInt16 index, EventMode mode);
-				virtual void Update(TimeAndInterval^ update, System::UInt16 index);				
+                virtual void Update(BinaryOutputStatus^ update, System::UInt16 index, EventMode mode);
+                virtual void Update(AnalogOutputStatus^ update, System::UInt16 index, EventMode mode);
+                virtual void Update(OctetString^ update, System::UInt16 index, EventMode mode);
+                virtual void Update(TimeAndInterval^ update, System::UInt16 index);
 
-				void Apply(opendnp3::IOutstation& proxy);
-				
-			private:
-				
-				opendnp3::UpdateBuilder* builder;
-			};
+                void Apply(opendnp3::IOutstation& proxy);
+                
+            private:
+                
+                opendnp3::UpdateBuilder* builder;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/ChannelAdapter.cpp
+++ b/dotnet/CLRAdapter/src/ChannelAdapter.cpp
@@ -34,74 +34,74 @@ using namespace System::Collections::Generic;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			ChannelAdapter::ChannelAdapter(const std::shared_ptr<opendnp3::IChannel>& channel)
+            ChannelAdapter::ChannelAdapter(const std::shared_ptr<opendnp3::IChannel>& channel)
                 : channel(new std::shared_ptr<opendnp3::IChannel>(channel))
-			{}
+            {}
 
-			ChannelAdapter::~ChannelAdapter()
-			{
-				this->!ChannelAdapter();
-			}
+            ChannelAdapter::~ChannelAdapter()
+            {
+                this->!ChannelAdapter();
+            }
 
-			ChannelAdapter::!ChannelAdapter()
-			{
-				delete channel;
-			}
+            ChannelAdapter::!ChannelAdapter()
+            {
+                delete channel;
+            }
 
-			LogFilter ChannelAdapter::GetLogFilters()
-			{
-				return LogFilter((*channel)->GetLogFilters().get_value());
-			}
+            LogFilter ChannelAdapter::GetLogFilters()
+            {
+                return LogFilter((*channel)->GetLogFilters().get_value());
+            }
 
-			IChannelStatistics^ ChannelAdapter::GetChannelStatistics()
-			{
-				auto stats = (*channel)->GetStatistics();
-				return Conversions::ConvertChannelStats(stats);
-			}
+            IChannelStatistics^ ChannelAdapter::GetChannelStatistics()
+            {
+                auto stats = (*channel)->GetStatistics();
+                return Conversions::ConvertChannelStats(stats);
+            }
 
-			void ChannelAdapter::SetLogFilters(LogFilter filters)
-			{				
+            void ChannelAdapter::SetLogFilters(LogFilter filters)
+            {				
                 (*channel)->SetLogFilters(opendnp3::LogLevel(filters.Flags));
-			}
+            }
 
-			void CallbackListener(gcroot < System::Action<ChannelState> ^ >* listener, opendnp3::ChannelState aState)
-			{
-				ChannelState state = Conversions::ConvertChannelState(aState);
-				(*listener)->Invoke(state);
-			}
+            void CallbackListener(gcroot < System::Action<ChannelState> ^ >* listener, opendnp3::ChannelState aState)
+            {
+                ChannelState state = Conversions::ConvertChannelState(aState);
+                (*listener)->Invoke(state);
+            }
 
-			IMaster^ ChannelAdapter::AddMaster(System::String^ loggerId, ISOEHandler^ handler, IMasterApplication^ application, MasterStackConfig^ config)
-			{
-				std::string stdLoggerId = Conversions::ConvertString(loggerId);				
+            IMaster^ ChannelAdapter::AddMaster(System::String^ loggerId, ISOEHandler^ handler, IMasterApplication^ application, MasterStackConfig^ config)
+            {
+                std::string stdLoggerId = Conversions::ConvertString(loggerId);
 
-				auto SOEAdapter = std::shared_ptr<opendnp3::ISOEHandler>(new SOEHandlerAdapter(handler));
-				auto appAdapter = std::shared_ptr<opendnp3::IMasterApplication>(new MasterApplicationAdapter(application));
+                auto SOEAdapter = std::shared_ptr<opendnp3::ISOEHandler>(new SOEHandlerAdapter(handler));
+                auto appAdapter = std::shared_ptr<opendnp3::IMasterApplication>(new MasterApplicationAdapter(application));
 
-				auto master = (*channel)->AddMaster(stdLoggerId.c_str(), SOEAdapter, appAdapter, Conversions::ConvertConfig(config));
-				return master ? gcnew MasterAdapter(master) : nullptr;
-			}
+                auto master = (*channel)->AddMaster(stdLoggerId.c_str(), SOEAdapter, appAdapter, Conversions::ConvertConfig(config));
+                return master ? gcnew MasterAdapter(master) : nullptr;
+            }
 
-			IOutstation^ ChannelAdapter::AddOutstation(System::String^ loggerId, ICommandHandler^ cmdHandler, IOutstationApplication^ application, OutstationStackConfig^ config)
-			{
-				std::string stdLoggerId = Conversions::ConvertString(loggerId);				
+            IOutstation^ ChannelAdapter::AddOutstation(System::String^ loggerId, ICommandHandler^ cmdHandler, IOutstationApplication^ application, OutstationStackConfig^ config)
+            {
+                std::string stdLoggerId = Conversions::ConvertString(loggerId);
 
-				auto commandAdapter = std::shared_ptr<opendnp3::ICommandHandler>(new OutstationCommandHandlerAdapter(cmdHandler));
-				auto appAdapter = std::shared_ptr<opendnp3::IOutstationApplication>(new OutstationApplicationAdapter(application));
+                auto commandAdapter = std::shared_ptr<opendnp3::ICommandHandler>(new OutstationCommandHandlerAdapter(cmdHandler));
+                auto appAdapter = std::shared_ptr<opendnp3::IOutstationApplication>(new OutstationApplicationAdapter(application));
 
-				auto outstation = (*channel)->AddOutstation(stdLoggerId.c_str(), commandAdapter, appAdapter, Conversions::ConvertConfig(config));
-				return outstation ? gcnew OutstationAdapter(outstation) : nullptr;
-			}
+                auto outstation = (*channel)->AddOutstation(stdLoggerId.c_str(), commandAdapter, appAdapter, Conversions::ConvertConfig(config));
+                return outstation ? gcnew OutstationAdapter(outstation) : nullptr;
+            }
 
-			void ChannelAdapter::Shutdown()
-			{
-				(*channel)->Shutdown();
-			}
+            void ChannelAdapter::Shutdown()
+            {
+                (*channel)->Shutdown();
+            }
 
-		}
-	}
+        }
+    }
 }

--- a/dotnet/CLRAdapter/src/ChannelAdapter.h
+++ b/dotnet/CLRAdapter/src/ChannelAdapter.h
@@ -31,39 +31,39 @@ using namespace System::Collections::ObjectModel;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			ref class ChannelAdapter : IChannel
-			{
-			public:
+            ref class ChannelAdapter : IChannel
+            {
+            public:
 
-				ChannelAdapter(const std::shared_ptr<opendnp3::IChannel>& channel);
+                ChannelAdapter(const std::shared_ptr<opendnp3::IChannel>& channel);
 
-				~ChannelAdapter();
-				!ChannelAdapter();
+                ~ChannelAdapter();
+                !ChannelAdapter();
 
-				virtual LogFilter GetLogFilters() sealed;
+                virtual LogFilter GetLogFilters() sealed;
 
-				virtual IChannelStatistics^ GetChannelStatistics() sealed;
+                virtual IChannelStatistics^ GetChannelStatistics() sealed;
 
-				virtual void SetLogFilters(LogFilter filters) sealed;				
+                virtual void SetLogFilters(LogFilter filters) sealed;
 
-				virtual IMaster^ AddMaster(System::String^ loggerId, ISOEHandler^ publisher, IMasterApplication^ application, MasterStackConfig^ config) sealed;
+                virtual IMaster^ AddMaster(System::String^ loggerId, ISOEHandler^ publisher, IMasterApplication^ application, MasterStackConfig^ config) sealed;
 
-				virtual IOutstation^ AddOutstation(System::String^ loggerId, ICommandHandler^ cmdHandler, IOutstationApplication^ application, OutstationStackConfig^ config) sealed;
+                virtual IOutstation^ AddOutstation(System::String^ loggerId, ICommandHandler^ cmdHandler, IOutstationApplication^ application, OutstationStackConfig^ config) sealed;
 
-				virtual void Shutdown() sealed;
+                virtual void Shutdown() sealed;
 
-			private:
+            private:
 
-				std::shared_ptr<opendnp3::IChannel>* channel;
-			};
+                std::shared_ptr<opendnp3::IChannel>* channel;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/ChannelListenerAdapter.h
+++ b/dotnet/CLRAdapter/src/ChannelListenerAdapter.h
@@ -28,29 +28,29 @@ using namespace Automatak::DNP3::Interface;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private class ChannelListenerAdapter final : public opendnp3::IChannelListener
-			{
-			public:
+            private class ChannelListenerAdapter final : public opendnp3::IChannelListener
+            {
+            public:
 
-				ChannelListenerAdapter(Automatak::DNP3::Interface::IChannelListener^ proxy) : proxy(proxy) {}	
+                ChannelListenerAdapter(Automatak::DNP3::Interface::IChannelListener^ proxy) : proxy(proxy) {}	
 
-				virtual void OnStateChange(opendnp3::ChannelState state) override
-				{
-					this->proxy->OnStateChange((Interface::ChannelState) state);
-				}
+                virtual void OnStateChange(opendnp3::ChannelState state) override
+                {
+                    this->proxy->OnStateChange((Interface::ChannelState) state);
+                }
 
-			private:
+            private:
 
-				gcroot < Automatak::DNP3::Interface::IChannelListener^ > proxy;
-			};
+                gcroot < Automatak::DNP3::Interface::IChannelListener^ > proxy;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/CollectionAdapter.h
+++ b/dotnet/CLRAdapter/src/CollectionAdapter.h
@@ -30,46 +30,46 @@ using namespace System::Collections::Generic;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			template <class Source, class Target, class Convert>
-			class CollectionAdapter : public opendnp3::IVisitor<Source>
-			{
-			public:
+            template <class Source, class Target, class Convert>
+            class CollectionAdapter : public opendnp3::IVisitor<Source>
+            {
+            public:
 
-				CollectionAdapter(const Convert& convert_) : list(gcnew List<Target>()), convert(convert_)
-				{
+                CollectionAdapter(const Convert& convert_) : list(gcnew List<Target>()), convert(convert_)
+                {
 
-				}
+                }
 
-				virtual void OnValue(const Source& value) override final
-				{
-					Target target = convert(value);
-					this->list->Add(target);
-				}
+                virtual void OnValue(const Source& value) override final
+                {
+                    Target target = convert(value);
+                    this->list->Add(target);
+                }
 
-				IEnumerable<Target>^ GetValues()
-				{
-					return list;
-				}
+                IEnumerable<Target>^ GetValues()
+                {
+                    return list;
+                }
 
-			private:
+            private:
 
-				gcroot<System::Collections::Generic::IList<Target>^> list;
-				Convert convert;
-			};
+                gcroot<System::Collections::Generic::IList<Target>^> list;
+                Convert convert;
+            };
 
-			template <class Source, class Target, class Convert>
-			CollectionAdapter<Source, Target, Convert> CreateAdapter(const Convert& convert)
-			{
-				return CollectionAdapter<Source, Target, Convert>(convert);
-			}
+            template <class Source, class Target, class Convert>
+            CollectionAdapter<Source, Target, Convert> CreateAdapter(const Convert& convert)
+            {
+                return CollectionAdapter<Source, Target, Convert>(convert);
+            }
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/CommandSetBuilder.cpp
+++ b/dotnet/CLRAdapter/src/CommandSetBuilder.cpp
@@ -23,59 +23,59 @@
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			CommandSetBuilder::CommandSetBuilder(opendnp3::CommandSet& commands) : commands(&commands)
-			{}
+            CommandSetBuilder::CommandSetBuilder(opendnp3::CommandSet& commands) : commands(&commands)
+            {}
 
-			void CommandSetBuilder::Add(IEnumerable<IndexedValue<ControlRelayOutputBlock^>^>^ commands)
-			{
-				auto& header = this->commands->StartHeader<opendnp3::ControlRelayOutputBlock>();
-				for each(auto pair in commands)
-				{
-					header.Add(Conversions::ConvertCommand(pair->Value), pair->Index);
-				}
-			}
+            void CommandSetBuilder::Add(IEnumerable<IndexedValue<ControlRelayOutputBlock^>^>^ commands)
+            {
+                auto& header = this->commands->StartHeader<opendnp3::ControlRelayOutputBlock>();
+                for each(auto pair in commands)
+                {
+                    header.Add(Conversions::ConvertCommand(pair->Value), pair->Index);
+                }
+            }
 
-			void CommandSetBuilder::Add(IEnumerable<IndexedValue<AnalogOutputInt16^>^>^ commands)
-			{
-				auto& header = this->commands->StartHeader<opendnp3::AnalogOutputInt16>();
-				for each(auto pair in commands)
-				{
-					header.Add(Conversions::ConvertCommand(pair->Value), pair->Index);
-				}
-			}
+            void CommandSetBuilder::Add(IEnumerable<IndexedValue<AnalogOutputInt16^>^>^ commands)
+            {
+                auto& header = this->commands->StartHeader<opendnp3::AnalogOutputInt16>();
+                for each(auto pair in commands)
+                {
+                    header.Add(Conversions::ConvertCommand(pair->Value), pair->Index);
+                }
+            }
 
-			void CommandSetBuilder::Add(IEnumerable<IndexedValue<AnalogOutputInt32^>^>^ commands)
-			{
-				auto& header = this->commands->StartHeader<opendnp3::AnalogOutputInt32>();
-				for each(auto pair in commands)
-				{
-					header.Add(Conversions::ConvertCommand(pair->Value), pair->Index);
-				}
-			}
+            void CommandSetBuilder::Add(IEnumerable<IndexedValue<AnalogOutputInt32^>^>^ commands)
+            {
+                auto& header = this->commands->StartHeader<opendnp3::AnalogOutputInt32>();
+                for each(auto pair in commands)
+                {
+                    header.Add(Conversions::ConvertCommand(pair->Value), pair->Index);
+                }
+            }
 
-			void CommandSetBuilder::Add(IEnumerable<IndexedValue<AnalogOutputFloat32^>^>^ commands)
-			{
-				auto& header = this->commands->StartHeader<opendnp3::AnalogOutputFloat32>();
-				for each(auto pair in commands)
-				{
-					header.Add(Conversions::ConvertCommand(pair->Value), pair->Index);
-				}
-			}
+            void CommandSetBuilder::Add(IEnumerable<IndexedValue<AnalogOutputFloat32^>^>^ commands)
+            {
+                auto& header = this->commands->StartHeader<opendnp3::AnalogOutputFloat32>();
+                for each(auto pair in commands)
+                {
+                    header.Add(Conversions::ConvertCommand(pair->Value), pair->Index);
+                }
+            }
 
-			void CommandSetBuilder::Add(IEnumerable<IndexedValue<AnalogOutputDouble64^>^>^ commands)
-			{
-				auto& header = this->commands->StartHeader<opendnp3::AnalogOutputDouble64>();
-				for each(auto pair in commands)
-				{
-					header.Add(Conversions::ConvertCommand(pair->Value), pair->Index);
-				}
-			}
+            void CommandSetBuilder::Add(IEnumerable<IndexedValue<AnalogOutputDouble64^>^>^ commands)
+            {
+                auto& header = this->commands->StartHeader<opendnp3::AnalogOutputDouble64>();
+                for each(auto pair in commands)
+                {
+                    header.Add(Conversions::ConvertCommand(pair->Value), pair->Index);
+                }
+            }
 
-		}
-	}
+        }
+    }
 }

--- a/dotnet/CLRAdapter/src/CommandSetBuilder.h
+++ b/dotnet/CLRAdapter/src/CommandSetBuilder.h
@@ -29,30 +29,30 @@ using namespace System::Collections::Generic;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private ref class CommandSetBuilder : ICommandBuilder
-			{
-			public:
+            private ref class CommandSetBuilder : ICommandBuilder
+            {
+            public:
 
-				CommandSetBuilder(opendnp3::CommandSet& commands);
+                CommandSetBuilder(opendnp3::CommandSet& commands);
 
-				virtual void Add(IEnumerable<IndexedValue<ControlRelayOutputBlock^>^>^ commands);
-				virtual void Add(IEnumerable<IndexedValue<AnalogOutputInt16^>^>^ commands);
-				virtual void Add(IEnumerable<IndexedValue<AnalogOutputInt32^>^>^ commands);
-				virtual void Add(IEnumerable<IndexedValue<AnalogOutputFloat32^>^>^ commands);
-				virtual void Add(IEnumerable<IndexedValue<AnalogOutputDouble64^>^>^ commands);
+                virtual void Add(IEnumerable<IndexedValue<ControlRelayOutputBlock^>^>^ commands);
+                virtual void Add(IEnumerable<IndexedValue<AnalogOutputInt16^>^>^ commands);
+                virtual void Add(IEnumerable<IndexedValue<AnalogOutputInt32^>^>^ commands);
+                virtual void Add(IEnumerable<IndexedValue<AnalogOutputFloat32^>^>^ commands);
+                virtual void Add(IEnumerable<IndexedValue<AnalogOutputDouble64^>^>^ commands);
 
-			private:
+            private:
 
-				opendnp3::CommandSet* commands;
-			};
+                opendnp3::CommandSet* commands;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/Conversions.h
+++ b/dotnet/CLRAdapter/src/Conversions.h
@@ -58,133 +58,133 @@ using namespace System::Collections::Generic;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private class Conversions
-			{
-			public:
+            private class Conversions
+            {
+            public:
 
-				static opendnp3::TimeDuration ConvertMilliseconds(System::Int64 ms);
+                static opendnp3::TimeDuration ConvertMilliseconds(System::Int64 ms);
 
-				static opendnp3::TimeDuration ConvertTimespan(System::TimeSpan ts);
+                static opendnp3::TimeDuration ConvertTimespan(System::TimeSpan ts);
 
-				static System::TimeSpan ConvertTimeDuration(const opendnp3::TimeDuration& duration);				
+                static System::TimeSpan ConvertTimeDuration(const opendnp3::TimeDuration& duration);
 
-				static opendnp3::ClassField ConvertClassField(ClassField classField);
+                static opendnp3::ClassField ConvertClassField(ClassField classField);
 
-				static opendnp3::TLSConfig Convert(Automatak::DNP3::Interface::TLSConfig^ config);
+                static opendnp3::TLSConfig Convert(Automatak::DNP3::Interface::TLSConfig^ config);
 
-				// Convert a .NET string to a C++ string
-				static std::string ConvertString(System::String^ s);
-				static System::String^ ConvertString(const std::string& s);
+                // Convert a .NET string to a C++ string
+                static std::string ConvertString(System::String^ s);
+                static System::String^ ConvertString(const std::string& s);
 
-				// Converting channel state enumeration
-				static ChannelState ConvertChannelState(opendnp3::ChannelState aState);
+                // Converting channel state enumeration
+                static ChannelState ConvertChannelState(opendnp3::ChannelState aState);
 
-				static LinkStatus ConvertLinkStatus(opendnp3::LinkStatus aState);
+                static LinkStatus ConvertLinkStatus(opendnp3::LinkStatus aState);
 
-				static IChannelStatistics^ ConvertChannelStats(const opendnp3::LinkStatistics& statistics);
+                static IChannelStatistics^ ConvertChannelStats(const opendnp3::LinkStatistics& statistics);
 
-				static IStackStatistics^ ConvertStackStats(const opendnp3::StackStatistics& statistics);
+                static IStackStatistics^ ConvertStackStats(const opendnp3::StackStatistics& statistics);
 
-				// Convert the command status enumeration
-				static CommandStatus ConvertCommandStatus(opendnp3::CommandStatus status);
-				static opendnp3::CommandStatus ConvertCommandStatus(CommandStatus status);				
+                // Convert the command status enumeration
+                static CommandStatus ConvertCommandStatus(opendnp3::CommandStatus status);
+                static opendnp3::CommandStatus ConvertCommandStatus(CommandStatus status);
 
-				static CommandTaskResult^ ConvertCommandTaskResult(const opendnp3::ICommandTaskResult& result);
+                static CommandTaskResult^ ConvertCommandTaskResult(const opendnp3::ICommandTaskResult& result);
 
-				//functions for Converting binary outputs
+                //functions for Converting binary outputs
 
-				static ControlRelayOutputBlock^ ConvertCommand(const opendnp3::ControlRelayOutputBlock& bo);
-				static opendnp3::ControlRelayOutputBlock ConvertCommand(ControlRelayOutputBlock^ bo);
+                static ControlRelayOutputBlock^ ConvertCommand(const opendnp3::ControlRelayOutputBlock& bo);
+                static opendnp3::ControlRelayOutputBlock ConvertCommand(ControlRelayOutputBlock^ bo);
 
-				//functions for Converting setpoints
+                //functions for Converting setpoints
 
-				static opendnp3::AnalogOutputInt32 ConvertCommand(AnalogOutputInt32^ sp);
-				static AnalogOutputInt32^ ConvertCommand(const opendnp3::AnalogOutputInt32& sp);
+                static opendnp3::AnalogOutputInt32 ConvertCommand(AnalogOutputInt32^ sp);
+                static AnalogOutputInt32^ ConvertCommand(const opendnp3::AnalogOutputInt32& sp);
 
-				static opendnp3::AnalogOutputInt16 ConvertCommand(AnalogOutputInt16^ sp);
-				static AnalogOutputInt16^ ConvertCommand(const opendnp3::AnalogOutputInt16& sp);
+                static opendnp3::AnalogOutputInt16 ConvertCommand(AnalogOutputInt16^ sp);
+                static AnalogOutputInt16^ ConvertCommand(const opendnp3::AnalogOutputInt16& sp);
 
-				static opendnp3::AnalogOutputFloat32 ConvertCommand(AnalogOutputFloat32^ sp);
-				static AnalogOutputFloat32^ ConvertCommand(const opendnp3::AnalogOutputFloat32& sp);
+                static opendnp3::AnalogOutputFloat32 ConvertCommand(AnalogOutputFloat32^ sp);
+                static AnalogOutputFloat32^ ConvertCommand(const opendnp3::AnalogOutputFloat32& sp);
 
-				static opendnp3::AnalogOutputDouble64 ConvertCommand(AnalogOutputDouble64^ sp);
-				static AnalogOutputDouble64^ ConvertCommand(const opendnp3::AnalogOutputDouble64& sp);
+                static opendnp3::AnalogOutputDouble64 ConvertCommand(AnalogOutputDouble64^ sp);
+                static AnalogOutputDouble64^ ConvertCommand(const opendnp3::AnalogOutputDouble64& sp);
 
-				//functions for Converting Measurement types
-				static Binary^ ConvertMeas(opendnp3::Binary meas);
-				static DoubleBitBinary^ ConvertMeas(opendnp3::DoubleBitBinary meas);
-				static Analog^ ConvertMeas(opendnp3::Analog meas);
-				static Counter^ ConvertMeas(opendnp3::Counter meas);
-				static FrozenCounter^ ConvertMeas(opendnp3::FrozenCounter meas);
-				static AnalogOutputStatus^ ConvertMeas(opendnp3::AnalogOutputStatus meas);
-				static BinaryOutputStatus^ ConvertMeas(opendnp3::BinaryOutputStatus meas);
-				static OctetString^ Conversions::ConvertMeas(const opendnp3::OctetString& meas);
-				static TimeAndInterval^ Conversions::ConvertMeas(const opendnp3::TimeAndInterval& meas);
-				static BinaryCommandEvent^ Conversions::ConvertMeas(const opendnp3::BinaryCommandEvent& meas);
-				static AnalogCommandEvent^ Conversions::ConvertMeas(const opendnp3::AnalogCommandEvent& meas);				
+                //functions for Converting Measurement types
+                static Binary^ ConvertMeas(opendnp3::Binary meas);
+                static DoubleBitBinary^ ConvertMeas(opendnp3::DoubleBitBinary meas);
+                static Analog^ ConvertMeas(opendnp3::Analog meas);
+                static Counter^ ConvertMeas(opendnp3::Counter meas);
+                static FrozenCounter^ ConvertMeas(opendnp3::FrozenCounter meas);
+                static AnalogOutputStatus^ ConvertMeas(opendnp3::AnalogOutputStatus meas);
+                static BinaryOutputStatus^ ConvertMeas(opendnp3::BinaryOutputStatus meas);
+                static OctetString^ Conversions::ConvertMeas(const opendnp3::OctetString& meas);
+                static TimeAndInterval^ Conversions::ConvertMeas(const opendnp3::TimeAndInterval& meas);
+                static BinaryCommandEvent^ Conversions::ConvertMeas(const opendnp3::BinaryCommandEvent& meas);
+                static AnalogCommandEvent^ Conversions::ConvertMeas(const opendnp3::AnalogCommandEvent& meas);
 
-				static opendnp3::DNPTime ConvertTime(DNPTime^ time);
+                static opendnp3::DNPTime ConvertTime(DNPTime^ time);
                 static DNPTime^ ConvertTime(opendnp3::DNPTime time);
 
-				static opendnp3::Binary ConvertMeas(Binary^ meas);
-				static opendnp3::DoubleBitBinary ConvertMeas(DoubleBitBinary^ meas);
-				static opendnp3::Analog ConvertMeas(Analog^ meas);
-				static opendnp3::Counter ConvertMeas(Counter^ meas);
-				static opendnp3::FrozenCounter ConvertMeas(FrozenCounter^ meas);
-				static opendnp3::AnalogOutputStatus ConvertMeas(AnalogOutputStatus^ meas);
-				static opendnp3::BinaryOutputStatus ConvertMeas(BinaryOutputStatus^ meas);
-				static opendnp3::TimeAndInterval ConvertMeas(TimeAndInterval^ meas);
-				static opendnp3::OctetString ConvertMeas(OctetString^ meas);
-				static opendnp3::BinaryCommandEvent ConvertMeas(BinaryCommandEvent^ meas);
-				static opendnp3::AnalogCommandEvent ConvertMeas(AnalogCommandEvent^ meas);
+                static opendnp3::Binary ConvertMeas(Binary^ meas);
+                static opendnp3::DoubleBitBinary ConvertMeas(DoubleBitBinary^ meas);
+                static opendnp3::Analog ConvertMeas(Analog^ meas);
+                static opendnp3::Counter ConvertMeas(Counter^ meas);
+                static opendnp3::FrozenCounter ConvertMeas(FrozenCounter^ meas);
+                static opendnp3::AnalogOutputStatus ConvertMeas(AnalogOutputStatus^ meas);
+                static opendnp3::BinaryOutputStatus ConvertMeas(BinaryOutputStatus^ meas);
+                static opendnp3::TimeAndInterval ConvertMeas(TimeAndInterval^ meas);
+                static opendnp3::OctetString ConvertMeas(OctetString^ meas);
+                static opendnp3::BinaryCommandEvent ConvertMeas(BinaryCommandEvent^ meas);
+                static opendnp3::AnalogCommandEvent ConvertMeas(AnalogCommandEvent^ meas);
 
-				static LinkHeader^ Conversions::Convert(const opendnp3::LinkHeaderFields& fields);
-				static opendnp3::IPEndpoint Convert(IPEndpoint^ endpoint);
+                static LinkHeader^ Conversions::Convert(const opendnp3::LinkHeaderFields& fields);
+                static opendnp3::IPEndpoint Convert(IPEndpoint^ endpoint);
 
-				static X509Info^ Convert(const opendnp3::X509Info& info);
+                static X509Info^ Convert(const opendnp3::X509Info& info);
 
-				//Convert the configuration types
-				static opendnp3::SerialSettings ConvertSerialSettings(SerialSettings^ settings);
-				static opendnp3::EventBufferConfig ConvertConfig(EventBufferConfig^ cm);
+                //Convert the configuration types
+                static opendnp3::SerialSettings ConvertSerialSettings(SerialSettings^ settings);
+                static opendnp3::EventBufferConfig ConvertConfig(EventBufferConfig^ cm);
 
-				static opendnp3::LinkConfig ConvertConfig(LinkConfig^ config);
-				static opendnp3::MasterParams ConvertConfig(MasterConfig^ config);
-				static opendnp3::OutstationConfig ConvertConfig(OutstationConfig^ config);
-				static opendnp3::OutstationParams ConvertConfig(OutstationParams^ config);
-				static opendnp3::MasterStackConfig ConvertConfig(MasterStackConfig^ config);
-				static opendnp3::OutstationStackConfig ConvertConfig(OutstationStackConfig^ config);
+                static opendnp3::LinkConfig ConvertConfig(LinkConfig^ config);
+                static opendnp3::MasterParams ConvertConfig(MasterConfig^ config);
+                static opendnp3::OutstationConfig ConvertConfig(OutstationConfig^ config);
+                static opendnp3::OutstationParams ConvertConfig(OutstationParams^ config);
+                static opendnp3::MasterStackConfig ConvertConfig(MasterStackConfig^ config);
+                static opendnp3::OutstationStackConfig ConvertConfig(OutstationStackConfig^ config);
                 static opendnp3::NumRetries ConvertNumRetries(NumRetries^ numRetries);
 
-				static opendnp3::PointClass Convert(PointClass clazz);
-				static array<System::Byte>^ Convert(const opendnp3::Buffer& bytes);
+                static opendnp3::PointClass Convert(PointClass clazz);
+                static array<System::Byte>^ Convert(const opendnp3::Buffer& bytes);
 
-				template <class Target, class Source>
-				static IndexedValue<Target>^ ConvertIndexValue(const opendnp3::Indexed<Source>& pair)
-				{
-					return gcnew IndexedValue<Target>(ConvertMeas(pair.value), pair.index);
-				}
+                template <class Target, class Source>
+                static IndexedValue<Target>^ ConvertIndexValue(const opendnp3::Indexed<Source>& pair)
+                {
+                    return gcnew IndexedValue<Target>(ConvertMeas(pair.value), pair.index);
+                }
 
-				template <class Target, class Source>
-				static IEnumerable<IndexedValue<Target>^>^ ToIndexedEnumerable(const opendnp3::ICollection<opendnp3::Indexed<Source>>& values)
-				{
-					auto convert = [](const opendnp3::Indexed <Source> &value) -> IndexedValue<Target>^ {
-						return ConvertIndexValue<Target, Source>(value);
-					};
+                template <class Target, class Source>
+                static IEnumerable<IndexedValue<Target>^>^ ToIndexedEnumerable(const opendnp3::ICollection<opendnp3::Indexed<Source>>& values)
+                {
+                    auto convert = [](const opendnp3::Indexed <Source> &value) -> IndexedValue<Target>^ {
+                        return ConvertIndexValue<Target, Source>(value);
+                    };
 
-					auto adapter = CreateAdapter<opendnp3::Indexed<Source>, IndexedValue<Target>^>(convert);
+                    auto adapter = CreateAdapter<opendnp3::Indexed<Source>, IndexedValue<Target>^>(convert);
 
-					values.Foreach(adapter);
-					return adapter.GetValues();
-				}
+                    values.Foreach(adapter);
+                    return adapter.GetValues();
+                }
 
-				private:
+                private:
 
-					static opendnp3::DatabaseConfig Convert(DatabaseTemplate^ lhs);
+                    static opendnp3::DatabaseConfig Convert(DatabaseTemplate^ lhs);
 
                     static opendnp3::BinaryConfig ConvertPointConfig(BinaryConfig^ config) {
                         return ConvertEventConfig<opendnp3::BinaryInfo, opendnp3::BinaryConfig>(config);
@@ -220,7 +220,7 @@ namespace Automatak
                         return ret;
                     }
 
-                    static opendnp3::OctetStringConfig ConvertPointConfig(OctetStringConfig^ config) {                        
+                    static opendnp3::OctetStringConfig ConvertPointConfig(OctetStringConfig^ config) {
                         return ConvertEventConfig<opendnp3::OctetStringInfo, opendnp3::OctetStringConfig>(config);
                     }
 
@@ -244,19 +244,19 @@ namespace Automatak
 
                     }
 
-					template <class Target, class Source>
+                    template <class Target, class Source>
                     static std::map<uint16_t, Target> ConvertConfigMap(System::Collections::Generic::IDictionary<System::UInt16, Source^>^ source)
-					{
+                    {
                         std::map<uint16_t, Target> ret;
                         for each(KeyValuePair<System::UInt16, Source^>^ kvp in source) {
-                            ret[kvp->Key] = ConvertPointConfig(kvp->Value);                            
+                            ret[kvp->Key] = ConvertPointConfig(kvp->Value);
                         }
                         return ret;
-					}					
-			};
+                    }
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/DNP3ManagerAdapter.cpp
+++ b/dotnet/CLRAdapter/src/DNP3ManagerAdapter.cpp
@@ -30,42 +30,42 @@
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			IDNP3Manager^ DNP3ManagerFactory::CreateManager(System::Int32 concurrency, ILogHandler^ logHandler)
-			{
-				return gcnew DNP3ManagerAdapter(concurrency, logHandler);
-			}
+            IDNP3Manager^ DNP3ManagerFactory::CreateManager(System::Int32 concurrency, ILogHandler^ logHandler)
+            {
+                return gcnew DNP3ManagerAdapter(concurrency, logHandler);
+            }
 
-			IDNP3Manager^ DNP3ManagerFactory::CreateManager(ILogHandler^ logHandler)
-			{
-				return gcnew DNP3ManagerAdapter(Environment::ProcessorCount, logHandler);
-			}
+            IDNP3Manager^ DNP3ManagerFactory::CreateManager(ILogHandler^ logHandler)
+            {
+                return gcnew DNP3ManagerAdapter(Environment::ProcessorCount, logHandler);
+            }
 
 
-			DNP3ManagerAdapter::DNP3ManagerAdapter(System::Int32 concurrency, ILogHandler^ logHandler) :
-				manager(new opendnp3::DNP3Manager(concurrency, LogAdapter::Create(logHandler)))				
-			{
+            DNP3ManagerAdapter::DNP3ManagerAdapter(System::Int32 concurrency, ILogHandler^ logHandler) :
+                manager(new opendnp3::DNP3Manager(concurrency, LogAdapter::Create(logHandler)))				
+            {
 
-			}
+            }
 
-			DNP3ManagerAdapter::!DNP3ManagerAdapter()
-			{
-				delete manager;
-			}
+            DNP3ManagerAdapter::!DNP3ManagerAdapter()
+            {
+                delete manager;
+            }
 
-			DNP3ManagerAdapter::~DNP3ManagerAdapter()
-			{
-				this->!DNP3ManagerAdapter();
-			}
+            DNP3ManagerAdapter::~DNP3ManagerAdapter()
+            {
+                this->!DNP3ManagerAdapter();
+            }
 
-			void DNP3ManagerAdapter::Shutdown()
-			{
-				manager->Shutdown();
-			}
+            void DNP3ManagerAdapter::Shutdown()
+            {
+                manager->Shutdown();
+            }
 
             IChannel^ DNP3ManagerAdapter::AddTCPClient(System::String^ id, System::UInt32 filters, Interface::ChannelRetry^ retry, System::Collections::Generic::IList<Interface::IPEndpoint^>^ remotes, Automatak::DNP3::Interface::IChannelListener^ listener)
             {
@@ -92,12 +92,12 @@ namespace Automatak
                 }
             }
 
-			IChannel^ DNP3ManagerAdapter::AddTCPServer(System::String^ id, System::UInt32 filters, Interface::ServerAcceptMode mode, Interface::IPEndpoint^ endpoint, Automatak::DNP3::Interface::IChannelListener^ listener)
-			{
-				std::string stdName = Conversions::ConvertString(id);
+            IChannel^ DNP3ManagerAdapter::AddTCPServer(System::String^ id, System::UInt32 filters, Interface::ServerAcceptMode mode, Interface::IPEndpoint^ endpoint, Automatak::DNP3::Interface::IChannelListener^ listener)
+            {
+                std::string stdName = Conversions::ConvertString(id);
                 auto stdEndpoint = Conversions::Convert(endpoint);
 
-				auto listenAdapter = listener
+                auto listenAdapter = listener
                     ? std::shared_ptr<opendnp3::IChannelListener>(new ChannelListenerAdapter(listener))
                     : nullptr;
 
@@ -111,7 +111,7 @@ namespace Automatak
                 {
                     throw gcnew DNP3Exception(Conversions::ConvertString(e.what()));
                 }
-			}
+            }
 
             IChannel^ DNP3ManagerAdapter::AddUDPChannel(System::String^ id, System::UInt32 filters, Interface::ChannelRetry^ retry, Interface::IPEndpoint^ localEndpoint, Interface::IPEndpoint^ remoteEndpoint, Interface::IChannelListener^ listener)
             {
@@ -149,7 +149,7 @@ namespace Automatak
                     ? std::shared_ptr<opendnp3::IChannelListener>(new ChannelListenerAdapter(listener))
                     : nullptr;
 
-				try
+                try
                 {
                     auto channel = this->manager->AddTLSClient(stdName.c_str(), opendnp3::LogLevel(filters), Convert(retry),
                                                                endpoints, "", Conversions::Convert(config), listenAdapter);
@@ -158,56 +158,56 @@ namespace Automatak
                 catch (opendnp3::DNP3Error e)
                 {
                     throw gcnew DNP3Exception(Conversions::ConvertString(e.what()));
-				}
+                }
             }
-			
-			IChannel^ DNP3ManagerAdapter::AddTLSServer(System::String^ id, System::UInt32 filters, Interface::ServerAcceptMode mode, Interface::IPEndpoint^ endpoint, Automatak::DNP3::Interface::TLSConfig^ config, Automatak::DNP3::Interface::IChannelListener^ listener)
-			{
-				std::string stdName = Conversions::ConvertString(id);
+            
+            IChannel^ DNP3ManagerAdapter::AddTLSServer(System::String^ id, System::UInt32 filters, Interface::ServerAcceptMode mode, Interface::IPEndpoint^ endpoint, Automatak::DNP3::Interface::TLSConfig^ config, Automatak::DNP3::Interface::IChannelListener^ listener)
+            {
+                std::string stdName = Conversions::ConvertString(id);
                 auto stdEndpoint = Conversions::Convert(endpoint);
 
-				auto listenAdapter = listener
+                auto listenAdapter = listener
                     ? std::shared_ptr<opendnp3::IChannelListener>(new ChannelListenerAdapter(listener))
                     : nullptr;
-				
+                
                 try
                 {
                     auto channel = this->manager->AddTLSServer(stdName.c_str(), opendnp3::LogLevel(filters), (opendnp3::ServerAcceptMode) mode, stdEndpoint, Conversions::Convert(config), listenAdapter);
-					return gcnew ChannelAdapter(channel);
-				}
+                    return gcnew ChannelAdapter(channel);
+                }
                 catch (opendnp3::DNP3Error e)
                 {
                     throw gcnew DNP3Exception(Conversions::ConvertString(e.what()));
                 }
-			}
+            }
 
-			IChannel^ DNP3ManagerAdapter::AddSerial(System::String^ id, System::UInt32 filters, Interface::ChannelRetry^ retry, Automatak::DNP3::Interface::SerialSettings^ settings, Automatak::DNP3::Interface::IChannelListener^ listener)
-			{
-				std::string stdName = Conversions::ConvertString(id);
-				auto s = Conversions::ConvertSerialSettings(settings);				
+            IChannel^ DNP3ManagerAdapter::AddSerial(System::String^ id, System::UInt32 filters, Interface::ChannelRetry^ retry, Automatak::DNP3::Interface::SerialSettings^ settings, Automatak::DNP3::Interface::IChannelListener^ listener)
+            {
+                std::string stdName = Conversions::ConvertString(id);
+                auto s = Conversions::ConvertSerialSettings(settings);				
 
-				auto listenAdapter = listener
+                auto listenAdapter = listener
                     ? std::shared_ptr<opendnp3::IChannelListener>(new ChannelListenerAdapter(listener))
                     : nullptr;
-				
+                
                 try
                 {
                     auto channel = this->manager->AddSerial(stdName.c_str(), opendnp3::LogLevel(filters),
                                                             Convert(retry), s, listenAdapter);
                     return gcnew ChannelAdapter(channel);
                 }
-				catch (opendnp3::DNP3Error e)
+                catch (opendnp3::DNP3Error e)
                 {
                     throw gcnew DNP3Exception(Conversions::ConvertString(e.what()));
                 }
-			}
+            }
 
-			Interface::IListener^ DNP3ManagerAdapter::CreateListener(System::String^ loggerid, System::UInt32 filters, Interface::IPEndpoint^ endpoint, IListenCallbacks^ callbacks)
-			{
-				auto id = Conversions::ConvertString(loggerid);
+            Interface::IListener^ DNP3ManagerAdapter::CreateListener(System::String^ loggerid, System::UInt32 filters, Interface::IPEndpoint^ endpoint, IListenCallbacks^ callbacks)
+            {
+                auto id = Conversions::ConvertString(loggerid);
                 auto levels = opendnp3::LogLevel(filters);
-				auto ep = Conversions::Convert(endpoint);
-				auto cb = std::shared_ptr<opendnp3::IListenCallbacks>(new ListenCallbacksAdapter(callbacks));
+                auto ep = Conversions::Convert(endpoint);
+                auto cb = std::shared_ptr<opendnp3::IListenCallbacks>(new ListenCallbacksAdapter(callbacks));
 
                 try
                 {
@@ -218,15 +218,15 @@ namespace Automatak
                 {
                     throw gcnew DNP3Exception(Conversions::ConvertString(e.what()));
                 }
-			}
+            }
 
-			Interface::IListener^ DNP3ManagerAdapter::CreateListener(System::String^ loggerid, System::UInt32 filters, Interface::IPEndpoint^ endpoint, Interface::TLSConfig^ config, IListenCallbacks^ callbacks)
-			{
-				auto id = Conversions::ConvertString(loggerid);
+            Interface::IListener^ DNP3ManagerAdapter::CreateListener(System::String^ loggerid, System::UInt32 filters, Interface::IPEndpoint^ endpoint, Interface::TLSConfig^ config, IListenCallbacks^ callbacks)
+            {
+                auto id = Conversions::ConvertString(loggerid);
                 auto levels = opendnp3::LogLevel(filters);
-				auto ep = Conversions::Convert(endpoint);
-				auto tlsConfig = Conversions::Convert(config);
-				auto cb = std::shared_ptr<opendnp3::IListenCallbacks>(new ListenCallbacksAdapter(callbacks));
+                auto ep = Conversions::Convert(endpoint);
+                auto tlsConfig = Conversions::Convert(config);
+                auto cb = std::shared_ptr<opendnp3::IListenCallbacks>(new ListenCallbacksAdapter(callbacks));
 
                 try
                 {
@@ -237,14 +237,14 @@ namespace Automatak
                 {
                     throw gcnew DNP3Exception(Conversions::ConvertString(e.what()));
                 }
-			}
+            }
 
-			opendnp3::ChannelRetry DNP3ManagerAdapter::Convert(Interface::ChannelRetry ^ retry)
-			{
+            opendnp3::ChannelRetry DNP3ManagerAdapter::Convert(Interface::ChannelRetry ^ retry)
+            {
                 return opendnp3::ChannelRetry(Conversions::ConvertTimespan(retry->minRetryDelay),
                                               Conversions::ConvertTimespan(retry->maxRetryDelay),
                                               Conversions::ConvertTimespan(retry->reconnectDelay));
-			}
-		}
-	}
+            }
+        }
+    }
 }

--- a/dotnet/CLRAdapter/src/DNP3ManagerAdapter.h
+++ b/dotnet/CLRAdapter/src/DNP3ManagerAdapter.h
@@ -29,73 +29,73 @@ using namespace System;
 
 namespace opendnp3
 {
-	class DNP3Manager;
+    class DNP3Manager;
 }
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			/// <summary>
-			/// Factory class used to get the root DNP3 object
-			/// </summary>
-			public ref class DNP3ManagerFactory
-			{
-			public:
-				/// <summary>
-				/// Create a new IDNP3Manager using the specified concurrency
-				/// </summary>
-				/// <param name="concurrency">how many threads are allocated to the thread pool</param>
-				
-				/// <returns>IDNP3Manager interface</returns>
-				static IDNP3Manager^ CreateManager(System::Int32 concurrency, ILogHandler^ logHandler);
+            /// <summary>
+            /// Factory class used to get the root DNP3 object
+            /// </summary>
+            public ref class DNP3ManagerFactory
+            {
+            public:
+                /// <summary>
+                /// Create a new IDNP3Manager using the specified concurrency
+                /// </summary>
+                /// <param name="concurrency">how many threads are allocated to the thread pool</param>
+                
+                /// <returns>IDNP3Manager interface</returns>
+                static IDNP3Manager^ CreateManager(System::Int32 concurrency, ILogHandler^ logHandler);
 
-				/// <summary>
-				/// Create a new IDNP3Manager using the default concurrency
-				/// </summary>
-				/// <param name="logHandler">Callback interface for log messages</param>
-				/// <returns>IDNP3Manager interface</returns>
-				static IDNP3Manager^ CreateManager(ILogHandler^ logHandler);
+                /// <summary>
+                /// Create a new IDNP3Manager using the default concurrency
+                /// </summary>
+                /// <param name="logHandler">Callback interface for log messages</param>
+                /// <returns>IDNP3Manager interface</returns>
+                static IDNP3Manager^ CreateManager(ILogHandler^ logHandler);
 
-			private:
-				DNP3ManagerFactory() {}
-			};
+            private:
+                DNP3ManagerFactory() {}
+            };
 
-			ref class DNP3ManagerAdapter : public Automatak::DNP3::Interface::IDNP3Manager
-			{
-			public:
+            ref class DNP3ManagerAdapter : public Automatak::DNP3::Interface::IDNP3Manager
+            {
+            public:
 
-				DNP3ManagerAdapter(System::Int32 concurrency, ILogHandler^ logHandler);
-				!DNP3ManagerAdapter();
-				~DNP3ManagerAdapter();
+                DNP3ManagerAdapter(System::Int32 concurrency, ILogHandler^ logHandler);
+                !DNP3ManagerAdapter();
+                ~DNP3ManagerAdapter();
 
-				virtual void Shutdown() sealed;
+                virtual void Shutdown() sealed;
 
-				virtual IChannel^ AddTCPClient(System::String^ id, System::UInt32 filters, Interface::ChannelRetry^ retry, System::Collections::Generic::IList<Interface::IPEndpoint^>^ remotes, Interface::IChannelListener^ listener)  sealed;
-				virtual IChannel^ AddTCPServer(System::String^ id, System::UInt32 filters, Interface::ServerAcceptMode mode, Interface::IPEndpoint^ endpoint, Interface::IChannelListener^ listener) sealed;
+                virtual IChannel^ AddTCPClient(System::String^ id, System::UInt32 filters, Interface::ChannelRetry^ retry, System::Collections::Generic::IList<Interface::IPEndpoint^>^ remotes, Interface::IChannelListener^ listener)  sealed;
+                virtual IChannel^ AddTCPServer(System::String^ id, System::UInt32 filters, Interface::ServerAcceptMode mode, Interface::IPEndpoint^ endpoint, Interface::IChannelListener^ listener) sealed;
                 virtual IChannel^ AddUDPChannel(System::String^ id, System::UInt32 filters, Interface::ChannelRetry^ retry, Interface::IPEndpoint^ localEndpoint, Interface::IPEndpoint^ remoteEndpoint, Interface::IChannelListener^ listener);
 
-				virtual IChannel^ AddTLSClient(System::String^ id, System::UInt32 filters, Interface::ChannelRetry^ retry, System::Collections::Generic::IList<Interface::IPEndpoint^>^ remotes, Interface::TLSConfig^ config, Interface::IChannelListener^ listener)  sealed;
-				virtual IChannel^ AddTLSServer(System::String^ id, System::UInt32 filters, Interface::ServerAcceptMode mode, Interface::IPEndpoint^ endpoint, Interface::TLSConfig^ config, Interface::IChannelListener^ listener) sealed;
-				
-				virtual IChannel^ AddSerial(System::String^ id, System::UInt32 filters, Interface::ChannelRetry^ retry, Automatak::DNP3::Interface::SerialSettings^ settings, Interface::IChannelListener^ listener) sealed;
+                virtual IChannel^ AddTLSClient(System::String^ id, System::UInt32 filters, Interface::ChannelRetry^ retry, System::Collections::Generic::IList<Interface::IPEndpoint^>^ remotes, Interface::TLSConfig^ config, Interface::IChannelListener^ listener)  sealed;
+                virtual IChannel^ AddTLSServer(System::String^ id, System::UInt32 filters, Interface::ServerAcceptMode mode, Interface::IPEndpoint^ endpoint, Interface::TLSConfig^ config, Interface::IChannelListener^ listener) sealed;
+                
+                virtual IChannel^ AddSerial(System::String^ id, System::UInt32 filters, Interface::ChannelRetry^ retry, Automatak::DNP3::Interface::SerialSettings^ settings, Interface::IChannelListener^ listener) sealed;
 
-				virtual Interface::IListener^ CreateListener(System::String^ loggerid, System::UInt32 filters, Interface::IPEndpoint^ endpoint, IListenCallbacks^ callbacks) sealed;
+                virtual Interface::IListener^ CreateListener(System::String^ loggerid, System::UInt32 filters, Interface::IPEndpoint^ endpoint, IListenCallbacks^ callbacks) sealed;
 
-				virtual Interface::IListener^ CreateListener(System::String^ loggerid, System::UInt32 filters, Interface::IPEndpoint^ endpoint, Interface::TLSConfig^ config, IListenCallbacks^ callbacks) sealed;
+                virtual Interface::IListener^ CreateListener(System::String^ loggerid, System::UInt32 filters, Interface::IPEndpoint^ endpoint, Interface::TLSConfig^ config, IListenCallbacks^ callbacks) sealed;
 
-			private:
+            private:
 
-				opendnp3::DNP3Manager* manager;
+                opendnp3::DNP3Manager* manager;
 
-				static opendnp3::ChannelRetry Convert(Interface::ChannelRetry^ retry);
-			};
+                static opendnp3::ChannelRetry Convert(Interface::ChannelRetry^ retry);
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/DatabaseAdapter.h
+++ b/dotnet/CLRAdapter/src/DatabaseAdapter.h
@@ -28,32 +28,32 @@ using namespace Automatak::DNP3::Interface;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
             template <class T>
-			private ref class DatabaseAdapter: public Automatak::DNP3::Interface::IDatabase
-			{
-			public:
+            private ref class DatabaseAdapter: public Automatak::DNP3::Interface::IDatabase
+            {
+            public:
 
-				DatabaseAdapter(T* handler);
-				
-				virtual void Update(Binary^ update, System::UInt16 index, EventMode mode);
-				virtual void Update(DoubleBitBinary^ update, System::UInt16 index, EventMode mode);				
-				virtual void Update(Analog^ update, System::UInt16 index, EventMode mode);
-				virtual void Update(Counter^ update, System::UInt16 index, EventMode mode);
+                DatabaseAdapter(T* handler);
+                
+                virtual void Update(Binary^ update, System::UInt16 index, EventMode mode);
+                virtual void Update(DoubleBitBinary^ update, System::UInt16 index, EventMode mode);				
+                virtual void Update(Analog^ update, System::UInt16 index, EventMode mode);
+                virtual void Update(Counter^ update, System::UInt16 index, EventMode mode);
                 virtual void FreezeCounter(System::UInt16 index, System::Boolean clear, EventMode mode);
-				virtual void Update(BinaryOutputStatus^ update, System::UInt16 index, EventMode mode);
-				virtual void Update(AnalogOutputStatus^ update, System::UInt16 index, EventMode mode);
-				virtual void Update(OctetString^ update, System::UInt16 index, EventMode mode);
-				virtual void Update(TimeAndInterval^ update, System::UInt16 index);								
-				
-			protected:
-				
-				T* handler;
-			};
+                virtual void Update(BinaryOutputStatus^ update, System::UInt16 index, EventMode mode);
+                virtual void Update(AnalogOutputStatus^ update, System::UInt16 index, EventMode mode);
+                virtual void Update(OctetString^ update, System::UInt16 index, EventMode mode);
+                virtual void Update(TimeAndInterval^ update, System::UInt16 index);								
+                
+            protected:
+                
+                T* handler;
+            };
 
             template<class T> DatabaseAdapter<T>::DatabaseAdapter(T* handler) : handler(handler) {}
 
@@ -110,8 +110,8 @@ namespace Automatak
                 handler->Update(Conversions::ConvertMeas(update), index);
             }
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/EventConverter.h
+++ b/dotnet/CLRAdapter/src/EventConverter.h
@@ -29,49 +29,49 @@ using namespace System::Collections::ObjectModel;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			template <class T, class U>
-			private class EventConverter
-			{
-			public:
+            template <class T, class U>
+            private class EventConverter
+            {
+            public:
 
-				EventConverter(const std::function<U(T)>& convert_, System::Action<U>^ listener) :
-					convert(convert_),
-					rootListener(listener)
-				{
+                EventConverter(const std::function<U(T)>& convert_, System::Action<U>^ listener) :
+                    convert(convert_),
+                    rootListener(listener)
+                {
 
-				}
+                }
 
-				std::function<void(T)> GetTrigger()
-				{
-					auto trigger = [this](T value) { this->OnEvent(value); };
-					return trigger;
-				}
+                std::function<void(T)> GetTrigger()
+                {
+                    auto trigger = [this](T value) { this->OnEvent(value); };
+                    return trigger;
+                }
 
-				/// How to subscribe on the managed side
-				void AddListener(System::Action<U>^ listener)
-				{
-					auto pRoot = new gcroot < System::Action<U> ^ >(listener);
-					callbacks.push_back(pRoot);
-				}
+                /// How to subscribe on the managed side
+                void AddListener(System::Action<U>^ listener)
+                {
+                    auto pRoot = new gcroot < System::Action<U> ^ >(listener);
+                    callbacks.push_back(pRoot);
+                }
 
-			private:
+            private:
 
-				void OnEvent(T value)
-				{
-					rootListener->Invoke(convert(value));
-				}
+                void OnEvent(T value)
+                {
+                    rootListener->Invoke(convert(value));
+                }
 
-				std::function<U(T)> convert;
-				gcroot < System::Action<U> ^ > rootListener;
-			};
+                std::function<U(T)> convert;
+                gcroot < System::Action<U> ^ > rootListener;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/ICommandHeaderWorkAround.h
+++ b/dotnet/CLRAdapter/src/ICommandHeaderWorkAround.h
@@ -23,10 +23,10 @@
 
 namespace opendnp3
 {
-	class ICommandHeader
-	{
+    class ICommandHeader
+    {
 
-	};
+    };
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/ListenCallbacksAdapter.cpp
+++ b/dotnet/CLRAdapter/src/ListenCallbacksAdapter.cpp
@@ -25,47 +25,47 @@
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			ListenCallbacksAdapter::ListenCallbacksAdapter(Interface::IListenCallbacks^ proxy) : 
-				m_proxy(proxy)
-			{}
+            ListenCallbacksAdapter::ListenCallbacksAdapter(Interface::IListenCallbacks^ proxy) : 
+                m_proxy(proxy)
+            {}
 
-			bool ListenCallbacksAdapter::AcceptConnection(uint64_t sessionid, const std::string& ipaddress)
-			{		
-				return m_proxy->AcceptConnection(sessionid, Conversions::ConvertString(ipaddress));
-			}
+            bool ListenCallbacksAdapter::AcceptConnection(uint64_t sessionid, const std::string& ipaddress)
+            {
+                return m_proxy->AcceptConnection(sessionid, Conversions::ConvertString(ipaddress));
+            }
 
-			bool ListenCallbacksAdapter::AcceptCertificate(uint64_t sessionid, const opendnp3::X509Info& info)
-			{
-				return m_proxy->AcceptCertificate(sessionid, Conversions::Convert(info));
-			}
+            bool ListenCallbacksAdapter::AcceptCertificate(uint64_t sessionid, const opendnp3::X509Info& info)
+            {
+                return m_proxy->AcceptCertificate(sessionid, Conversions::Convert(info));
+            }
 
-			opendnp3::TimeDuration ListenCallbacksAdapter::GetFirstFrameTimeout()
-			{
-				return Conversions::ConvertTimespan(m_proxy->GetFirstFrameTimeout());
-			}
+            opendnp3::TimeDuration ListenCallbacksAdapter::GetFirstFrameTimeout()
+            {
+                return Conversions::ConvertTimespan(m_proxy->GetFirstFrameTimeout());
+            }
 
-			void ListenCallbacksAdapter::OnFirstFrame(uint64_t sessionid, const opendnp3::LinkHeaderFields& header, opendnp3::ISessionAcceptor& acceptor)
-			{
-				auto linkheader = Conversions::Convert(header);
-				auto adapter = gcnew SessionAcceptorAdapter(acceptor);
-				m_proxy->OnFirstFrame(sessionid, linkheader, adapter);
-			}
+            void ListenCallbacksAdapter::OnFirstFrame(uint64_t sessionid, const opendnp3::LinkHeaderFields& header, opendnp3::ISessionAcceptor& acceptor)
+            {
+                auto linkheader = Conversions::Convert(header);
+                auto adapter = gcnew SessionAcceptorAdapter(acceptor);
+                m_proxy->OnFirstFrame(sessionid, linkheader, adapter);
+            }
 
-			void ListenCallbacksAdapter::OnConnectionClose(uint64_t sessionid, const std::shared_ptr<opendnp3::IMasterSession>& session)
-			{	
-				m_proxy->OnConnectionClose(sessionid, session ? gcnew MasterSessionAdapter(session) : nullptr);
-			}
+            void ListenCallbacksAdapter::OnConnectionClose(uint64_t sessionid, const std::shared_ptr<opendnp3::IMasterSession>& session)
+            {	
+                m_proxy->OnConnectionClose(sessionid, session ? gcnew MasterSessionAdapter(session) : nullptr);
+            }
 
-			void ListenCallbacksAdapter::OnCertificateError(uint64_t sessionid, const opendnp3::X509Info& info, int error)
-			{
-				m_proxy->OnCertificateError(sessionid, Conversions::Convert(info), error);
-			}
+            void ListenCallbacksAdapter::OnCertificateError(uint64_t sessionid, const opendnp3::X509Info& info, int error)
+            {
+                m_proxy->OnCertificateError(sessionid, Conversions::Convert(info), error);
+            }
 
-		}
-	}
+        }
+    }
 }

--- a/dotnet/CLRAdapter/src/ListenCallbacksAdapter.h
+++ b/dotnet/CLRAdapter/src/ListenCallbacksAdapter.h
@@ -30,32 +30,31 @@ using namespace System;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private
-            class ListenCallbacksAdapter final : public opendnp3::IListenCallbacks
-			{
-			public:
+            private class ListenCallbacksAdapter final : public opendnp3::IListenCallbacks
+            {
+            public:
 
-				ListenCallbacksAdapter(Interface::IListenCallbacks^ proxy);
+                ListenCallbacksAdapter(Interface::IListenCallbacks^ proxy);
 
-				virtual bool AcceptConnection(uint64_t sessionid, const std::string& ipaddress) override;
+                virtual bool AcceptConnection(uint64_t sessionid, const std::string& ipaddress) override;
                 virtual bool AcceptCertificate(uint64_t sessionid, const opendnp3::X509Info& info) override;
                 virtual opendnp3::TimeDuration GetFirstFrameTimeout() override;
                 virtual void OnFirstFrame(uint64_t sessionid, const opendnp3::LinkHeaderFields& header, opendnp3::ISessionAcceptor& acceptor) override;
                 virtual void OnConnectionClose(uint64_t sessionid, const std::shared_ptr<opendnp3::IMasterSession>& session) override;
                 virtual void OnCertificateError(uint64_t sessionid, const opendnp3::X509Info& info, int err) override;
 
-			private:
+            private:
 
-				gcroot < Interface::IListenCallbacks^ > m_proxy;
-			};
+                gcroot < Interface::IListenCallbacks^ > m_proxy;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/ListenerAdapter.h
+++ b/dotnet/CLRAdapter/src/ListenerAdapter.h
@@ -30,41 +30,41 @@ using namespace System::Threading::Tasks;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private ref class ListenerAdapter sealed : Interface::IListener
-			{
-			public:
+            private ref class ListenerAdapter sealed : Interface::IListener
+            {
+            public:
 
-				ListenerAdapter(const std::shared_ptr<opendnp3::IListener>& proxy)
+                ListenerAdapter(const std::shared_ptr<opendnp3::IListener>& proxy)
                     : proxy(new std::shared_ptr<opendnp3::IListener>(proxy))
-				{}
+                {}
 
-				ListenerAdapter::~ListenerAdapter()
-				{
-					this->!ListenerAdapter();
-				}
+                ListenerAdapter::~ListenerAdapter()
+                {
+                    this->!ListenerAdapter();
+                }
 
-				ListenerAdapter::!ListenerAdapter()
-				{
-					delete proxy;
-				}
+                ListenerAdapter::!ListenerAdapter()
+                {
+                    delete proxy;
+                }
 
-				virtual void BeginShutdown()
-				{
-					(*proxy)->Shutdown();
-				}
+                virtual void BeginShutdown()
+                {
+                    (*proxy)->Shutdown();
+                }
 
-			private:
-				
-				const std::shared_ptr<opendnp3::IListener>* proxy;
-			};
+            private:
+                
+                const std::shared_ptr<opendnp3::IListener>* proxy;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/Lock.h
+++ b/dotnet/CLRAdapter/src/Lock.h
@@ -25,19 +25,19 @@ using namespace System::Threading;
 private ref class Lock
 {
 public:
-	Lock( Object^ pObject ) : m_pObject( pObject )
-	{
-		Monitor::Enter( m_pObject );
-	}
+    Lock( Object^ pObject ) : m_pObject( pObject )
+    {
+        Monitor::Enter( m_pObject );
+    }
 
-	~Lock()
-	{
-		Monitor::Exit( m_pObject );
-	}
+    ~Lock()
+    {
+        Monitor::Exit( m_pObject );
+    }
 
 private:
 
-	Object^ m_pObject;
+    Object^ m_pObject;
 };
 
 #endif

--- a/dotnet/CLRAdapter/src/LogAdapter.cpp
+++ b/dotnet/CLRAdapter/src/LogAdapter.cpp
@@ -23,31 +23,31 @@
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			LogAdapter::LogAdapter(Automatak::DNP3::Interface::ILogHandler^ proxy) : proxy(proxy)
-			{}
+            LogAdapter::LogAdapter(Automatak::DNP3::Interface::ILogHandler^ proxy) : proxy(proxy)
+            {}
 
-			std::shared_ptr<opendnp3::ILogHandler> LogAdapter::Create(Automatak::DNP3::Interface::ILogHandler ^ proxy)
-			{
+            std::shared_ptr<opendnp3::ILogHandler> LogAdapter::Create(Automatak::DNP3::Interface::ILogHandler ^ proxy)
+            {
                 return std::shared_ptr<opendnp3::ILogHandler>(new LogAdapter(proxy));
-			}
+            }
 
-			// logging error messages, etc
+            // logging error messages, etc
             void LogAdapter::log(opendnp3::ModuleId module,
                                  const char* id,
                                  opendnp3::LogLevel level,
                                  char const* location,
                                  char const* message)
-			{								
-				proxy->Log(gcnew Automatak::DNP3::Interface::LogEntry(level.value, Conversions::ConvertString(id),
+            {
+                proxy->Log(gcnew Automatak::DNP3::Interface::LogEntry(level.value, Conversions::ConvertString(id),
                                                                       Conversions::ConvertString(location),
                                                                       Conversions::ConvertString(message)));
-			}
+            }
 
-		}
-	}
+        }
+    }
 }

--- a/dotnet/CLRAdapter/src/LogAdapter.h
+++ b/dotnet/CLRAdapter/src/LogAdapter.h
@@ -32,32 +32,32 @@ using namespace System::Collections::ObjectModel;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private class LogAdapter final : public opendnp3::ILogHandler
-			{
-			public:
+            private class LogAdapter final : public opendnp3::ILogHandler
+            {
+            public:
 
-				LogAdapter(Automatak::DNP3::Interface::ILogHandler^ proxy);
+                LogAdapter(Automatak::DNP3::Interface::ILogHandler^ proxy);
 
-				static std::shared_ptr<opendnp3::ILogHandler> Create(Automatak::DNP3::Interface::ILogHandler ^ proxy);
+                static std::shared_ptr<opendnp3::ILogHandler> Create(Automatak::DNP3::Interface::ILogHandler ^ proxy);
 
-				// logging error messages, etc
+                // logging error messages, etc
                 virtual void log(opendnp3::ModuleId module,
                                  const char* id,
                                  opendnp3::LogLevel level,
                                  char const* location,
                                  char const* message) override;
 
-			private:
-				gcroot < Automatak::DNP3::Interface::ILogHandler^ > proxy;
-			};
+            private:
+                gcroot < Automatak::DNP3::Interface::ILogHandler^ > proxy;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/MasterAdapter.cpp
+++ b/dotnet/CLRAdapter/src/MasterAdapter.cpp
@@ -23,42 +23,41 @@
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			MasterAdapter::MasterAdapter(const std::shared_ptr<opendnp3::IMaster>& master)
-                : 
-				MasterOperationsAdapter(master.get()), 
-				master(new std::shared_ptr<opendnp3::IMaster>(master))
-			{}
+            MasterAdapter::MasterAdapter(const std::shared_ptr<opendnp3::IMaster>& master)
+                : MasterOperationsAdapter(master.get()),
+                  master(new std::shared_ptr<opendnp3::IMaster>(master))
+            {}
 
-			MasterAdapter::!MasterAdapter()
-			{
-				delete master;
-			}
+            MasterAdapter::!MasterAdapter()
+            {
+                delete master;
+            }
 
-			void MasterAdapter::Enable()
-			{
-				(*master)->Enable();
-			}
+            void MasterAdapter::Enable()
+            {
+                (*master)->Enable();
+            }
 
-			void MasterAdapter::Disable()
-			{
-				(*master)->Disable();
-			}
+            void MasterAdapter::Disable()
+            {
+                (*master)->Disable();
+            }
 
-			void MasterAdapter::Shutdown()
-			{
-				(*master)->Shutdown();
-			}
+            void MasterAdapter::Shutdown()
+            {
+                (*master)->Shutdown();
+            }
 
-			Interface::IStackStatistics^ MasterAdapter::GetStackStatistics()
-			{
-				return Conversions::ConvertStackStats((*master)->GetStackStatistics());
-			}
+            Interface::IStackStatistics^ MasterAdapter::GetStackStatistics()
+            {
+                return Conversions::ConvertStackStats((*master)->GetStackStatistics());
+            }
 
-		}
-	}
+        }
+    }
 }

--- a/dotnet/CLRAdapter/src/MasterAdapter.h
+++ b/dotnet/CLRAdapter/src/MasterAdapter.h
@@ -28,35 +28,35 @@ using namespace Automatak::DNP3::Interface;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private ref class MasterAdapter : MasterOperationsAdapter, IMaster
-			{
-			public:
+            private ref class MasterAdapter : MasterOperationsAdapter, IMaster
+            {
+            public:
 
-				MasterAdapter(const std::shared_ptr<opendnp3::IMaster>& master);
+                MasterAdapter(const std::shared_ptr<opendnp3::IMaster>& master);
 
-				~MasterAdapter() { this ->!MasterAdapter(); }
-				!MasterAdapter();
-			
-				virtual void Enable();
+                ~MasterAdapter() { this ->!MasterAdapter(); }
+                !MasterAdapter();
+            
+                virtual void Enable();
 
-				virtual void Disable();
+                virtual void Disable();
 
-				virtual void Shutdown();
+                virtual void Shutdown();
 
-				virtual Interface::IStackStatistics^ GetStackStatistics();
+                virtual Interface::IStackStatistics^ GetStackStatistics();
 
-			private:
+            private:
 
-				std::shared_ptr<opendnp3::IMaster>* master;
-			};
+                std::shared_ptr<opendnp3::IMaster>* master;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/MasterApplicationAdapter.h
+++ b/dotnet/CLRAdapter/src/MasterApplicationAdapter.h
@@ -33,108 +33,108 @@ using namespace System::Collections::ObjectModel;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private class MasterApplicationAdapter final : public opendnp3::IMasterApplication
-			{
-			public:
+            private class MasterApplicationAdapter final : public opendnp3::IMasterApplication
+            {
+            public:
 
-				MasterApplicationAdapter(Automatak::DNP3::Interface::IMasterApplication^ proxy) : proxy(proxy)
-				{}
+                MasterApplicationAdapter(Automatak::DNP3::Interface::IMasterApplication^ proxy) : proxy(proxy)
+                {}
 
-				virtual void OnStateChange(opendnp3::LinkStatus value) override
-				{
-					proxy->OnStateChange((LinkStatus)value);
-				}
+                virtual void OnStateChange(opendnp3::LinkStatus value) override
+                {
+                    proxy->OnStateChange((LinkStatus)value);
+                }
 
-				void OnUnknownDestinationAddress(uint16_t destination)
-				{
-					proxy->OnUnknownDestinationAddress(destination);
-				}
+                void OnUnknownDestinationAddress(uint16_t destination)
+                {
+                    proxy->OnUnknownDestinationAddress(destination);
+                }
 
-				void OnUnknownSourceAddress(uint16_t source)
-				{
-					proxy->OnUnknownSourceAddress(source);
-				}
-				
-				virtual void OnKeepAliveInitiated() override
-				{
-					proxy->OnKeepAliveInitiated();
-				}
+                void OnUnknownSourceAddress(uint16_t source)
+                {
+                    proxy->OnUnknownSourceAddress(source);
+                }
+                
+                virtual void OnKeepAliveInitiated() override
+                {
+                    proxy->OnKeepAliveInitiated();
+                }
 
-				virtual void OnKeepAliveFailure() override
-				{
-					proxy->OnKeepAliveFailure();
-				}
+                virtual void OnKeepAliveFailure() override
+                {
+                    proxy->OnKeepAliveFailure();
+                }
 
-				virtual void OnKeepAliveSuccess() override
-				{
-					proxy->OnKeepAliveSuccess();
-				}
+                virtual void OnKeepAliveSuccess() override
+                {
+                    proxy->OnKeepAliveSuccess();
+                }
 
-				virtual opendnp3::UTCTimestamp Now() override final
-				{
-					auto milliseconds = proxy->GetMillisecondsSinceEpoch();
+                virtual opendnp3::UTCTimestamp Now() override final
+                {
+                    auto milliseconds = proxy->GetMillisecondsSinceEpoch();
                     return opendnp3::UTCTimestamp(milliseconds);
-				}
+                }
 
-				virtual void OnReceiveIIN(const opendnp3::IINField& iin) override final
-				{
-					IINField ^iinField = gcnew IINField((Automatak::DNP3::Interface::LSBMask)iin.LSB, (Automatak::DNP3::Interface::MSBMask)iin.MSB);
-					proxy->OnReceiveIIN(iinField);
-				}
+                virtual void OnReceiveIIN(const opendnp3::IINField& iin) override final
+                {
+                    IINField ^iinField = gcnew IINField((Automatak::DNP3::Interface::LSBMask)iin.LSB, (Automatak::DNP3::Interface::MSBMask)iin.MSB);
+                    proxy->OnReceiveIIN(iinField);
+                }
 
-				virtual void OnTaskStart(opendnp3::MasterTaskType type, opendnp3::TaskId id) override final
-				{
-					proxy->OnTaskStart((MasterTaskType)type, id.GetId());
-				}
+                virtual void OnTaskStart(opendnp3::MasterTaskType type, opendnp3::TaskId id) override final
+                {
+                    proxy->OnTaskStart((MasterTaskType)type, id.GetId());
+                }
 
-				virtual void OnTaskComplete(const opendnp3::TaskInfo& info) override final
-				{					
-					proxy->OnTaskComplete(MasterConversions::Convert(info));
-				}
+                virtual void OnTaskComplete(const opendnp3::TaskInfo& info) override final
+                {					
+                    proxy->OnTaskComplete(MasterConversions::Convert(info));
+                }
 
-				virtual void OnOpen() override final
-				{
-					proxy->OnOpen();
-				}
+                virtual void OnOpen() override final
+                {
+                    proxy->OnOpen();
+                }
 
-				virtual void OnClose() override final
-				{
-					proxy->OnClose();
-				}
+                virtual void OnClose() override final
+                {
+                    proxy->OnClose();
+                }
 
-				virtual bool AssignClassDuringStartup() override final
-				{
-					return proxy->AssignClassDuringStartup();
-				}
+                virtual bool AssignClassDuringStartup() override final
+                {
+                    return proxy->AssignClassDuringStartup();
+                }
 
-				virtual void ConfigureAssignClassRequest(const opendnp3::WriteHeaderFunT& writer) override final
-				{
-					auto assignments = proxy->GetClassAssignments();
-					for each(auto a in assignments)
-					{
-						if (a.range.IsAllObjects())
-						{
-							writer(opendnp3::Header::AllObjects(a.group, a.variation));
-						}
-						else
-						{
-							writer(opendnp3::Header::Range16(a.group, a.variation, a.range.start, a.range.stop));
-						}
-					}
-				}
+                virtual void ConfigureAssignClassRequest(const opendnp3::WriteHeaderFunT& writer) override final
+                {
+                    auto assignments = proxy->GetClassAssignments();
+                    for each(auto a in assignments)
+                    {
+                        if (a.range.IsAllObjects())
+                        {
+                            writer(opendnp3::Header::AllObjects(a.group, a.variation));
+                        }
+                        else
+                        {
+                            writer(opendnp3::Header::Range16(a.group, a.variation, a.range.start, a.range.stop));
+                        }
+                    }
+                }
 
-			private:
+            private:
 
-				gcroot < Automatak::DNP3::Interface::IMasterApplication^ > proxy;
-			};
+                gcroot < Automatak::DNP3::Interface::IMasterApplication^ > proxy;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/MasterConversions.cpp
+++ b/dotnet/CLRAdapter/src/MasterConversions.cpp
@@ -24,157 +24,157 @@
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			std::vector<opendnp3::Header> MasterConversions::ConvertToVectorOfHeaders(IEnumerable<Header^>^ headers)
-			{
-				std::vector<opendnp3::Header> ret;
-				for each(auto header in headers)
-				{
-					opendnp3::Header output;
-					if (Convert(header, output))
-					{
-						ret.push_back(output);
-					}
-				}
-				return ret;
-			}
+            std::vector<opendnp3::Header> MasterConversions::ConvertToVectorOfHeaders(IEnumerable<Header^>^ headers)
+            {
+                std::vector<opendnp3::Header> ret;
+                for each(auto header in headers)
+                {
+                    opendnp3::Header output;
+                    if (Convert(header, output))
+                    {
+                        ret.push_back(output);
+                    }
+                }
+                return ret;
+            }
 
-			bool MasterConversions::Convert(Header^ header, opendnp3::Header& output)
-			{
-				switch (header->qualifier)
-				{
-				case(QualifierCode::ALL_OBJECTS) :
-				{
-					output = opendnp3::Header::AllObjects(header->group, header->variation);
-					return true;
-				}
-				case(QualifierCode::UINT8_CNT) :
-				{
-					auto value = dynamic_cast<CountHeader^>(header);
-					if (!value)
-					{
-						return false;
-					}
-					else
-					{
-						output = ConvertCount8(value);
-						return true;
-					}
-				}
-				case(QualifierCode::UINT16_CNT) :
-				{
-					auto value = dynamic_cast<CountHeader^>(header);
-					if (!value)
-					{
-						return false;
-					}
-					else
-					{
-						output = ConvertCount16(value);
-						return true;
-					}
-				}
-				case(QualifierCode::UINT8_START_STOP) :
-				{
-					auto value = dynamic_cast<RangeHeader^>(header);
-					if (!value)
-					{
-						return false;
-					}
-					else
-					{
-						output = ConvertRange8(value);
-						return true;
-					}
-				}
-				case(QualifierCode::UINT16_START_STOP) :
-				{
-					auto value = dynamic_cast<RangeHeader^>(header);
-					if (!value)
-					{
-						return false;
-					}
-					else
-					{
-						output = ConvertRange16(value);
-						return true;
-					}
-				}
-				default:
-					return false;
-				}
-			}
-		
-			opendnp3::Header MasterConversions::Convert(Header^ header)
-			{
-				return opendnp3::Header::AllObjects(header->group, header->variation);
-			}
+            bool MasterConversions::Convert(Header^ header, opendnp3::Header& output)
+            {
+                switch (header->qualifier)
+                {
+                case(QualifierCode::ALL_OBJECTS) :
+                {
+                    output = opendnp3::Header::AllObjects(header->group, header->variation);
+                    return true;
+                }
+                case(QualifierCode::UINT8_CNT) :
+                {
+                    auto value = dynamic_cast<CountHeader^>(header);
+                    if (!value)
+                    {
+                        return false;
+                    }
+                    else
+                    {
+                        output = ConvertCount8(value);
+                        return true;
+                    }
+                }
+                case(QualifierCode::UINT16_CNT) :
+                {
+                    auto value = dynamic_cast<CountHeader^>(header);
+                    if (!value)
+                    {
+                        return false;
+                    }
+                    else
+                    {
+                        output = ConvertCount16(value);
+                        return true;
+                    }
+                }
+                case(QualifierCode::UINT8_START_STOP) :
+                {
+                    auto value = dynamic_cast<RangeHeader^>(header);
+                    if (!value)
+                    {
+                        return false;
+                    }
+                    else
+                    {
+                        output = ConvertRange8(value);
+                        return true;
+                    }
+                }
+                case(QualifierCode::UINT16_START_STOP) :
+                {
+                    auto value = dynamic_cast<RangeHeader^>(header);
+                    if (!value)
+                    {
+                        return false;
+                    }
+                    else
+                    {
+                        output = ConvertRange16(value);
+                        return true;
+                    }
+                }
+                default:
+                    return false;
+                }
+            }
+        
+            opendnp3::Header MasterConversions::Convert(Header^ header)
+            {
+                return opendnp3::Header::AllObjects(header->group, header->variation);
+            }
 
-			opendnp3::Header MasterConversions::ConvertCount8(CountHeader^ header)
-			{
-				return opendnp3::Header::Count8(header->group, header->variation, static_cast<uint8_t>(header->count));
-			}
+            opendnp3::Header MasterConversions::ConvertCount8(CountHeader^ header)
+            {
+                return opendnp3::Header::Count8(header->group, header->variation, static_cast<uint8_t>(header->count));
+            }
 
-			opendnp3::Header MasterConversions::ConvertCount16(CountHeader^ header)
-			{
-				return opendnp3::Header::Count16(header->group, header->variation, header->count);
-			}
+            opendnp3::Header MasterConversions::ConvertCount16(CountHeader^ header)
+            {
+                return opendnp3::Header::Count16(header->group, header->variation, header->count);
+            }
 
-			opendnp3::Header MasterConversions::ConvertRange8(RangeHeader^ header)
-			{
-				return opendnp3::Header::Range8(header->group, header->variation, static_cast<uint8_t>(header->start), static_cast<uint8_t>(header->stop));
-			}
+            opendnp3::Header MasterConversions::ConvertRange8(RangeHeader^ header)
+            {
+                return opendnp3::Header::Range8(header->group, header->variation, static_cast<uint8_t>(header->start), static_cast<uint8_t>(header->stop));
+            }
 
-			opendnp3::Header MasterConversions::ConvertRange16(RangeHeader^ header)
-			{
-				return opendnp3::Header::Range16(header->group, header->variation, header->start, header->stop);
-			}
+            opendnp3::Header MasterConversions::ConvertRange16(RangeHeader^ header)
+            {
+                return opendnp3::Header::Range16(header->group, header->variation, header->start, header->stop);
+            }
 
-			opendnp3::TaskConfig MasterConversions::Convert(TaskConfig^ config, ITaskCallback^ wrapper)
-			{			
-				return opendnp3::TaskConfig(Convert(config->taskId), CreateTaskCallback(wrapper));
-			}
+            opendnp3::TaskConfig MasterConversions::Convert(TaskConfig^ config, ITaskCallback^ wrapper)
+            {			
+                return opendnp3::TaskConfig(Convert(config->taskId), CreateTaskCallback(wrapper));
+            }
 
-			opendnp3::TaskConfig MasterConversions::Convert(TaskConfig^ config)
-			{
-				return opendnp3::TaskConfig(Convert(config->taskId), CreateTaskCallback(config->callback));
-			}
-			
-			opendnp3::CommandSet MasterConversions::Convert(ICommandHeaders^ headers)
-			{
-				opendnp3::CommandSet commands;
+            opendnp3::TaskConfig MasterConversions::Convert(TaskConfig^ config)
+            {
+                return opendnp3::TaskConfig(Convert(config->taskId), CreateTaskCallback(config->callback));
+            }
+            
+            opendnp3::CommandSet MasterConversions::Convert(ICommandHeaders^ headers)
+            {
+                opendnp3::CommandSet commands;
 
-				auto builder = gcnew CommandSetBuilder(commands);
+                auto builder = gcnew CommandSetBuilder(commands);
 
-				headers->Build(builder);
+                headers->Build(builder);
 
-				return commands;
-			}
+                return commands;
+            }
 
-			opendnp3::TaskId MasterConversions::Convert(TaskId^ id)
-			{
-				return id->IsValid ? opendnp3::TaskId::Defined(id->Value) : opendnp3::TaskId::Undefined();
-			}
+            opendnp3::TaskId MasterConversions::Convert(TaskId^ id)
+            {
+                return id->IsValid ? opendnp3::TaskId::Defined(id->Value) : opendnp3::TaskId::Undefined();
+            }
 
-			TaskId^ MasterConversions::Convert(const opendnp3::TaskId& id)
-			{
-				return id.IsDefined() ? TaskId::Defined(id.GetId()) : TaskId::Undefined;
-			}
+            TaskId^ MasterConversions::Convert(const opendnp3::TaskId& id)
+            {
+                return id.IsDefined() ? TaskId::Defined(id.GetId()) : TaskId::Undefined;
+            }
 
-			TaskInfo^ MasterConversions::Convert(const opendnp3::TaskInfo& info)
-			{
-				return gcnew TaskInfo((MasterTaskType)info.type, (TaskCompletion)info.result, MasterConversions::Convert(info.id));
-			}
+            TaskInfo^ MasterConversions::Convert(const opendnp3::TaskInfo& info)
+            {
+                return gcnew TaskInfo((MasterTaskType)info.type, (TaskCompletion)info.result, MasterConversions::Convert(info.id));
+            }
 
-			std::shared_ptr<opendnp3::ITaskCallback> MasterConversions::CreateTaskCallback(ITaskCallback^ callback)
-			{
+            std::shared_ptr<opendnp3::ITaskCallback> MasterConversions::CreateTaskCallback(ITaskCallback^ callback)
+            {
                 return callback ? TaskCallbackAdapter::Create(callback) : nullptr;
-			}
+            }
 
-		}
-	}
+        }
+    }
 }

--- a/dotnet/CLRAdapter/src/MasterConversions.h
+++ b/dotnet/CLRAdapter/src/MasterConversions.h
@@ -37,41 +37,41 @@ using namespace System::Collections::Generic;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private class MasterConversions
-			{
-			public:
+            private class MasterConversions
+            {
+            public:
 
-				static std::vector<opendnp3::Header> ConvertToVectorOfHeaders(IEnumerable<Header^>^ headers);
+                static std::vector<opendnp3::Header> ConvertToVectorOfHeaders(IEnumerable<Header^>^ headers);
 
-				static bool Convert(Header^ header, opendnp3::Header& output);
+                static bool Convert(Header^ header, opendnp3::Header& output);
 
-				static opendnp3::Header Convert(Header^ header);
-				static opendnp3::Header ConvertCount8(CountHeader^ header);
-				static opendnp3::Header ConvertCount16(CountHeader^ header);
-				static opendnp3::Header ConvertRange8(RangeHeader^ header);
-				static opendnp3::Header ConvertRange16(RangeHeader^ header);
+                static opendnp3::Header Convert(Header^ header);
+                static opendnp3::Header ConvertCount8(CountHeader^ header);
+                static opendnp3::Header ConvertCount16(CountHeader^ header);
+                static opendnp3::Header ConvertRange8(RangeHeader^ header);
+                static opendnp3::Header ConvertRange16(RangeHeader^ header);
 
-				static opendnp3::TaskConfig Convert(TaskConfig^ config, ITaskCallback^ wrapper);
-				static opendnp3::TaskConfig Convert(TaskConfig^ config);
+                static opendnp3::TaskConfig Convert(TaskConfig^ config, ITaskCallback^ wrapper);
+                static opendnp3::TaskConfig Convert(TaskConfig^ config);
 
-				static opendnp3::CommandSet Convert(ICommandHeaders^ headers);
-								
-				static opendnp3::TaskId Convert(TaskId^ taskId);
-				static TaskId^ Convert(const opendnp3::TaskId& id);
+                static opendnp3::CommandSet Convert(ICommandHeaders^ headers);
 
-				static TaskInfo^ Convert(const opendnp3::TaskInfo& info);
+                static opendnp3::TaskId Convert(TaskId^ taskId);
+                static TaskId^ Convert(const opendnp3::TaskId& id);
 
-				static std::shared_ptr<opendnp3::ITaskCallback> CreateTaskCallback(ITaskCallback^ callback);
-			
-			};
+                static TaskInfo^ Convert(const opendnp3::TaskInfo& info);
 
-		}
-	}
+                static std::shared_ptr<opendnp3::ITaskCallback> CreateTaskCallback(ITaskCallback^ callback);
+            
+            };
+
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/MasterOperationsAdapter.cpp
+++ b/dotnet/CLRAdapter/src/MasterOperationsAdapter.cpp
@@ -24,183 +24,183 @@
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			MasterOperationsAdapter::MasterOperationsAdapter(opendnp3::IMasterOperations* operations) : operations(operations)
-			{}
-			
-			void MasterOperationsAdapter::SetLogFilters(LogFilter flags)
-			{
+            MasterOperationsAdapter::MasterOperationsAdapter(opendnp3::IMasterOperations* operations) : operations(operations)
+            {}
+            
+            void MasterOperationsAdapter::SetLogFilters(LogFilter flags)
+            {
                 operations->SetLogFilters(opendnp3::LogLevel(flags.Flags));
-			}
-			
-			Task<TaskCompletion>^ MasterOperationsAdapter::Scan(IEnumerable<Header^>^ headers, ISOEHandler^ soeHandler, TaskConfig^ config)
-			{
-				auto proxy = gcnew TaskCompletionProxy(config->callback);
-				auto vec = MasterConversions::ConvertToVectorOfHeaders(headers);
+            }
+            
+            Task<TaskCompletion>^ MasterOperationsAdapter::Scan(IEnumerable<Header^>^ headers, ISOEHandler^ soeHandler, TaskConfig^ config)
+            {
+                auto proxy = gcnew TaskCompletionProxy(config->callback);
+                auto vec = MasterConversions::ConvertToVectorOfHeaders(headers);
                 auto soeAdapter = std::make_shared<SOEHandlerAdapter>(soeHandler);
-				operations->Scan(vec, soeAdapter, MasterConversions::Convert(config, proxy));
-				return proxy->CompletionTask;
-			}
+                operations->Scan(vec, soeAdapter, MasterConversions::Convert(config, proxy));
+                return proxy->CompletionTask;
+            }
 
-			Task<TaskCompletion>^ MasterOperationsAdapter::ScanAllObjects(System::Byte group, System::Byte variation, ISOEHandler^ soeHandler, TaskConfig^ config)
-			{
-				auto proxy = gcnew TaskCompletionProxy(config->callback);
+            Task<TaskCompletion>^ MasterOperationsAdapter::ScanAllObjects(System::Byte group, System::Byte variation, ISOEHandler^ soeHandler, TaskConfig^ config)
+            {
+                auto proxy = gcnew TaskCompletionProxy(config->callback);
                 auto soeAdapter = std::make_shared<SOEHandlerAdapter>(soeHandler);
-				operations->ScanAllObjects(opendnp3::GroupVariationID(group, variation), soeAdapter, MasterConversions::Convert(config, proxy));
-				return proxy->CompletionTask;
-			}
+                operations->ScanAllObjects(opendnp3::GroupVariationID(group, variation), soeAdapter, MasterConversions::Convert(config, proxy));
+                return proxy->CompletionTask;
+            }
 
-			Task<TaskCompletion>^ MasterOperationsAdapter::ScanClasses(ClassField field, ISOEHandler^ soeHandler, TaskConfig^ config)
-			{
-				auto proxy = gcnew TaskCompletionProxy(config->callback);
+            Task<TaskCompletion>^ MasterOperationsAdapter::ScanClasses(ClassField field, ISOEHandler^ soeHandler, TaskConfig^ config)
+            {
+                auto proxy = gcnew TaskCompletionProxy(config->callback);
                 auto soeAdapter = std::make_shared<SOEHandlerAdapter>(soeHandler);
-				operations->ScanClasses(Conversions::ConvertClassField(field), soeAdapter, MasterConversions::Convert(config, proxy));
-				return proxy->CompletionTask;
-			}
-				
-			Task<TaskCompletion>^ MasterOperationsAdapter::ScanRange(System::Byte group, System::Byte variation, System::UInt16 start, System::UInt16 stop, ISOEHandler^ soeHandler, TaskConfig^ config)
-			{
-				opendnp3::GroupVariationID gvid(group, variation);
-				auto proxy = gcnew TaskCompletionProxy(config->callback);
+                operations->ScanClasses(Conversions::ConvertClassField(field), soeAdapter, MasterConversions::Convert(config, proxy));
+                return proxy->CompletionTask;
+            }
+                
+            Task<TaskCompletion>^ MasterOperationsAdapter::ScanRange(System::Byte group, System::Byte variation, System::UInt16 start, System::UInt16 stop, ISOEHandler^ soeHandler, TaskConfig^ config)
+            {
+                opendnp3::GroupVariationID gvid(group, variation);
+                auto proxy = gcnew TaskCompletionProxy(config->callback);
                 auto soeAdapter = std::make_shared<SOEHandlerAdapter>(soeHandler);
-				operations->ScanRange(gvid, start, stop, soeAdapter, MasterConversions::Convert(config, proxy));
-				return proxy->CompletionTask;
-			}
+                operations->ScanRange(gvid, start, stop, soeAdapter, MasterConversions::Convert(config, proxy));
+                return proxy->CompletionTask;
+            }
 
-			Task<TaskCompletion>^ MasterOperationsAdapter::Write(TimeAndInterval^ value, System::UInt16 index, TaskConfig^ config)
-			{
-				auto proxy = gcnew TaskCompletionProxy(config->callback);
-				operations->Write(Conversions::ConvertMeas(value), index, MasterConversions::Convert(config, proxy));
-				return proxy->CompletionTask;
-			}
+            Task<TaskCompletion>^ MasterOperationsAdapter::Write(TimeAndInterval^ value, System::UInt16 index, TaskConfig^ config)
+            {
+                auto proxy = gcnew TaskCompletionProxy(config->callback);
+                operations->Write(Conversions::ConvertMeas(value), index, MasterConversions::Convert(config, proxy));
+                return proxy->CompletionTask;
+            }
 
-			Task<RestartResultType^>^ MasterOperationsAdapter::Restart(RestartType restartType, TaskConfig^ config)
-			{
-				auto tcs = gcnew TaskCompletionSource<RestartResultType^>();
+            Task<RestartResultType^>^ MasterOperationsAdapter::Restart(RestartType restartType, TaskConfig^ config)
+            {
+                auto tcs = gcnew TaskCompletionSource<RestartResultType^>();
 
-				operations->Restart((opendnp3::RestartType) restartType,  CallbackAdapters::Get(tcs), MasterConversions::Convert(config));
+                operations->Restart((opendnp3::RestartType) restartType,  CallbackAdapters::Get(tcs), MasterConversions::Convert(config));
 
-				return tcs->Task;
-			}
+                return tcs->Task;
+            }
 
-			Task<TaskCompletion>^ MasterOperationsAdapter::PerformFunction(System::String^ name, FunctionCode func, IEnumerable<Header^>^ headers, TaskConfig^ config)
-			{
-				auto proxy = gcnew TaskCompletionProxy(config->callback);
-				auto vec = MasterConversions::ConvertToVectorOfHeaders(headers);
-				auto nativeName = Conversions::ConvertString(name);
-				operations->PerformFunction(nativeName, (opendnp3::FunctionCode) func, vec, MasterConversions::Convert(config, proxy));
-				return proxy->CompletionTask;
-			}
+            Task<TaskCompletion>^ MasterOperationsAdapter::PerformFunction(System::String^ name, FunctionCode func, IEnumerable<Header^>^ headers, TaskConfig^ config)
+            {
+                auto proxy = gcnew TaskCompletionProxy(config->callback);
+                auto vec = MasterConversions::ConvertToVectorOfHeaders(headers);
+                auto nativeName = Conversions::ConvertString(name);
+                operations->PerformFunction(nativeName, (opendnp3::FunctionCode) func, vec, MasterConversions::Convert(config, proxy));
+                return proxy->CompletionTask;
+            }
 
-			IMasterScan^ MasterOperationsAdapter::AddScan(IEnumerable<Header^>^ headers, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config)
-			{
-				auto vec = MasterConversions::ConvertToVectorOfHeaders(headers);
+            IMasterScan^ MasterOperationsAdapter::AddScan(IEnumerable<Header^>^ headers, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config)
+            {
+                auto vec = MasterConversions::ConvertToVectorOfHeaders(headers);
                 auto soeAdapter = std::make_shared<SOEHandlerAdapter>(soeHandler);
-				auto scan = operations->AddScan(Conversions::ConvertTimespan(period), vec, soeAdapter, MasterConversions::Convert(config));
-				return gcnew MasterScanAdapter(scan);
-			}
+                auto scan = operations->AddScan(Conversions::ConvertTimespan(period), vec, soeAdapter, MasterConversions::Convert(config));
+                return gcnew MasterScanAdapter(scan);
+            }
 
-			IMasterScan^ MasterOperationsAdapter::AddAllObjectsScan(System::Byte group, System::Byte variation, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config)
-			{
-				opendnp3::GroupVariationID gvid(group, variation);
+            IMasterScan^ MasterOperationsAdapter::AddAllObjectsScan(System::Byte group, System::Byte variation, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config)
+            {
+                opendnp3::GroupVariationID gvid(group, variation);
                 auto soeAdapter = std::make_shared<SOEHandlerAdapter>(soeHandler);
-				auto scan = operations->AddAllObjectsScan(gvid, Conversions::ConvertTimespan(period), soeAdapter, MasterConversions::Convert(config));
-				return gcnew MasterScanAdapter(scan);
-			}
+                auto scan = operations->AddAllObjectsScan(gvid, Conversions::ConvertTimespan(period), soeAdapter, MasterConversions::Convert(config));
+                return gcnew MasterScanAdapter(scan);
+            }
 
-			IMasterScan^ MasterOperationsAdapter::AddClassScan(ClassField field, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config)
-			{
+            IMasterScan^ MasterOperationsAdapter::AddClassScan(ClassField field, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config)
+            {
                 auto soeAdapter = std::make_shared<SOEHandlerAdapter>(soeHandler);
-				auto scan = operations->AddClassScan(Conversions::ConvertClassField(field), Conversions::ConvertTimespan(period), soeAdapter, MasterConversions::Convert(config));
-				return gcnew MasterScanAdapter(scan);
-			}
+                auto scan = operations->AddClassScan(Conversions::ConvertClassField(field), Conversions::ConvertTimespan(period), soeAdapter, MasterConversions::Convert(config));
+                return gcnew MasterScanAdapter(scan);
+            }
 
-			IMasterScan^ MasterOperationsAdapter::AddRangeScan(System::Byte group, System::Byte variation, System::UInt16 start, System::UInt16 stop, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config)
-			{
-				opendnp3::GroupVariationID gvid(group, variation);
+            IMasterScan^ MasterOperationsAdapter::AddRangeScan(System::Byte group, System::Byte variation, System::UInt16 start, System::UInt16 stop, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config)
+            {
+                opendnp3::GroupVariationID gvid(group, variation);
                 auto soeAdapter = std::make_shared<SOEHandlerAdapter>(soeHandler);
-				auto scan = operations->AddRangeScan(gvid, start, stop, Conversions::ConvertTimespan(period), soeAdapter, MasterConversions::Convert(config));
-				return gcnew MasterScanAdapter(scan);
-			}
+                auto scan = operations->AddRangeScan(gvid, start, stop, Conversions::ConvertTimespan(period), soeAdapter, MasterConversions::Convert(config));
+                return gcnew MasterScanAdapter(scan);
+            }
 
-			Task<CommandTaskResult^>^ MasterOperationsAdapter::SelectAndOperate(ICommandHeaders^ headers, TaskConfig^ config)
-			{
-				auto tcs = gcnew TaskCompletionSource<CommandTaskResult^>();
-				operations->SelectAndOperate(MasterConversions::Convert(headers), CallbackAdapters::Get(tcs), MasterConversions::Convert(config));
-				return tcs->Task;
-			}
+            Task<CommandTaskResult^>^ MasterOperationsAdapter::SelectAndOperate(ICommandHeaders^ headers, TaskConfig^ config)
+            {
+                auto tcs = gcnew TaskCompletionSource<CommandTaskResult^>();
+                operations->SelectAndOperate(MasterConversions::Convert(headers), CallbackAdapters::Get(tcs), MasterConversions::Convert(config));
+                return tcs->Task;
+            }
 
-			Task<CommandTaskResult^>^ MasterOperationsAdapter::DirectOperate(ICommandHeaders^ headers, TaskConfig^ config)
-			{
-				auto tcs = gcnew TaskCompletionSource<CommandTaskResult^>();
-				operations->DirectOperate(MasterConversions::Convert(headers), CallbackAdapters::Get(tcs), MasterConversions::Convert(config));
-				return tcs->Task;
-			}
+            Task<CommandTaskResult^>^ MasterOperationsAdapter::DirectOperate(ICommandHeaders^ headers, TaskConfig^ config)
+            {
+                auto tcs = gcnew TaskCompletionSource<CommandTaskResult^>();
+                operations->DirectOperate(MasterConversions::Convert(headers), CallbackAdapters::Get(tcs), MasterConversions::Convert(config));
+                return tcs->Task;
+            }
 
-			Task<CommandTaskResult^>^ MasterOperationsAdapter::SelectAndOperate(ControlRelayOutputBlock^ command, System::UInt16 index, TaskConfig^ config)
-			{
-				ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
-				return this->SelectAndOperate(headers, config);
-			}
+            Task<CommandTaskResult^>^ MasterOperationsAdapter::SelectAndOperate(ControlRelayOutputBlock^ command, System::UInt16 index, TaskConfig^ config)
+            {
+                ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
+                return this->SelectAndOperate(headers, config);
+            }
 
-			Task<CommandTaskResult^>^ MasterOperationsAdapter::SelectAndOperate(AnalogOutputInt16^ command, System::UInt16 index, TaskConfig^ config)
-			{
-				ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
-				return this->SelectAndOperate(headers, config);
-			}
+            Task<CommandTaskResult^>^ MasterOperationsAdapter::SelectAndOperate(AnalogOutputInt16^ command, System::UInt16 index, TaskConfig^ config)
+            {
+                ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
+                return this->SelectAndOperate(headers, config);
+            }
 
-			Task<CommandTaskResult^>^ MasterOperationsAdapter::SelectAndOperate(AnalogOutputInt32^ command, System::UInt16 index, TaskConfig^ config)
-			{
-				ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
-				return this->SelectAndOperate(headers, config);
-			}
+            Task<CommandTaskResult^>^ MasterOperationsAdapter::SelectAndOperate(AnalogOutputInt32^ command, System::UInt16 index, TaskConfig^ config)
+            {
+                ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
+                return this->SelectAndOperate(headers, config);
+            }
 
-			Task<CommandTaskResult^>^ MasterOperationsAdapter::SelectAndOperate(AnalogOutputFloat32^ command, System::UInt16 index, TaskConfig^ config)
-			{
-				ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
-				return this->SelectAndOperate(headers, config);
-			}
+            Task<CommandTaskResult^>^ MasterOperationsAdapter::SelectAndOperate(AnalogOutputFloat32^ command, System::UInt16 index, TaskConfig^ config)
+            {
+                ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
+                return this->SelectAndOperate(headers, config);
+            }
 
-			Task<CommandTaskResult^>^ MasterOperationsAdapter::SelectAndOperate(AnalogOutputDouble64^ command, System::UInt16 index, TaskConfig^ config)
-			{
-				ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
-				return this->SelectAndOperate(headers, config);
-			}
+            Task<CommandTaskResult^>^ MasterOperationsAdapter::SelectAndOperate(AnalogOutputDouble64^ command, System::UInt16 index, TaskConfig^ config)
+            {
+                ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
+                return this->SelectAndOperate(headers, config);
+            }
 
-			Task<CommandTaskResult^>^ MasterOperationsAdapter::DirectOperate(ControlRelayOutputBlock^ command, System::UInt16 index, TaskConfig^ config)
-			{
-				ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
-				return this->DirectOperate(headers, config);
-			}
+            Task<CommandTaskResult^>^ MasterOperationsAdapter::DirectOperate(ControlRelayOutputBlock^ command, System::UInt16 index, TaskConfig^ config)
+            {
+                ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
+                return this->DirectOperate(headers, config);
+            }
 
-			Task<CommandTaskResult^>^ MasterOperationsAdapter::DirectOperate(AnalogOutputDouble64^ command, System::UInt16 index, TaskConfig^ config)
-			{
-				ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
-				return this->DirectOperate(headers, config);
-			}
-				
-			Task<CommandTaskResult^>^ MasterOperationsAdapter::DirectOperate(AnalogOutputInt16^ command, System::UInt16 index, TaskConfig^ config)
-			{
-				ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
-				return this->DirectOperate(headers, config);
-			}
+            Task<CommandTaskResult^>^ MasterOperationsAdapter::DirectOperate(AnalogOutputDouble64^ command, System::UInt16 index, TaskConfig^ config)
+            {
+                ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
+                return this->DirectOperate(headers, config);
+            }
+                
+            Task<CommandTaskResult^>^ MasterOperationsAdapter::DirectOperate(AnalogOutputInt16^ command, System::UInt16 index, TaskConfig^ config)
+            {
+                ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
+                return this->DirectOperate(headers, config);
+            }
 
-			Task<CommandTaskResult^>^ MasterOperationsAdapter::DirectOperate(AnalogOutputInt32^ command, System::UInt16 index, TaskConfig^ config)
-			{
-				ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
-				return this->DirectOperate(headers, config);
-			}
+            Task<CommandTaskResult^>^ MasterOperationsAdapter::DirectOperate(AnalogOutputInt32^ command, System::UInt16 index, TaskConfig^ config)
+            {
+                ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
+                return this->DirectOperate(headers, config);
+            }
 
-			Task<CommandTaskResult^>^ MasterOperationsAdapter::DirectOperate(AnalogOutputFloat32^ command, System::UInt16 index, TaskConfig^ config)
-			{
-				ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
-				return this->DirectOperate(headers, config);
-			}
+            Task<CommandTaskResult^>^ MasterOperationsAdapter::DirectOperate(AnalogOutputFloat32^ command, System::UInt16 index, TaskConfig^ config)
+            {
+                ICommandHeaders^ headers = CommandHeader::From(IndexedValue::From(command, index));
+                return this->DirectOperate(headers, config);
+            }
 
-		}
-	}
+        }
+    }
 }

--- a/dotnet/CLRAdapter/src/MasterOperationsAdapter.h
+++ b/dotnet/CLRAdapter/src/MasterOperationsAdapter.h
@@ -33,66 +33,66 @@ using namespace System::Collections::Generic;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private ref class MasterOperationsAdapter abstract
-			{
-			public:
+            private ref class MasterOperationsAdapter abstract
+            {
+            public:
 
-				MasterOperationsAdapter(opendnp3::IMasterOperations* operations);
+                MasterOperationsAdapter(opendnp3::IMasterOperations* operations);
 
-				virtual void SetLogFilters(LogFilter flags);
-			
-				virtual Task<TaskCompletion>^ Scan(IEnumerable<Header^>^ headers, ISOEHandler^ soeHandler, TaskConfig^ config);
+                virtual void SetLogFilters(LogFilter flags);
+            
+                virtual Task<TaskCompletion>^ Scan(IEnumerable<Header^>^ headers, ISOEHandler^ soeHandler, TaskConfig^ config);
 
-				virtual Task<TaskCompletion>^ ScanAllObjects(System::Byte group, System::Byte variation, ISOEHandler^ soeHandler, TaskConfig^ config);
+                virtual Task<TaskCompletion>^ ScanAllObjects(System::Byte group, System::Byte variation, ISOEHandler^ soeHandler, TaskConfig^ config);
 
-				virtual Task<TaskCompletion>^ ScanClasses(ClassField field, ISOEHandler^ soeHandler, TaskConfig^ config);
-				
-				virtual Task<TaskCompletion>^ ScanRange(System::Byte group, System::Byte variation, System::UInt16 start, System::UInt16 stop, ISOEHandler^ soeHandler, TaskConfig^ config);
+                virtual Task<TaskCompletion>^ ScanClasses(ClassField field, ISOEHandler^ soeHandler, TaskConfig^ config);
+                
+                virtual Task<TaskCompletion>^ ScanRange(System::Byte group, System::Byte variation, System::UInt16 start, System::UInt16 stop, ISOEHandler^ soeHandler, TaskConfig^ config);
 
-				virtual Task<TaskCompletion>^ Write(TimeAndInterval^ value, System::UInt16 index, TaskConfig^ config);
+                virtual Task<TaskCompletion>^ Write(TimeAndInterval^ value, System::UInt16 index, TaskConfig^ config);
 
-				virtual Task<RestartResultType^>^ Restart(RestartType restartType, TaskConfig^ config);
+                virtual Task<RestartResultType^>^ Restart(RestartType restartType, TaskConfig^ config);
 
-				virtual Task<TaskCompletion>^ PerformFunction(System::String^ name, FunctionCode func, IEnumerable<Header^>^ headers, TaskConfig^ config);
+                virtual Task<TaskCompletion>^ PerformFunction(System::String^ name, FunctionCode func, IEnumerable<Header^>^ headers, TaskConfig^ config);
 
-				virtual IMasterScan^ AddScan(IEnumerable<Header^>^ headers, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config);
+                virtual IMasterScan^ AddScan(IEnumerable<Header^>^ headers, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config);
 
-				virtual IMasterScan^ AddAllObjectsScan(System::Byte group, System::Byte variation, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config);
+                virtual IMasterScan^ AddAllObjectsScan(System::Byte group, System::Byte variation, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config);
 
-				virtual IMasterScan^ AddClassScan(ClassField field, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config);
+                virtual IMasterScan^ AddClassScan(ClassField field, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config);
 
-				virtual IMasterScan^ AddRangeScan(System::Byte group, System::Byte variation, System::UInt16 start, System::UInt16 stop, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config);												
+                virtual IMasterScan^ AddRangeScan(System::Byte group, System::Byte variation, System::UInt16 start, System::UInt16 stop, System::TimeSpan period, ISOEHandler^ soeHandler, TaskConfig^ config);												
 
-				/// --- implement ICommandProcessor ----
+                /// --- implement ICommandProcessor ----
 
-				virtual Task<CommandTaskResult^>^ SelectAndOperate(ICommandHeaders^ headers, TaskConfig^ config);
-				virtual Task<CommandTaskResult^>^ DirectOperate(ICommandHeaders^ headers, TaskConfig^ config);
+                virtual Task<CommandTaskResult^>^ SelectAndOperate(ICommandHeaders^ headers, TaskConfig^ config);
+                virtual Task<CommandTaskResult^>^ DirectOperate(ICommandHeaders^ headers, TaskConfig^ config);
 
-				virtual Task<CommandTaskResult^>^ SelectAndOperate(ControlRelayOutputBlock^ command, System::UInt16 index, TaskConfig^ config);			
-				virtual Task<CommandTaskResult^>^ SelectAndOperate(AnalogOutputInt16^ command, System::UInt16 index, TaskConfig^ config);				
-				virtual Task<CommandTaskResult^>^ SelectAndOperate(AnalogOutputInt32^ command, System::UInt16 index, TaskConfig^ config);				
-				virtual Task<CommandTaskResult^>^ SelectAndOperate(AnalogOutputFloat32^ command, System::UInt16 index, TaskConfig^ config);				
-				virtual Task<CommandTaskResult^>^ SelectAndOperate(AnalogOutputDouble64^ command, System::UInt16 index, TaskConfig^ config);
-				
-				virtual Task<CommandTaskResult^>^ DirectOperate(ControlRelayOutputBlock^ command, System::UInt16 index, TaskConfig^ config);
-				virtual Task<CommandTaskResult^>^ DirectOperate(AnalogOutputDouble64^ command, System::UInt16 index, TaskConfig^ config);				
-				virtual Task<CommandTaskResult^>^ DirectOperate(AnalogOutputInt16^ command, System::UInt16 index, TaskConfig^ config);
-				virtual Task<CommandTaskResult^>^ DirectOperate(AnalogOutputInt32^ command, System::UInt16 index, TaskConfig^ config);
-				virtual Task<CommandTaskResult^>^ DirectOperate(AnalogOutputFloat32^ command, System::UInt16 index, TaskConfig^ config);
-				
+                virtual Task<CommandTaskResult^>^ SelectAndOperate(ControlRelayOutputBlock^ command, System::UInt16 index, TaskConfig^ config);			
+                virtual Task<CommandTaskResult^>^ SelectAndOperate(AnalogOutputInt16^ command, System::UInt16 index, TaskConfig^ config);				
+                virtual Task<CommandTaskResult^>^ SelectAndOperate(AnalogOutputInt32^ command, System::UInt16 index, TaskConfig^ config);				
+                virtual Task<CommandTaskResult^>^ SelectAndOperate(AnalogOutputFloat32^ command, System::UInt16 index, TaskConfig^ config);				
+                virtual Task<CommandTaskResult^>^ SelectAndOperate(AnalogOutputDouble64^ command, System::UInt16 index, TaskConfig^ config);
+                
+                virtual Task<CommandTaskResult^>^ DirectOperate(ControlRelayOutputBlock^ command, System::UInt16 index, TaskConfig^ config);
+                virtual Task<CommandTaskResult^>^ DirectOperate(AnalogOutputDouble64^ command, System::UInt16 index, TaskConfig^ config);				
+                virtual Task<CommandTaskResult^>^ DirectOperate(AnalogOutputInt16^ command, System::UInt16 index, TaskConfig^ config);
+                virtual Task<CommandTaskResult^>^ DirectOperate(AnalogOutputInt32^ command, System::UInt16 index, TaskConfig^ config);
+                virtual Task<CommandTaskResult^>^ DirectOperate(AnalogOutputFloat32^ command, System::UInt16 index, TaskConfig^ config);
+                
 
-			private:
-				
-				opendnp3::IMasterOperations* operations;
-			};
+            private:
+                
+                opendnp3::IMasterOperations* operations;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/MasterScanAdapter.h
+++ b/dotnet/CLRAdapter/src/MasterScanAdapter.h
@@ -31,42 +31,42 @@ using namespace System::Collections::ObjectModel;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private ref class MasterScanAdapter : IMasterScan
-			{
-			public:
+            private ref class MasterScanAdapter : IMasterScan
+            {
+            public:
 
-				MasterScanAdapter(const std::shared_ptr<opendnp3::IMasterScan>& scan)
+                MasterScanAdapter(const std::shared_ptr<opendnp3::IMasterScan>& scan)
                     : 
-						scan(new std::shared_ptr<opendnp3::IMasterScan>(scan))
-				{}
+                        scan(new std::shared_ptr<opendnp3::IMasterScan>(scan))
+                {}
 
-				~MasterScanAdapter()
-				{
-					this->!MasterScanAdapter();
-				}
-				
-				!MasterScanAdapter()
-				{
-					delete scan;
-				}
+                ~MasterScanAdapter()
+                {
+                    this->!MasterScanAdapter();
+                }
+                
+                !MasterScanAdapter()
+                {
+                    delete scan;
+                }
 
-				virtual void Demand()
-				{
-					(*this->scan)->Demand();
-				}
+                virtual void Demand()
+                {
+                    (*this->scan)->Demand();
+                }
 
-			private:
+            private:
 
-				std::shared_ptr<opendnp3::IMasterScan>* scan;
-			};
+                std::shared_ptr<opendnp3::IMasterScan>* scan;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/MasterSessionAdapter.cpp
+++ b/dotnet/CLRAdapter/src/MasterSessionAdapter.cpp
@@ -21,28 +21,28 @@
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			MasterSessionAdapter::MasterSessionAdapter(std::shared_ptr<opendnp3::IMasterSession> proxy) :
-				MasterOperationsAdapter(proxy.get()),
-				proxy(new std::shared_ptr<opendnp3::IMasterSession>(proxy))
-			{
+            MasterSessionAdapter::MasterSessionAdapter(std::shared_ptr<opendnp3::IMasterSession> proxy) :
+                MasterOperationsAdapter(proxy.get()),
+                proxy(new std::shared_ptr<opendnp3::IMasterSession>(proxy))
+            {
 
-			}
+            }
 
-			void MasterSessionAdapter::BeginShutdown()
-			{
-				(*proxy)->BeginShutdown();
-			}
+            void MasterSessionAdapter::BeginShutdown()
+            {
+                (*proxy)->BeginShutdown();
+            }
 
-			Interface::IStackStatistics^ MasterSessionAdapter::GetStackStatistics()
-			{
-				return Conversions::ConvertStackStats((*proxy)->GetStackStatistics());
-			}
+            Interface::IStackStatistics^ MasterSessionAdapter::GetStackStatistics()
+            {
+                return Conversions::ConvertStackStats((*proxy)->GetStackStatistics());
+            }
 
-		}
-	}
+        }
+    }
 }

--- a/dotnet/CLRAdapter/src/MasterSessionAdapter.h
+++ b/dotnet/CLRAdapter/src/MasterSessionAdapter.h
@@ -34,39 +34,39 @@ using namespace System::Threading::Tasks;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private ref class MasterSessionAdapter sealed : IMasterSession, MasterOperationsAdapter
-			{
-			public:
+            private ref class MasterSessionAdapter sealed : IMasterSession, MasterOperationsAdapter
+            {
+            public:
 
-				MasterSessionAdapter(std::shared_ptr<opendnp3::IMasterSession> proxy);
-				
-				MasterSessionAdapter::~MasterSessionAdapter()
-				{
-					this->!MasterSessionAdapter();
-				}
+                MasterSessionAdapter(std::shared_ptr<opendnp3::IMasterSession> proxy);
+                
+                MasterSessionAdapter::~MasterSessionAdapter()
+                {
+                    this->!MasterSessionAdapter();
+                }
 
-				MasterSessionAdapter::!MasterSessionAdapter()
-				{
-					delete proxy;
-				}
+                MasterSessionAdapter::!MasterSessionAdapter()
+                {
+                    delete proxy;
+                }
 
-				/// --- implement IMasterSession ----
-				virtual void BeginShutdown();
+                /// --- implement IMasterSession ----
+                virtual void BeginShutdown();
 
-				virtual Interface::IStackStatistics^ GetStackStatistics();
+                virtual Interface::IStackStatistics^ GetStackStatistics();
 
-			private:
+            private:
 
-				std::shared_ptr<opendnp3::IMasterSession>* proxy;
-			};
+                std::shared_ptr<opendnp3::IMasterSession>* proxy;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/OutstationAdapter.cpp
+++ b/dotnet/CLRAdapter/src/OutstationAdapter.cpp
@@ -24,59 +24,59 @@
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			OutstationAdapter::OutstationAdapter(const std::shared_ptr<opendnp3::IOutstation>& outstation) : 
-				outstation(new std::shared_ptr<opendnp3::IOutstation>(outstation))
-			{}
+            OutstationAdapter::OutstationAdapter(const std::shared_ptr<opendnp3::IOutstation>& outstation) : 
+                outstation(new std::shared_ptr<opendnp3::IOutstation>(outstation))
+            {}
 
-			OutstationAdapter::!OutstationAdapter()
-			{
-				delete outstation;
-			}
+            OutstationAdapter::!OutstationAdapter()
+            {
+                delete outstation;
+            }
 
-			void OutstationAdapter::SetLogFilters(LogFilter filters)
-			{
+            void OutstationAdapter::SetLogFilters(LogFilter filters)
+            {
                 (*outstation)->SetLogFilters(opendnp3::LogLevel(filters.Flags));
-			}
+            }
 
-			void OutstationAdapter::Load(IChangeSet^ changes)
-			{
+            void OutstationAdapter::Load(IChangeSet^ changes)
+            {
                 auto adapter = gcnew UpdateAdapter();
-				changes->Apply(adapter);
-				adapter->Apply(**outstation);
-				delete adapter;
-			}
+                changes->Apply(adapter);
+                adapter->Apply(**outstation);
+                delete adapter;
+            }
 
-			void OutstationAdapter::SetRestartIIN()
-			{
-				(*outstation)->SetRestartIIN();
-			}
+            void OutstationAdapter::SetRestartIIN()
+            {
+                (*outstation)->SetRestartIIN();
+            }
 
-			void OutstationAdapter::Shutdown()
-			{
-				(*outstation)->Shutdown();
-			}
+            void OutstationAdapter::Shutdown()
+            {
+                (*outstation)->Shutdown();
+            }
 
-			void OutstationAdapter::Enable()
-			{
-				(*outstation)->Enable();
-			}
+            void OutstationAdapter::Enable()
+            {
+                (*outstation)->Enable();
+            }
 
-			void OutstationAdapter::Disable()
-			{
-				(*outstation)->Disable();
-			}
+            void OutstationAdapter::Disable()
+            {
+                (*outstation)->Disable();
+            }
 
-			IStackStatistics^ OutstationAdapter::GetStackStatistics()
-			{
-				auto stats = (*outstation)->GetStackStatistics();
-				return Conversions::ConvertStackStats(stats);
-			}
+            IStackStatistics^ OutstationAdapter::GetStackStatistics()
+            {
+                auto stats = (*outstation)->GetStackStatistics();
+                return Conversions::ConvertStackStats(stats);
+            }
 
-		}
-	}
+        }
+    }
 }

--- a/dotnet/CLRAdapter/src/OutstationAdapter.h
+++ b/dotnet/CLRAdapter/src/OutstationAdapter.h
@@ -28,41 +28,41 @@ using namespace System::Collections::ObjectModel;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private ref class OutstationAdapter : IOutstation
-			{
-			public:
+            private ref class OutstationAdapter : IOutstation
+            {
+            public:
 
-				OutstationAdapter(const std::shared_ptr<opendnp3::IOutstation>& outstation);
+                OutstationAdapter(const std::shared_ptr<opendnp3::IOutstation>& outstation);
 
-				~OutstationAdapter() { this ->!OutstationAdapter(); }
-				!OutstationAdapter();
+                ~OutstationAdapter() { this ->!OutstationAdapter(); }
+                !OutstationAdapter();
 
-				virtual void SetLogFilters(LogFilter filters);
+                virtual void SetLogFilters(LogFilter filters);
 
-				virtual void Load(IChangeSet^ changes);
+                virtual void Load(IChangeSet^ changes);
 
-				virtual void SetRestartIIN();
+                virtual void SetRestartIIN();
 
-				virtual void Shutdown();
+                virtual void Shutdown();
 
-				virtual void Enable();
+                virtual void Enable();
 
-				virtual void Disable();
+                virtual void Disable();
 
-				virtual IStackStatistics^ GetStackStatistics();
+                virtual IStackStatistics^ GetStackStatistics();
 
-			private:
+            private:
 
-				std::shared_ptr<opendnp3::IOutstation>* outstation;
-			};
+                std::shared_ptr<opendnp3::IOutstation>* outstation;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/OutstationApplicationAdapter.cpp
+++ b/dotnet/CLRAdapter/src/OutstationApplicationAdapter.cpp
@@ -23,112 +23,112 @@
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			OutstationApplicationAdapter::OutstationApplicationAdapter(Automatak::DNP3::Interface::IOutstationApplication^ proxy_) :
-				proxy(proxy_)
-			{
+            OutstationApplicationAdapter::OutstationApplicationAdapter(Automatak::DNP3::Interface::IOutstationApplication^ proxy_) :
+                proxy(proxy_)
+            {
 
-			}
+            }
 
-			void OutstationApplicationAdapter::OnStateChange(opendnp3::LinkStatus value)
-			{
-				proxy->OnStateChange((LinkStatus)value);
-			}
+            void OutstationApplicationAdapter::OnStateChange(opendnp3::LinkStatus value)
+            {
+                proxy->OnStateChange((LinkStatus)value);
+            }
 
-			void OutstationApplicationAdapter::OnUnknownDestinationAddress(uint16_t destination)
-			{
-				proxy->OnUnknownDestinationAddress(destination);
-			}
+            void OutstationApplicationAdapter::OnUnknownDestinationAddress(uint16_t destination)
+            {
+                proxy->OnUnknownDestinationAddress(destination);
+            }
 
-			void OutstationApplicationAdapter::OnUnknownSourceAddress(uint16_t source)
-			{
-				proxy->OnUnknownSourceAddress(source);
-			}
+            void OutstationApplicationAdapter::OnUnknownSourceAddress(uint16_t source)
+            {
+                proxy->OnUnknownSourceAddress(source);
+            }
 
-			void OutstationApplicationAdapter::OnKeepAliveInitiated()
-			{
-				proxy->OnKeepAliveInitiated();
-			}
+            void OutstationApplicationAdapter::OnKeepAliveInitiated()
+            {
+                proxy->OnKeepAliveInitiated();
+            }
 
-			void OutstationApplicationAdapter::OnKeepAliveFailure()
-			{
-				proxy->OnKeepAliveFailure();
-			}
+            void OutstationApplicationAdapter::OnKeepAliveFailure()
+            {
+                proxy->OnKeepAliveFailure();
+            }
 
-			void OutstationApplicationAdapter::OnKeepAliveSuccess()
-			{
-				proxy->OnKeepAliveSuccess();
-			}
+            void OutstationApplicationAdapter::OnKeepAliveSuccess()
+            {
+                proxy->OnKeepAliveSuccess();
+            }
 
-			bool OutstationApplicationAdapter::WriteAbsoluteTime(const opendnp3::UTCTimestamp& timestamp)
-			{
-				return proxy->WriteAbsoluteTime(timestamp.msSinceEpoch);
-			}
+            bool OutstationApplicationAdapter::WriteAbsoluteTime(const opendnp3::UTCTimestamp& timestamp)
+            {
+                return proxy->WriteAbsoluteTime(timestamp.msSinceEpoch);
+            }
 
-			bool OutstationApplicationAdapter::SupportsWriteAbsoluteTime()
-			{
-				return proxy->SupportsWriteAbsoluteTime;
-			}
+            bool OutstationApplicationAdapter::SupportsWriteAbsoluteTime()
+            {
+                return proxy->SupportsWriteAbsoluteTime;
+            }
 
-			bool OutstationApplicationAdapter::SupportsWriteTimeAndInterval()
-			{
-				return proxy->SupportsWriteTimeAndInterval();
-			}
+            bool OutstationApplicationAdapter::SupportsWriteTimeAndInterval()
+            {
+                return proxy->SupportsWriteTimeAndInterval();
+            }
 
-			bool OutstationApplicationAdapter::WriteTimeAndInterval(const opendnp3::ICollection<opendnp3::Indexed<opendnp3::TimeAndInterval>>& values)
-			{
-				auto list = Conversions::ToIndexedEnumerable<TimeAndInterval^>(values);
+            bool OutstationApplicationAdapter::WriteTimeAndInterval(const opendnp3::ICollection<opendnp3::Indexed<opendnp3::TimeAndInterval>>& values)
+            {
+                auto list = Conversions::ToIndexedEnumerable<TimeAndInterval^>(values);
 
-				return proxy->WriteTimeAndInterval(list);
-			}
+                return proxy->WriteTimeAndInterval(list);
+            }
 
-			bool OutstationApplicationAdapter::SupportsAssignClass()
-			{
-				return proxy->SupportsAssignClass();
-			}
+            bool OutstationApplicationAdapter::SupportsAssignClass()
+            {
+                return proxy->SupportsAssignClass();
+            }
 
-			void OutstationApplicationAdapter::RecordClassAssignment(opendnp3::AssignClassType type, opendnp3::PointClass clazz, uint16_t start, uint16_t stop)
-			{
-				proxy->RecordClassAssignment((AssignClassType) type, (PointClass) clazz, start, stop);
-			}
+            void OutstationApplicationAdapter::RecordClassAssignment(opendnp3::AssignClassType type, opendnp3::PointClass clazz, uint16_t start, uint16_t stop)
+            {
+                proxy->RecordClassAssignment((AssignClassType) type, (PointClass) clazz, start, stop);
+            }
 
-			opendnp3::ApplicationIIN OutstationApplicationAdapter::GetApplicationIIN() const
-			{
-				ApplicationIIN indications = proxy->ApplicationIndications;
+            opendnp3::ApplicationIIN OutstationApplicationAdapter::GetApplicationIIN() const
+            {
+                ApplicationIIN indications = proxy->ApplicationIndications;
 
-				opendnp3::ApplicationIIN iin;
-				iin.configCorrupt = indications.configCorrupt;
-				iin.deviceTrouble = indications.deviceTrouble;
-				iin.localControl = indications.localControl;
-				iin.needTime = indications.needTime;
-				iin.eventBufferOverflow = indications.eventBufferOverflow;
-				return iin;
-			}
+                opendnp3::ApplicationIIN iin;
+                iin.configCorrupt = indications.configCorrupt;
+                iin.deviceTrouble = indications.deviceTrouble;
+                iin.localControl = indications.localControl;
+                iin.needTime = indications.needTime;
+                iin.eventBufferOverflow = indications.eventBufferOverflow;
+                return iin;
+            }
 
-			opendnp3::RestartMode OutstationApplicationAdapter::ColdRestartSupport() const
-			{
-				return (opendnp3::RestartMode) proxy->ColdRestartSupport;
-			}
+            opendnp3::RestartMode OutstationApplicationAdapter::ColdRestartSupport() const
+            {
+                return (opendnp3::RestartMode) proxy->ColdRestartSupport;
+            }
 
-			opendnp3::RestartMode OutstationApplicationAdapter::WarmRestartSupport() const
-			{
-				return (opendnp3::RestartMode) proxy->WarmRestartSupport;
-			}
+            opendnp3::RestartMode OutstationApplicationAdapter::WarmRestartSupport() const
+            {
+                return (opendnp3::RestartMode) proxy->WarmRestartSupport;
+            }
 
-			uint16_t OutstationApplicationAdapter::ColdRestart()
-			{
-				return proxy->ColdRestart();
-			}
+            uint16_t OutstationApplicationAdapter::ColdRestart()
+            {
+                return proxy->ColdRestart();
+            }
 
-			uint16_t OutstationApplicationAdapter::WarmRestart()
-			{
-				return proxy->WarmRestart();
-			}
+            uint16_t OutstationApplicationAdapter::WarmRestart()
+            {
+                return proxy->WarmRestart();
+            }
 
-		}
-	}
+        }
+    }
 }

--- a/dotnet/CLRAdapter/src/OutstationApplicationAdapter.h
+++ b/dotnet/CLRAdapter/src/OutstationApplicationAdapter.h
@@ -30,57 +30,57 @@ using namespace System::Collections::ObjectModel;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private class OutstationApplicationAdapter final : public opendnp3::IOutstationApplication
-			{
-			public:
-				OutstationApplicationAdapter(Automatak::DNP3::Interface::IOutstationApplication^ proxy);
+            private class OutstationApplicationAdapter final : public opendnp3::IOutstationApplication
+            {
+            public:
+                OutstationApplicationAdapter(Automatak::DNP3::Interface::IOutstationApplication^ proxy);
 
-				virtual void OnStateChange(opendnp3::LinkStatus value) override;
-				
-				virtual void OnUnknownDestinationAddress(uint16_t destination) override;
-				
-				virtual void OnUnknownSourceAddress(uint16_t source) override;
+                virtual void OnStateChange(opendnp3::LinkStatus value) override;
+                
+                virtual void OnUnknownDestinationAddress(uint16_t destination) override;
+                
+                virtual void OnUnknownSourceAddress(uint16_t source) override;
 
-				virtual void OnKeepAliveInitiated() override final;
+                virtual void OnKeepAliveInitiated() override final;
 
-				virtual void OnKeepAliveFailure() override final;
+                virtual void OnKeepAliveFailure() override final;
 
-				virtual void OnKeepAliveSuccess() override final;				
+                virtual void OnKeepAliveSuccess() override final;				
 
-				virtual bool WriteAbsoluteTime(const opendnp3::UTCTimestamp& timestamp) override final;
+                virtual bool WriteAbsoluteTime(const opendnp3::UTCTimestamp& timestamp) override final;
 
-				virtual bool SupportsWriteAbsoluteTime() override final;
-				
-				virtual bool SupportsWriteTimeAndInterval() override final;
-				
-				virtual bool WriteTimeAndInterval(const opendnp3::ICollection<opendnp3::Indexed<opendnp3::TimeAndInterval>>& values) override final;
+                virtual bool SupportsWriteAbsoluteTime() override final;
+                
+                virtual bool SupportsWriteTimeAndInterval() override final;
+                
+                virtual bool WriteTimeAndInterval(const opendnp3::ICollection<opendnp3::Indexed<opendnp3::TimeAndInterval>>& values) override final;
 
-				virtual bool SupportsAssignClass() override final;
+                virtual bool SupportsAssignClass() override final;
 
-				virtual void RecordClassAssignment(opendnp3::AssignClassType type, opendnp3::PointClass clazz, uint16_t start, uint16_t stop) override final;
+                virtual void RecordClassAssignment(opendnp3::AssignClassType type, opendnp3::PointClass clazz, uint16_t start, uint16_t stop) override final;
 
-				virtual opendnp3::ApplicationIIN GetApplicationIIN() const override final;
+                virtual opendnp3::ApplicationIIN GetApplicationIIN() const override final;
 
-				virtual opendnp3::RestartMode ColdRestartSupport() const override final;
+                virtual opendnp3::RestartMode ColdRestartSupport() const override final;
 
-				virtual opendnp3::RestartMode WarmRestartSupport() const override final;
+                virtual opendnp3::RestartMode WarmRestartSupport() const override final;
 
-				virtual uint16_t ColdRestart();
+                virtual uint16_t ColdRestart();
 
-				virtual uint16_t WarmRestart();
+                virtual uint16_t WarmRestart();
 
-			private:
+            private:
 
-				gcroot < Automatak::DNP3::Interface::IOutstationApplication^ > proxy;
-			};
+                gcroot < Automatak::DNP3::Interface::IOutstationApplication^ > proxy;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/OutstationCommandHandlerAdapter.h
+++ b/dotnet/CLRAdapter/src/OutstationCommandHandlerAdapter.h
@@ -36,8 +36,7 @@ namespace DNP3
     {
 
         // this object goes into the stack
-    private
-        class OutstationCommandHandlerAdapter : public opendnp3::ICommandHandler
+        private class OutstationCommandHandlerAdapter : public opendnp3::ICommandHandler
         {
         public:
             OutstationCommandHandlerAdapter(Automatak::DNP3::Interface::ICommandHandler ^ proxy);

--- a/dotnet/CLRAdapter/src/SOEHandlerAdapter.cpp
+++ b/dotnet/CLRAdapter/src/SOEHandlerAdapter.cpp
@@ -23,102 +23,102 @@
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			HeaderInfo ^ ConvertHeaderInfo(const opendnp3::HeaderInfo& info)
+            HeaderInfo ^ ConvertHeaderInfo(const opendnp3::HeaderInfo& info)
             {
                 return gcnew HeaderInfo((GroupVariation)info.gv, (QualifierCode)info.qualifier,
                                         (TimestampQuality)info.tsquality, info.isEventVariation, info.flagsValid,
                                         info.headerIndex);
             }
 
-			ResponseInfo ^ ConvertResponseInfo(const opendnp3::ResponseInfo& info)
+            ResponseInfo ^ ConvertResponseInfo(const opendnp3::ResponseInfo& info)
             {
                 return gcnew ResponseInfo(info.unsolicited, info.fir, info.fin);
             }
 
-			SOEHandlerAdapter::SOEHandlerAdapter(Automatak::DNP3::Interface::ISOEHandler^ aProxy) : proxy(aProxy)
-			{}
+            SOEHandlerAdapter::SOEHandlerAdapter(Automatak::DNP3::Interface::ISOEHandler^ aProxy) : proxy(aProxy)
+            {}
                         
             void SOEHandlerAdapter::BeginFragment(const opendnp3::ResponseInfo& info)
-			{
-				proxy->BeginFragment(ConvertResponseInfo(info));
-			}
+            {
+                proxy->BeginFragment(ConvertResponseInfo(info));
+            }
 
-			void SOEHandlerAdapter::EndFragment(const opendnp3::ResponseInfo& info)
-			{
+            void SOEHandlerAdapter::EndFragment(const opendnp3::ResponseInfo& info)
+            {
                 proxy->EndFragment(ConvertResponseInfo(info));
-			}
-		
-			void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::Binary>>& values)
-			{
-				auto enumerable = Conversions::ToIndexedEnumerable<Binary^>(values);
+            }
+        
+            void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::Binary>>& values)
+            {
+                auto enumerable = Conversions::ToIndexedEnumerable<Binary^>(values);
                 proxy->Process(ConvertHeaderInfo(info), enumerable);
-			}
+            }
 
-			void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::DoubleBitBinary>>& values)
-			{
-				auto enumerable = Conversions::ToIndexedEnumerable<DoubleBitBinary^>(values);
+            void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::DoubleBitBinary>>& values)
+            {
+                auto enumerable = Conversions::ToIndexedEnumerable<DoubleBitBinary^>(values);
                 proxy->Process(ConvertHeaderInfo(info), enumerable);
-			}
+            }
 
-			void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::Analog>>& values)
-			{
-				auto enumerable = Conversions::ToIndexedEnumerable<Analog^>(values);
+            void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::Analog>>& values)
+            {
+                auto enumerable = Conversions::ToIndexedEnumerable<Analog^>(values);
                 proxy->Process(ConvertHeaderInfo(info), enumerable);
-			}
+            }
 
-			void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::Counter>>& values)
-			{
-				auto enumerable = Conversions::ToIndexedEnumerable<Counter^>(values);
+            void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::Counter>>& values)
+            {
+                auto enumerable = Conversions::ToIndexedEnumerable<Counter^>(values);
                 proxy->Process(ConvertHeaderInfo(info), enumerable);
-			}
+            }
 
-			void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::FrozenCounter>>& values)
-			{
-				auto enumerable = Conversions::ToIndexedEnumerable<FrozenCounter^>(values);
+            void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::FrozenCounter>>& values)
+            {
+                auto enumerable = Conversions::ToIndexedEnumerable<FrozenCounter^>(values);
                 proxy->Process(ConvertHeaderInfo(info), enumerable);
-			}
+            }
 
-			void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::BinaryOutputStatus>>& values)
-			{
-				auto enumerable = Conversions::ToIndexedEnumerable<BinaryOutputStatus^>(values);
+            void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::BinaryOutputStatus>>& values)
+            {
+                auto enumerable = Conversions::ToIndexedEnumerable<BinaryOutputStatus^>(values);
                 proxy->Process(ConvertHeaderInfo(info), enumerable);
-			}
+            }
 
-			void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::AnalogOutputStatus>>& values)
-			{
-				auto enumerable = Conversions::ToIndexedEnumerable<AnalogOutputStatus^>(values);
+            void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::AnalogOutputStatus>>& values)
+            {
+                auto enumerable = Conversions::ToIndexedEnumerable<AnalogOutputStatus^>(values);
                 proxy->Process(ConvertHeaderInfo(info), enumerable);
-			}
+            }
 
-			void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::OctetString>>& values)
-			{
-				auto enumerable = Conversions::ToIndexedEnumerable<OctetString^>(values);
+            void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::OctetString>>& values)
+            {
+                auto enumerable = Conversions::ToIndexedEnumerable<OctetString^>(values);
                 proxy->Process(ConvertHeaderInfo(info), enumerable);
-			}
+            }
 
-			void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::TimeAndInterval>>& values)
-			{
-				auto enumerable = Conversions::ToIndexedEnumerable<TimeAndInterval^>(values);
+            void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::TimeAndInterval>>& values)
+            {
+                auto enumerable = Conversions::ToIndexedEnumerable<TimeAndInterval^>(values);
                 proxy->Process(ConvertHeaderInfo(info), enumerable);
-			}
+            }
 
-			void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::BinaryCommandEvent>>& values)
-			{
-				auto enumerable = Conversions::ToIndexedEnumerable<BinaryCommandEvent^>(values);
+            void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::BinaryCommandEvent>>& values)
+            {
+                auto enumerable = Conversions::ToIndexedEnumerable<BinaryCommandEvent^>(values);
                 proxy->Process(ConvertHeaderInfo(info), enumerable);
-			}
+            }
 
-			void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::AnalogCommandEvent>>& values)
-			{
-				auto enumerable = Conversions::ToIndexedEnumerable<AnalogCommandEvent^>(values);
+            void SOEHandlerAdapter::Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::AnalogCommandEvent>>& values)
+            {
+                auto enumerable = Conversions::ToIndexedEnumerable<AnalogCommandEvent^>(values);
                 proxy->Process(ConvertHeaderInfo(info), enumerable);
-			}
-		
-		}
-	}
+            }
+        
+        }
+    }
 }

--- a/dotnet/CLRAdapter/src/SOEHandlerAdapter.h
+++ b/dotnet/CLRAdapter/src/SOEHandlerAdapter.h
@@ -30,40 +30,40 @@ using namespace System::Collections::ObjectModel;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private class SOEHandlerAdapter : public opendnp3::ISOEHandler
-			{
-			public:
+            private class SOEHandlerAdapter : public opendnp3::ISOEHandler
+            {
+            public:
 
-				SOEHandlerAdapter(Automatak::DNP3::Interface::ISOEHandler^ proxy);
+                SOEHandlerAdapter(Automatak::DNP3::Interface::ISOEHandler^ proxy);
 
-				virtual void BeginFragment(const opendnp3::ResponseInfo& info) override final;
+                virtual void BeginFragment(const opendnp3::ResponseInfo& info) override final;
                 virtual void EndFragment(const opendnp3::ResponseInfo& info) override final;
 
-				virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::Binary>>& values) override final;
-				virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::DoubleBitBinary>>& values) override final;
-				virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::Analog>>& values) override final;
-				virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::Counter>>& values) override final;
-				virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::FrozenCounter>>& values) override final;
-				virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::BinaryOutputStatus>>& values) override final;
-				virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::AnalogOutputStatus>>& values) override final;
-				virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::OctetString>>& values) override final;
-				virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::TimeAndInterval>>& values) override final;
-				virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::BinaryCommandEvent>>& values) override final;
-				virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::AnalogCommandEvent>>& values) override final;				
-				virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::DNPTime>& values) override final {} // not implemented in bindings
+                virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::Binary>>& values) override final;
+                virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::DoubleBitBinary>>& values) override final;
+                virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::Analog>>& values) override final;
+                virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::Counter>>& values) override final;
+                virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::FrozenCounter>>& values) override final;
+                virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::BinaryOutputStatus>>& values) override final;
+                virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::AnalogOutputStatus>>& values) override final;
+                virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::OctetString>>& values) override final;
+                virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::TimeAndInterval>>& values) override final;
+                virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::BinaryCommandEvent>>& values) override final;
+                virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::Indexed<opendnp3::AnalogCommandEvent>>& values) override final;				
+                virtual void Process(const opendnp3::HeaderInfo& info, const opendnp3::ICollection<opendnp3::DNPTime>& values) override final {} // not implemented in bindings
 
-			private:				
+            private:
 
-				gcroot < Automatak::DNP3::Interface::ISOEHandler^ > proxy;
-			};
+                gcroot < Automatak::DNP3::Interface::ISOEHandler^ > proxy;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/SessionAcceptorAdapter.cpp
+++ b/dotnet/CLRAdapter/src/SessionAcceptorAdapter.cpp
@@ -26,37 +26,37 @@
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			SessionAcceptorAdapter::SessionAcceptorAdapter(opendnp3::ISessionAcceptor& proxy) :
-				proxy(&proxy)
-			{}
+            SessionAcceptorAdapter::SessionAcceptorAdapter(opendnp3::ISessionAcceptor& proxy) :
+                proxy(&proxy)
+            {}
 
-			IMasterSession^ SessionAcceptorAdapter::AcceptSession(
-				System::String^ loggerid,
-				ISOEHandler^ SOEHandler,
-				IMasterApplication^ application,
-				MasterStackConfig^ config
-				)
-			{
-				auto id = Conversions::ConvertString(loggerid);
-				auto mconfig = Conversions::ConvertConfig(config);	
-				auto handler = std::shared_ptr<SOEHandlerAdapter>(new SOEHandlerAdapter(SOEHandler));
-				auto app = std::shared_ptr<MasterApplicationAdapter>(new MasterApplicationAdapter(application));
-	
-				auto session = proxy->AcceptSession(id, handler, app, mconfig);
+            IMasterSession^ SessionAcceptorAdapter::AcceptSession(
+                System::String^ loggerid,
+                ISOEHandler^ SOEHandler,
+                IMasterApplication^ application,
+                MasterStackConfig^ config
+                )
+            {
+                auto id = Conversions::ConvertString(loggerid);
+                auto mconfig = Conversions::ConvertConfig(config);	
+                auto handler = std::shared_ptr<SOEHandlerAdapter>(new SOEHandlerAdapter(SOEHandler));
+                auto app = std::shared_ptr<MasterApplicationAdapter>(new MasterApplicationAdapter(application));
+    
+                auto session = proxy->AcceptSession(id, handler, app, mconfig);
 
-				if (!session)
-				{
-					return nullptr;
-				}
-	
-				return gcnew MasterSessionAdapter(session);
-			}
+                if (!session)
+                {
+                    return nullptr;
+                }
+    
+                return gcnew MasterSessionAdapter(session);
+            }
 
-		}
-	}
+        }
+    }
 }

--- a/dotnet/CLRAdapter/src/SessionAcceptorAdapter.h
+++ b/dotnet/CLRAdapter/src/SessionAcceptorAdapter.h
@@ -29,31 +29,31 @@ using namespace Automatak::DNP3::Interface;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private ref class SessionAcceptorAdapter sealed : public ISessionAcceptor
-			{
-			public:
+            private ref class SessionAcceptorAdapter sealed : public ISessionAcceptor
+            {
+            public:
 
-				SessionAcceptorAdapter(opendnp3::ISessionAcceptor& proxy);
-				
-				virtual IMasterSession^ AcceptSession(
-					System::String^ loggerid,
-					ISOEHandler^ SOEHandler,
-					IMasterApplication^ application,
-					MasterStackConfig^ config
-				);
-				
-			private:
+                SessionAcceptorAdapter(opendnp3::ISessionAcceptor& proxy);
+                
+                virtual IMasterSession^ AcceptSession(
+                    System::String^ loggerid,
+                    ISOEHandler^ SOEHandler,
+                    IMasterApplication^ application,
+                    MasterStackConfig^ config
+                );
+                
+            private:
 
-				opendnp3::ISessionAcceptor* proxy;
-			};
+                opendnp3::ISessionAcceptor* proxy;
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/TaskCallbackAdapter.h
+++ b/dotnet/CLRAdapter/src/TaskCallbackAdapter.h
@@ -34,45 +34,44 @@ using namespace System::Collections::ObjectModel;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			class TaskCallbackAdapter : public opendnp3::ITaskCallback, opendnp3::Uncopyable
-			{
-			public:
+            class TaskCallbackAdapter : public opendnp3::ITaskCallback, opendnp3::Uncopyable
+            {
+            public:
 
-				static std::shared_ptr<opendnp3::ITaskCallback> Create(Automatak::DNP3::Interface::ITaskCallback^ proxy)
-				{
-					return std::make_shared<TaskCallbackAdapter>(proxy);
-				}
+                static std::shared_ptr<opendnp3::ITaskCallback> Create(Automatak::DNP3::Interface::ITaskCallback^ proxy)
+                {
+                    return std::make_shared<TaskCallbackAdapter>(proxy);
+                }
 
                 TaskCallbackAdapter(Automatak::DNP3::Interface::ITaskCallback ^ proxy) : root(proxy) {}
 
-				virtual void OnStart() sealed
-				{
-					root->OnStart();
-				}
+                virtual void OnStart() sealed
+                {
+                    root->OnStart();
+                }
 
-				virtual void OnComplete(opendnp3::TaskCompletion result) sealed
-				{
-					root->OnComplete((TaskCompletion) result);
-				}
+                virtual void OnComplete(opendnp3::TaskCompletion result) sealed
+                {
+                    root->OnComplete((TaskCompletion) result);
+                }
 
-				virtual void OnDestroyed() sealed
-				{
-					root->OnDestroyed();
-					delete this;
-				}
+                virtual void OnDestroyed() sealed
+                {
+                    root->OnDestroyed();
+                }
 
-			private:
+            private:
 
-				gcroot < Automatak::DNP3::Interface::ITaskCallback^ > root;
-			};
-		
-		}
-	}
+                gcroot < Automatak::DNP3::Interface::ITaskCallback^ > root;
+            };
+        
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRAdapter/src/UpdateAdapter.h
+++ b/dotnet/CLRAdapter/src/UpdateAdapter.h
@@ -30,26 +30,25 @@ using namespace Automatak::DNP3::Interface;
 
 namespace Automatak
 {
-	namespace DNP3
-	{
-		namespace Adapter
-		{
+    namespace DNP3
+    {
+        namespace Adapter
+        {
 
-			private ref class UpdateAdapter : public DatabaseAdapter<opendnp3::UpdateBuilder>
+            private ref class UpdateAdapter : public DatabaseAdapter<opendnp3::UpdateBuilder>
             {
-			public:
+            public:
 
-				UpdateAdapter();
+                UpdateAdapter();
 
-				~UpdateAdapter();
-                !UpdateAdapter();				
+                ~UpdateAdapter();
+                !UpdateAdapter();
 
-				void Apply(opendnp3::IOutstation& proxy);					
-                		                               
-			};
+                void Apply(opendnp3::IOutstation& proxy);
+            };
 
-		}
-	}
+        }
+    }
 }
 
 #endif

--- a/dotnet/CLRInterface/src/TaskInfo.cs
+++ b/dotnet/CLRInterface/src/TaskInfo.cs
@@ -29,11 +29,11 @@ namespace Automatak.DNP3.Interface
         {
             this.type = type;
             this.result = result;
-            this.taskid = taskid;            
+            this.taskid = taskid;
         }
           
-        public readonly MasterTaskType type; 
+        public readonly MasterTaskType type;
         public readonly TaskCompletion result;
-        public readonly TaskId taskid;        
+        public readonly TaskId taskid;
     }
 }


### PR DESCRIPTION
- Fix issue in TaskCallbackAdapter that was deleted twice. This only affects the 3.x branch.
- Also formatted all the C# adapter files to indent with spaces instead of tabs.