### PR TITLE
check max/min values for ms, s, min when constructing TimeDuration

### DIFF
--- a/cpp/lib/include/opendnp3/util/TimeDuration.h
+++ b/cpp/lib/include/opendnp3/util/TimeDuration.h
@@ -45,11 +45,7 @@ public:
 
     static TimeDuration Seconds(int64_t seconds);
 
-    static TimeDuration Minutes(int64_t minutes);
-
-    static TimeDuration Hours(int64_t hours);
-
-    static TimeDuration Days(int64_t days);
+    static TimeDuration Minutes(int64_t minutes);    
 
     TimeDuration();
 

--- a/cpp/lib/include/opendnp3/util/TimeDuration.h
+++ b/cpp/lib/include/opendnp3/util/TimeDuration.h
@@ -64,6 +64,8 @@ public:
     std::chrono::steady_clock::duration value;
 
 private:
+    template<class T> static TimeDuration FromValue(int64_t value);
+
     explicit TimeDuration(std::chrono::steady_clock::duration value);
 };
 

--- a/cpp/lib/src/util/TimeDuration.cpp
+++ b/cpp/lib/src/util/TimeDuration.cpp
@@ -39,56 +39,39 @@ TimeDuration TimeDuration::Zero()
     return TimeDuration(std::chrono::milliseconds(0));
 }
 
-TimeDuration TimeDuration::Milliseconds(int64_t milliseconds)
-{        
+template<class T> TimeDuration TimeDuration::FromValue(int64_t value)
+{
     // > this will overflow when converting to nanos
-    const auto MAX = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::duration::max()).count();
+    const auto MAX = std::chrono::duration_cast<T>(std::chrono::steady_clock::duration::max()).count();
+    const auto MIN = std::chrono::duration_cast<T>(std::chrono::steady_clock::duration::min()).count();
 
-    if (milliseconds > MAX)
+    if (value > MAX)
     {
         return TimeDuration(std::chrono::steady_clock::duration::max());
     }
-    else
+
+    if (value < MIN)
     {
-        return TimeDuration(std::chrono::milliseconds(milliseconds));
+        return TimeDuration(std::chrono::steady_clock::duration::min());
     }
-    
-    return TimeDuration(std::chrono::milliseconds(milliseconds));
+
+    return TimeDuration(T(value));
+}
+
+TimeDuration TimeDuration::Milliseconds(int64_t milliseconds)
+{        
+    return FromValue<std::chrono::milliseconds>(milliseconds);
 }
 
 
 TimeDuration TimeDuration::Seconds(int64_t seconds)
 {
-    // > this will overflow when converting to nanos
-    const auto MAX = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::duration::max()).count();
-
-    if (seconds > MAX)
-    {
-        return TimeDuration(std::chrono::steady_clock::duration::max());
-    }
-    else
-    {
-        return TimeDuration(std::chrono::seconds(seconds));
-    }
-
-    return TimeDuration(std::chrono::seconds(seconds));
+    return FromValue<std::chrono::seconds>(seconds);
 }
 
 TimeDuration TimeDuration::Minutes(int64_t minutes)
 {
-    // > this will overflow when converting to nanos
-    const auto MAX = std::chrono::duration_cast<std::chrono::minutes>(std::chrono::steady_clock::duration::max()).count();
-
-    if (minutes > MAX)
-    {
-        return TimeDuration(std::chrono::steady_clock::duration::max());
-    }
-    else
-    {
-        return TimeDuration(std::chrono::minutes(minutes));
-    }
-
-    return TimeDuration(std::chrono::seconds(minutes));
+    return FromValue<std::chrono::minutes>(minutes);
 }
 
 

--- a/cpp/lib/src/util/TimeDuration.cpp
+++ b/cpp/lib/src/util/TimeDuration.cpp
@@ -40,29 +40,57 @@ TimeDuration TimeDuration::Zero()
 }
 
 TimeDuration TimeDuration::Milliseconds(int64_t milliseconds)
-{
+{        
+    // > this will overflow when converting to nanos
+    const auto MAX = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::duration::max()).count();
+
+    if (milliseconds > MAX)
+    {
+        return TimeDuration(std::chrono::steady_clock::duration::max());
+    }
+    else
+    {
+        return TimeDuration(std::chrono::milliseconds(milliseconds));
+    }
+    
     return TimeDuration(std::chrono::milliseconds(milliseconds));
 }
 
