### PR TITLE
Java `CommandHeader` builder methods now all return `CommandHeaders`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * :beetle: Fix keep-alive timer not properly calculated. See [#407](https://github.com/dnp3/opendnp3/pull/407).
 * :beetle: Fix `LinkContext` and `MContext` possible lifetime issue.
   See [#407](https://github.com/dnp3/opendnp3/pull/407).
+* :beetle: In Java, `CommandHeader` builder methods now all return `CommandHeaders`.
+  See [#440](https://github.com/dnp3/opendnp3/pull/440).
 
 ### 3.1.1 ###
 * :beetle: Fix static octet string serilazation bug.

--- a/java/bindings/src/main/java/com/automatak/dnp3/CommandHeader.java
+++ b/java/bindings/src/main/java/com/automatak/dnp3/CommandHeader.java
@@ -44,17 +44,17 @@ public class CommandHeader implements CommandHeaders
         return new CommandHeader((CommandBuilder b) -> b.addAO16(commands));
     }
 
-    public static CommandHeader fromAO32(Iterable<IndexedValue<AnalogOutputInt32>> commands)
+    public static CommandHeaders fromAO32(Iterable<IndexedValue<AnalogOutputInt32>> commands)
     {
        return new CommandHeader((CommandBuilder b) -> b.addAO32(commands));
     }
 
-    public static CommandHeader fromAOFloat32(Iterable<IndexedValue<AnalogOutputFloat32>> commands)
+    public static CommandHeaders fromAOFloat32(Iterable<IndexedValue<AnalogOutputFloat32>> commands)
     {
         return new CommandHeader((CommandBuilder b) -> b.addAOFloat32(commands));
     }
 
-    public static CommandHeader fromAODouble64(Iterable<IndexedValue<AnalogOutputDouble64>> commands)
+    public static CommandHeaders fromAODouble64(Iterable<IndexedValue<AnalogOutputDouble64>> commands)
     {
         return new CommandHeader((CommandBuilder b) -> b.addAODouble64(commands));
     }
@@ -69,17 +69,17 @@ public class CommandHeader implements CommandHeaders
         return fromAO16(wrap(command, index));
     }
 
-    public static CommandHeader fromSingleAO32(AnalogOutputInt32 command, int index)
+    public static CommandHeaders fromSingleAO32(AnalogOutputInt32 command, int index)
     {
         return fromAO32(wrap(command, index));
     }
 
-    public static CommandHeader fromSingleAOFloat32(AnalogOutputFloat32 command, int index)
+    public static CommandHeaders fromSingleAOFloat32(AnalogOutputFloat32 command, int index)
     {
         return fromAOFloat32(wrap(command, index));
     }
 
-    public static CommandHeader fromSingleAODouble64(AnalogOutputDouble64 command, int index)
+    public static CommandHeaders fromSingleAODouble64(AnalogOutputDouble64 command, int index)
     {
         return fromAODouble64(wrap(command, index));
     }


### PR DESCRIPTION
Fix #417