### PR TITLE
Fix EventOnly behaviour (Reprise)

### DIFF
--- a/cpp/lib/src/outstation/StaticDataMap.h
+++ b/cpp/lib/src/outstation/StaticDataMap.h
@@ -258,7 +258,7 @@ bool StaticDataMap<Spec>::update(const map_iter_t& iter,
             EventClass ec;
             if (convert_to_event_class(iter->second.config.clazz, ec))
             {
-                receiver.Update(Event<Spec>(iter->second.value, iter->first, ec, iter->second.config.evariation));
+                receiver.Update(Event<Spec>(new_value, iter->first, ec, iter->second.config.evariation));
             }
         }
     }


### PR DESCRIPTION
Fix #384 (Reprise).

The fix in #385 was not enough, since it kept reporting the old static value. I added unit tests that verify both the static and the event value to make sure this fix works.