+
 TimeDuration TimeDuration::Seconds(int64_t seconds)
 {
+    // > this will overflow when converting to nanos
+    const auto MAX = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::duration::max()).count();
+
+    if (seconds > MAX)
+    {
+        return TimeDuration(std::chrono::steady_clock::duration::max());
+    }
+    else
+    {
+        return TimeDuration(std::chrono::seconds(seconds));
+    }
+
     return TimeDuration(std::chrono::seconds(seconds));
 }
 
 TimeDuration TimeDuration::Minutes(int64_t minutes)
 {
-    return TimeDuration(std::chrono::minutes(minutes));
+    // > this will overflow when converting to nanos
+    const auto MAX = std::chrono::duration_cast<std::chrono::minutes>(std::chrono::steady_clock::duration::max()).count();
+
+    if (minutes > MAX)
+    {
+        return TimeDuration(std::chrono::steady_clock::duration::max());
+    }
+    else
+    {
+        return TimeDuration(std::chrono::minutes(minutes));
+    }
+
+    return TimeDuration(std::chrono::seconds(minutes));
 }
 
-TimeDuration TimeDuration::Hours(int64_t hours)
-{
-    return TimeDuration(std::chrono::hours(hours));
-}
-
-TimeDuration TimeDuration::Days(int64_t days)
-{
-    return TimeDuration(std::chrono::hours(24) * days);
-}
 
 TimeDuration::TimeDuration() : value(std::chrono::milliseconds(0)) {}
 

--- a/cpp/tests/unit/CMakeLists.txt
+++ b/cpp/tests/unit/CMakeLists.txt
@@ -54,6 +54,7 @@ set(unittests_src
     ./TestOutstationUnsolicitedResponses.cpp
     ./TestShiftableBuffer.cpp
 	./TestStaticDataMap.cpp
+    ./TestTimeDuration.cpp
     ./TestTransportLayer.cpp
     ./TestTypedCommandHeader.cpp
     ./TestUpdateBuilder.cpp

--- a/cpp/tests/unit/TestTimeDuration.cpp
+++ b/cpp/tests/unit/TestTimeDuration.cpp
@@ -32,5 +32,12 @@ TEST_CASE(SUITE("constructing from maximum values are clamped to prevent overflo
     REQUIRE(TimeDuration::Minutes(std::numeric_limits<int64_t>::max()) == TimeDuration::Max());
 }
 
+TEST_CASE(SUITE("constructing from minimum values are clamped to prevent overflow when converting to nanos"))
+{    
+    REQUIRE(TimeDuration::Milliseconds(std::numeric_limits<int64_t>::min()) == TimeDuration::Min());
+    REQUIRE(TimeDuration::Seconds(std::numeric_limits<int64_t>::min()) == TimeDuration::Min());
+    REQUIRE(TimeDuration::Minutes(std::numeric_limits<int64_t>::min()) == TimeDuration::Min());    
+}
+
 
 

--- a/cpp/tests/unit/TestTimeDuration.cpp
+++ b/cpp/tests/unit/TestTimeDuration.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2020 Automatak, LLC
+ *
+ * Licensed to Green Energy Corp (www.greenenergycorp.com) and Automatak
+ * LLC (www.automatak.com) under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Green Energy Corp and Automatak LLC license
+ * this file to you under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may obtain
+ * a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <opendnp3/util/TimeDuration.h>
+
+#include <catch.hpp>
+
+using namespace opendnp3;
+
+#define SUITE(name) "TimeDurationTestSuite - " name
+
+TEST_CASE(SUITE("constructing from maximum values are clamped to prevent overflow when converting to nanos"))
+{
+    REQUIRE(TimeDuration::Milliseconds(std::numeric_limits<int64_t>::max()) == TimeDuration::Max());
+    REQUIRE(TimeDuration::Seconds(std::numeric_limits<int64_t>::max()) == TimeDuration::Max());
+    REQUIRE(TimeDuration::Minutes(std::numeric_limits<int64_t>::max()) == TimeDuration::Max());
+}
+
+
+


### PR DESCRIPTION
Fix for #381 

std::chrono::<milliseconds, seconds, etc> can mult overflow b/c of ratio conversions when
storing in std::chrono::steady_clock duration.