### PR TITLE
Makes DNPTime(uint64_t value) default to TimestampQuality::Synchronzied

### DIFF
--- a/cpp/lib/include/opendnp3/app/DNPTime.h
+++ b/cpp/lib/include/opendnp3/app/DNPTime.h
@@ -30,7 +30,7 @@ namespace opendnp3
 struct DNPTime
 {
     DNPTime() : value(0), quality(TimestampQuality::INVALID) {}
-    explicit DNPTime(uint64_t value) : value(value), quality(TimestampQuality::INVALID) {}
+    explicit DNPTime(uint64_t value) : value(value), quality(TimestampQuality::SYNCHRONIZED) {}
     DNPTime(uint64_t value, TimestampQuality quality) : value(value), quality(quality) {}
 
     bool operator==(const DNPTime& rhs) const

--- a/cpp/tests/unit/TestOutstationEventResponses.cpp
+++ b/cpp/tests/unit/TestOutstationEventResponses.cpp
@@ -360,7 +360,7 @@ TEST_CASE(SUITE("ReadGrp2Var2"))
 
 TEST_CASE(SUITE("ReadGrp2Var3SingleValue"))
 {
-    auto update = [](IUpdateHandler& db) { db.Update(Binary(false, Flags(0x01), DNPTime(0x4571)), 3); };
+    auto update = [](IUpdateHandler& db) { db.Update(Binary(false, Flags(0x01), DNPTime(0x4571, TimestampQuality::UNSYNCHRONIZED)), 3); };
 
     TestEventRead("C0 01 02 03 06", "E0 81 80 00 33 02 07 01 71 45 00 00 00 00 02 03 28 01 00 03 00 01 00 00", update);
 }

--- a/dotnet/CLRInterface/src/DNPTime.cs
+++ b/dotnet/CLRInterface/src/DNPTime.cs
@@ -22,12 +22,12 @@ namespace Automatak.DNP3.Interface
 {
     public class DNPTime
     {
-        public static DNPTime Unset = new DNPTime(DateTime.MinValue, TimestampQuality.INVALID);
-        private static DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        public static readonly DNPTime Unset = new DNPTime(DateTime.MinValue, TimestampQuality.INVALID);
+        private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         public static DNPTime Now
         {
-            get { return new DNPTime(DateTime.Now, TimestampQuality.INVALID); }
+            get { return new DNPTime(DateTime.Now, TimestampQuality.SYNCHRONIZED); }
         }
 
         public static DNPTime FromEpoch(Int64 epochTime, TimestampQuality quality)
@@ -43,7 +43,7 @@ namespace Automatak.DNP3.Interface
             }
         }
 
-        public DNPTime(DateTime time) : this(time, TimestampQuality.INVALID)
+        public DNPTime(DateTime time) : this(time, TimestampQuality.SYNCHRONIZED)
         {
         }
 

--- a/java/bindings/src/main/java/com/automatak/dnp3/DNPTime.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/DNPTime.java
@@ -21,14 +21,12 @@ package com.automatak.dnp3;
 
 import com.automatak.dnp3.enums.TimestampQuality;
 
-/**
- * Maps to g50v1
- */
+
 public class DNPTime {
 
     public DNPTime(long msSinceEpoch)
     {
-        this(msSinceEpoch, TimestampQuality.INVALID);
+        this(msSinceEpoch, TimestampQuality.SYNCHRONIZED);
     }
 
     public DNPTime(long msSinceEpoch, TimestampQuality quality)


### PR DESCRIPTION
Deleting this constructor entirely and/or adding an internal "Timestamp" type in the variations
turned out to be way more involved than I would have liked.

1) This might break the conformance tests depending on how they constructor DNPTime
2) I changed the C# and Java versions of DNPTime to match
3) There are units tests for g1v{1,2,3} for the MeasurementHandler