### PR TITLE
Fix for #396 LinkContext shutdown datarace

### DIFF
--- a/cpp/lib/src/link/ILinkSession.h
+++ b/cpp/lib/src/link/ILinkSession.h
@@ -21,6 +21,7 @@
 #define OPENDNP3_ILINKSESSION_H
 
 #include "IFrameSink.h"
+#include <memory>
 
 namespace opendnp3
 {

--- a/cpp/lib/src/link/ILinkSession.h
+++ b/cpp/lib/src/link/ILinkSession.h
@@ -26,7 +26,7 @@ namespace opendnp3
 {
 
 // @section DESCRIPTION Interface from the link router to the link layer
-class ILinkSession : public IFrameSink
+class ILinkSession : public IFrameSink, public std::enable_shared_from_this<ILinkSession>
 {
 public:
     virtual ~ILinkSession() {}

--- a/cpp/lib/src/link/LinkContext.cpp
+++ b/cpp/lib/src/link/LinkContext.cpp
@@ -253,12 +253,22 @@ void LinkContext::OnResponseTimeout()
 
 void LinkContext::StartResponseTimer()
 {
-    rspTimeoutTimer = executor->start(config.Timeout.value, [this]() { this->OnResponseTimeout(); });
+    std::weak_ptr<ILinkSession> weak_session = pSession->shared_from_this();
+    rspTimeoutTimer = executor->start(config.Timeout.value, [this,weak_session]()
+    {
+	  if(auto session = weak_session.lock())
+		this->OnResponseTimeout();
+    });
 }
 
 void LinkContext::StartKeepAliveTimer(const Timestamp& expiration)
 {
-    this->keepAliveTimer = executor->start(expiration.value, [this]() { this->OnKeepAliveTimeout(); });
+    std::weak_ptr<ILinkSession> weak_session = pSession->shared_from_this();
+    this->keepAliveTimer = executor->start(expiration.value, [this,weak_session]()
+    {
+	  if(auto session = weak_session.lock())
+		this->OnKeepAliveTimeout();
+    });
 }
 
 void LinkContext::CancelTimer()

--- a/cpp/lib/src/master/MasterStack.h
+++ b/cpp/lib/src/master/MasterStack.h
@@ -33,7 +33,6 @@ namespace opendnp3
 class MasterStack : public IMaster,
                     public ILinkSession,
                     public ILinkTx,
-                    public std::enable_shared_from_this<MasterStack>,
                     public StackBase
 {
 public:
@@ -165,6 +164,12 @@ public:
 
 protected:
     MContext mcontext;
+
+private:
+    std::shared_ptr<MasterStack> shared_from_this()
+    {
+	  return std::static_pointer_cast<MasterStack>(ILinkSession::shared_from_this());
+    }
 };
 
 } // namespace opendnp3

--- a/cpp/lib/src/outstation/OutstationStack.h
+++ b/cpp/lib/src/outstation/OutstationStack.h
@@ -39,7 +39,6 @@ namespace opendnp3
 class OutstationStack final : public IOutstation,
                               public ILinkSession,
                               public ILinkTx,
-                              public std::enable_shared_from_this<OutstationStack>,
                               public StackBase
 {
 public:
@@ -114,6 +113,12 @@ public:
 
 private:
     OContext ocontext;
+
+private:
+    std::shared_ptr<OutstationStack> shared_from_this()
+    {
+	  return std::static_pointer_cast<OutstationStack>(ILinkSession::shared_from_this());
+    }
 };
 
 } // namespace opendnp3


### PR DESCRIPTION
The problem is that the link keepalive and response timers on LinkContext
could have outstanding handlers at the time of shutdown.
Most of the time this is OK, because the handlers get cancelled on OnLowerLayerDown()
and usually execute with operation aborted error code.

But in the case where a timer handler is already queued for execution
when OnLowerLayerDown() is called, it executes with a success error code
and goes on to access LinkContext members which are in the process of being destroyed.

This fix copies a weak pointer to the ILinkSession into the handlers.
The link session abstraction is the top level of the composition that
the LinkContext is a part of, and hence lifetime is tied to.
This way the handlers can check if their logical lifetime has ended and return
instead of racing with the destruction of the LinkContext.