### PR TITLE
Feature/fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           if("${{ matrix.architecture }}" -eq "x86") { $flag = "--x86" } else { $flag = "" };
           choco install --no-progress "$flag" cmake.portable nuget.commandline openssl; mkdir build
       - name: Install Java
-        uses: emgre/setup-java@master
+        uses: actions/setup-java
         with:
           java-version: 8
           java-package: jdk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           if("${{ matrix.architecture }}" -eq "x86") { $flag = "--x86" } else { $flag = "" };
           choco install --no-progress "$flag" cmake.portable nuget.commandline openssl; mkdir build
       - name: Install Java
-        uses: actions/setup-java
+        uses: actions/setup-java@v1.4.3
         with:
           java-version: 8
           java-package: jdk


### PR DESCRIPTION
`actions/setup-java` has merged the architecture support AND resolved the environment variables changes Github made due to a CVE, so this fixes the CI and gets us off a custom version of the action.