### PR TITLE
Feature/octet string fix

### DIFF
--- a/cpp/lib/src/outstation/StaticWriters.cpp
+++ b/cpp/lib/src/outstation/StaticWriters.cpp
@@ -251,22 +251,34 @@ static_write_func_t<TimeAndIntervalSpec> StaticWriters::get(StaticTimeAndInterva
 
 template<class Writer> bool write_some_octet_strings(StaticDataMap<OctetStringSpec>& map, Writer& writer)
 {
-    auto next_index = map.get_selected_range().start;
+    bool first = true;
+    uint8_t last_length = 0;
+    uint16_t next_index = 0;
 
     for (const auto& elem : map)
     {
-        if (elem.first != next_index)
-        {
-            // we've loaded all we can with a contiguous range
-            return true;
+
+        if(!first) {
+
+            if(next_index != elem.first) {
+                // discontiguous indices
+                return true;
+            }
+
+            if(last_length != elem.second.value.Size()) {
+                // different lengths
+                return true;
+            }
         }
+
+        first = false;
+        next_index = elem.first + 1;
+        last_length = elem.second.value.Size();
 
         if (!writer.Write(elem.second.value))
         {
             return false;
         }
-
-        ++next_index;
     }
 
     return true;

--- a/cpp/tests/unit/TestOutstation.cpp
+++ b/cpp/tests/unit/TestOutstation.cpp
@@ -320,6 +320,24 @@ TEST_CASE(SUITE("octet strings can be returned as part of a class 0 scan"))
     REQUIRE(t.lower->PopWriteAsHex() == "C0 81 80 00 6E 01 00 00 02 00 00 00");
 }
 
+TEST_CASE(SUITE("static octet strings switch headers if length differs"))
+{
+    OutstationConfig config;
+    config.params.typesAllowedInClass0 = StaticTypeBitField::AllTypes();
+    OutstationTestObject t(config, configure::by_count_of::octet_string(2));
+
+    OctetString data;
+    REQUIRE(data.Set("a"));
+    REQUIRE(t.context.GetUpdateHandler().Update(data, 0));
+    REQUIRE(data.Set("bb"));
+    REQUIRE(t.context.GetUpdateHandler().Update(data, 1));
+
+    t.LowerLayerUp();
+    t.SendToOutstation("C0 01 3C 01 06"); // Read class 0
+
+    REQUIRE(t.lower->PopWriteAsHex() == "C0 81 80 00 6E 01 00 00 00 61 6E 02 00 01 01 62 62");
+}
+
 TEST_CASE(SUITE("octet strings can be returned by reading g110v0"))
 {
     OutstationConfig config;

--- a/dotnet/CLRAdapter/src/Conversions.cpp
+++ b/dotnet/CLRAdapter/src/Conversions.cpp
@@ -373,6 +373,7 @@ namespace DNP3
             config.maxAnalogEvents = cm->maxAnalogEvents;
             config.maxBinaryOutputStatusEvents = cm->maxBinaryOutputStatusEvents;
             config.maxAnalogOutputStatusEvents = cm->maxAnalogOutputStatusEvents;
+            config.maxOctetStringEvents = cm->maxOctetStringEvents;
             return config;
         }
 

--- a/dotnet/CLRInterface/src/PrintingSOEHandler.cs
+++ b/dotnet/CLRInterface/src/PrintingSOEHandler.cs
@@ -187,12 +187,12 @@ namespace Automatak.DNP3.Interface
 
         private static void Print(OctetString value, UInt16 index)
         {            
-            Console.WriteLine("OctetString[" + index + "] lemgth: " + value.Bytes.Length);            
+            Console.WriteLine("OctetString[" + index + "] length: " + value.Bytes.Length);            
         }
 
         private static void Print(TimeAndInterval value, UInt16 index)
-        {            
-            Console.WriteLine(String.Format("TimeAndInterval[{0}] {1}", index, value));           
+        {
+            Console.WriteLine(String.Format("TimeAndInterval[{0}] {1}", index, value));
         }
 
         private static void Print(BinaryCommandEvent value, UInt16 index)

--- a/dotnet/CLRInterface/src/config/EventBufferConfig.cs
+++ b/dotnet/CLRInterface/src/config/EventBufferConfig.cs
@@ -47,6 +47,7 @@ namespace Automatak.DNP3.Interface
             this.maxFrozenCounterEvents = count;
             this.maxBinaryOutputStatusEvents = count;
             this.maxAnalogOutputStatusEvents = count;
+            this.maxOctetStringEvents = count;
         }
 
 
@@ -92,6 +93,11 @@ namespace Automatak.DNP3.Interface
         /// The number of analog output status events the outstation will buffer before overflowing
         /// </summary>
         public System.UInt16 maxAnalogOutputStatusEvents;
+
+        /// <summary>
+        /// The number of octet stringevents the outstation will buffer before overflowing
+        /// </summary>
+        public System.UInt16 maxOctetStringEvents;
     }
 
 }


### PR DESCRIPTION
* Adds missing configuration of octet string events to C# `EventBufferConfig`
* Fixes a serialization bug in underlying C++ where static octet strings wouldn't switch headers if the length varied