### PR TITLE
Added extra log when closing a new connection based on `ServerAcceptMode::CloseNew`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * :beetle: Fix keep-alive timer not properly calculated. See [#407](https://github.com/dnp3/opendnp3/pull/407).
 * :beetle: Fix `LinkContext` and `MContext` possible lifetime issue.
   See [#407](https://github.com/dnp3/opendnp3/pull/407).
+* :beetle: Added extra log when closing a new connection based on `ServerAcceptMode::CloseNew`.
+  See [#442](https://github.com/dnp3/opendnp3/pull/442).
 
 ### 3.1.1 ###
 * :beetle: Fix static octet string serilazation bug.

--- a/cpp/lib/src/channel/IOHandler.cpp
+++ b/cpp/lib/src/channel/IOHandler.cpp
@@ -212,6 +212,7 @@ void IOHandler::OnNewChannel(const std::shared_ptr<IAsyncChannel>& channel)
     // close the new channel instead
     if (this->channel && !this->close_existing)
     {
+        SIMPLE_LOG_BLOCK(this->logger, flags::WARN, "Existing channel, closing new connection");
         channel->Shutdown();
         return;
     }


### PR DESCRIPTION
The `ServerAcceptMode::CloseNew` works as expected. However, in the logs, it shows that it accepts the connection but doesn't tell that it is immediately shutdown. I added a log statement to make it clear.

Fix #421.