### PR TITLE
Fix EventOnly behaviour

### DIFF
--- a/cpp/examples/outstation/main.cpp
+++ b/cpp/examples/outstation/main.cpp
@@ -36,7 +36,7 @@ using namespace opendnp3;
 DatabaseConfig ConfigureDatabase()
 {
     DatabaseConfig config(10); // 10 of each type with default settings
-            
+
     config.analog_input[0].clazz = PointClass::Class2;
     config.analog_input[0].svariation = StaticAnalogVariation::Group30Var5;
     config.analog_input[0].evariation = EventAnalogVariation::Group32Var7;
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
     auto channel = std::shared_ptr<IChannel>(nullptr);
     try
     {
-        channel = manager.AddTCPServer("server", logLevels, ServerAcceptMode::CloseExisting, IPEndpoint("asdf", 20000),
+        channel = manager.AddTCPServer("server", logLevels, ServerAcceptMode::CloseExisting, IPEndpoint("0.0.0.0", 20000),
                                        PrintingChannelListener::Create());
     }
     catch(const std::exception& e)

--- a/cpp/examples/tls/master/main.cpp
+++ b/cpp/examples/tls/master/main.cpp
@@ -31,16 +31,18 @@ using namespace opendnp3;
 
 int main(int argc, char* argv[])
 {
-    if (argc != 3)
+    if (argc != 4)
     {
-        std::cout << "usage: master-tls-demo <peer certificate> <private key/certificate>" << std::endl;
+        std::cout << "usage: master-tls-demo <peer certificate> <local certificate> <private key>" << std::endl;
         return -1;
     }
 
     std::string peerCertificate(argv[1]);
-    std::string privateKey(argv[2]);
+    std::string localCertificate(argv[2]);
+    std::string privateKey(argv[3]);
 
     std::cout << "Using peer cert: " << peerCertificate << std::endl;
+    std::cout << "Using local cert: " << localCertificate << std::endl;
     std::cout << "Using private key file: " << privateKey << std::endl;
 
     // Specify what log levels to use. NORMAL is warning and above
@@ -54,7 +56,7 @@ int main(int argc, char* argv[])
     // Connect via a TCPClient socket to a outstation
     auto channel = manager.AddTLSClient(
         "tls-client", logLevels, ChannelRetry::Default(), {IPEndpoint("127.0.0.1", 20001)}, "0.0.0.0",
-        TLSConfig(peerCertificate, privateKey, privateKey), PrintingChannelListener::Create());
+        TLSConfig(peerCertificate, localCertificate, privateKey), PrintingChannelListener::Create());
 
     // The master config object for a master. The default are
     // useable, but understanding the options are important.

--- a/cpp/examples/tls/outstation/main.cpp
+++ b/cpp/examples/tls/outstation/main.cpp
@@ -57,16 +57,16 @@ int main(int argc, char* argv[])
 {
     if (argc != 4)
     {
-        std::cout << "usage: master-gprs-tls-demo <ca certificate> <certificate chain> <private key>" << std::endl;
+        std::cout << "usage: master-gprs-tls-demo <peer certificate> <local certificate chain> <private key>" << std::endl;
         return -1;
     }
 
-    std::string caCertificate(argv[1]);
-    std::string certificateChain(argv[2]);
+    std::string peerCertificate(argv[1]);
+    std::string localCertificate(argv[2]);
     std::string privateKey(argv[3]);
 
-    std::cout << "Using CA certificate: " << caCertificate << std::endl;
-    std::cout << "Using certificate chain: " << certificateChain << std::endl;
+    std::cout << "Using peer certificate: " << peerCertificate << std::endl;
+    std::cout << "Using local certificate: " << localCertificate << std::endl;
     std::cout << "Using private key file: " << privateKey << std::endl;
 
     // Specify what log levels to use. NORMAL is warning and above
@@ -79,7 +79,7 @@ int main(int argc, char* argv[])
 
     // Create a TCP server (listener)
     auto channel = manager.AddTLSServer("server", logLevels, ServerAcceptMode::CloseExisting, IPEndpoint("0.0.0.0", 20001),
-                                        TLSConfig(caCertificate, certificateChain, privateKey),
+                                        TLSConfig(peerCertificate, localCertificate, privateKey),
                                         PrintingChannelListener::Create());
 
     // The main object for a outstation. The defaults are useable,

--- a/cpp/lib/include/opendnp3/gen/EventMode.h
+++ b/cpp/lib/include/opendnp3/gen/EventMode.h
@@ -48,8 +48,7 @@ enum class EventMode : uint8_t
   Force = 0x1,
   /// Never produce an event regardless of changes
   Suppress = 0x2,
-  /// Force the creation of an event bypassing detection mechanism, but does not
-  /// update the static value
+  /// Force the creation of an event bypassing detection mechanism, but does not update the static value
   EventOnly = 0x3
 };
 

--- a/cpp/lib/include/opendnp3/gen/EventMode.h
+++ b/cpp/lib/include/opendnp3/gen/EventMode.h
@@ -48,7 +48,8 @@ enum class EventMode : uint8_t
   Force = 0x1,
   /// Never produce an event regardless of changes
   Suppress = 0x2,
-  /// Send an event directly to the event buffer, bypassing the static value completely
+  /// Force the creation of an event bypassing detection mechanism, but does not
+  /// update the static value
   EventOnly = 0x3
 };
 

--- a/cpp/lib/src/outstation/StaticDataMap.h
+++ b/cpp/lib/src/outstation/StaticDataMap.h
@@ -165,8 +165,6 @@ public:
 
     iterator end();
 
-    iterator find(uint16_t index);
-
 private:
     map_t map;
     Range selected;
@@ -252,7 +250,7 @@ bool StaticDataMap<Spec>::update(const map_iter_t& iter,
         iter->second.value = new_value;
     }
 
-    if (mode == EventMode::Force || Spec::IsEvent(iter->second.event.lastEvent, new_value, iter->second.config))
+    if (mode == EventMode::Force || mode == EventMode::EventOnly || Spec::IsEvent(iter->second.event.lastEvent, new_value, iter->second.config))
     {
         iter->second.event.lastEvent = new_value;
         if (mode != EventMode::Suppress)

--- a/cpp/tests/unit/TestStaticDataMap.cpp
+++ b/cpp/tests/unit/TestStaticDataMap.cpp
@@ -88,12 +88,49 @@ TEST_CASE(SUITE("can only add points that aren't already defined"))
 TEST_CASE(SUITE("can detect events on existing point"))
 {
     StaticDataMap<BinarySpec> map{{{0, {}}}};
+    map.select_all();
 
     EventReceiver receiver;
     REQUIRE(map.update(Binary(true), 0, EventMode::Detect, receiver));
     REQUIRE(receiver.count == 1);
     REQUIRE(map.update(Binary(true), 0, EventMode::Detect, receiver));
     REQUIRE(receiver.count == 1);
+}
+
+TEST_CASE(SUITE("can force events on existing point"))
+{
+    StaticDataMap<BinarySpec> map{{{0, {}}}};
+    map.select_all();
+
+    EventReceiver receiver;
+    REQUIRE(map.update(Binary(true), 0, EventMode::Force, receiver));
+    REQUIRE(receiver.count == 1);
+    REQUIRE(map.update(Binary(true), 0, EventMode::Force, receiver));
+    REQUIRE(receiver.count == 2);
+}
+
+TEST_CASE(SUITE("can ignore events on existing point"))
+{
+    StaticDataMap<BinarySpec> map{{{0, {}}}};
+    map.select_all();
+
+    EventReceiver receiver;
+    REQUIRE(map.update(Binary(true), 0, EventMode::Suppress, receiver));
+    REQUIRE(receiver.count == 0);
+    REQUIRE(map.update(Binary(true), 0, EventMode::Suppress, receiver));
+    REQUIRE(receiver.count == 0);
+}
+
+TEST_CASE(SUITE("can generate events on existing point"))
+{
+    StaticDataMap<BinarySpec> map{{{0, {}}}};
+    map.select_all();
+
+    EventReceiver receiver;
+    REQUIRE(map.update(Binary(true), 0, EventMode::EventOnly, receiver));
+    REQUIRE(receiver.count == 1);
+    REQUIRE(map.update(Binary(true), 0, EventMode::EventOnly, receiver));
+    REQUIRE(receiver.count == 2);
 }
 
 TEST_CASE(SUITE("can select all points using default variation and iterate"))

--- a/dotnet/CLRInterface/src/gen/EventMode.cs
+++ b/dotnet/CLRInterface/src/gen/EventMode.cs
@@ -49,7 +49,7 @@ namespace Automatak.DNP3.Interface
     /// </summary>
     Suppress = 0x2,
     /// <summary>
-    /// Send an event directly to the event buffer, bypassing the static value completely
+    /// Force the creation of an event bypassing detection mechanism, but does not update the static value
     /// </summary>
     EventOnly = 0x3
   }

--- a/generation/dnp3/src/main/scala/com/automatak/render/dnp3/enums/EventMode.scala
+++ b/generation/dnp3/src/main/scala/com/automatak/render/dnp3/enums/EventMode.scala
@@ -34,10 +34,7 @@ object EventMode {
     EnumValue("Detect", 0, "Detect events using the specific mechanism for that type"),
     EnumValue("Force", 1, "Force the creation of an event bypassing detection mechanism"),
     EnumValue("Suppress", 2, "Never produce an event regardless of changes"),
-    EnumValue("EventOnly", 3, "Send an event directly to the event buffer, bypassing the static value completely")
+    EnumValue("EventOnly", 3, "Force the creation of an event bypassing detection mechanism, but does not update the static value")
   )
 
 }
-
-
-

--- a/java/bindings/src/main/java/com/automatak/dnp3/enums/EventMode.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/enums/EventMode.java
@@ -48,7 +48,7 @@ public enum EventMode
   */
   Suppress(0x2),
   /**
-  * Send an event directly to the event buffer, bypassing the static value completely
+  * Force the creation of an event bypassing detection mechanism, but does not update the static value
   */
   EventOnly(0x3);
 


### PR DESCRIPTION
Fix #384.

- Fix `EventOnly`behaviour to match the 2.x.
- Updated outstation example adapter. `0.0.0.0` is more common default than `asdf`.
- Updated TLS examples to be consistent.