### PR TITLE
Add missing deadband conversion in C# bindings.

### DIFF
--- a/dotnet/CLRAdapter/src/Conversions.h
+++ b/dotnet/CLRAdapter/src/Conversions.h
@@ -240,8 +240,8 @@ namespace Automatak
                         ret.clazz = static_cast<opendnp3::PointClass>(config->clazz);
                         ret.evariation = static_cast<Info::event_variation_t>(config->eventVariation);
                         ret.svariation = static_cast<Info::static_variation_t>(config->staticVariation);
+                        ret.deadband = static_cast<Info::value_t>(config->deadband);
                         return ret;
-
                     }
 
                     template <class Target, class Source>


### PR DESCRIPTION
Deadband value was not properly set in C# bindings, making them always set to 0. I checked the Java bindings they are good. I also checked the 2.x branch and it is good. The bug was introduced in 7dd1aa72fe1bc6ddcf5c0406ee6c193370b4a17c.