### PR TITLE
Fix TLS server not throwing exception when a certificate or key file is not valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * :beetle: Fix keep-alive timer not properly calculated. See [#407](https://github.com/dnp3/opendnp3/pull/407).
 * :beetle: Fix `LinkContext` and `MContext` possible lifetime issue.
   See [#407](https://github.com/dnp3/opendnp3/pull/407).
+* :beetle: Fix TLS server not throwing exception when a certificate or key file
+  is not valid. See [#443](https://github.com/dnp3/opendnp3/pull/443).
 
 ### 3.1.1 ###
 * :beetle: Fix static octet string serilazation bug.

--- a/cpp/examples/tls/master/main.cpp
+++ b/cpp/examples/tls/master/main.cpp
@@ -55,7 +55,7 @@ int main(int argc, char* argv[])
 
     // Connect via a TCPClient socket to a outstation
     auto channel = manager.AddTLSClient(
-        "tls-client", logLevels, ChannelRetry::Default(), {IPEndpoint("127.0.0.1", 20001)}, "0.0.0.0",
+        "tlsclient", logLevels, ChannelRetry::Default(), {IPEndpoint("127.0.0.1", 20001)}, "0.0.0.0",
         TLSConfig(peerCertificate, localCertificate, privateKey), PrintingChannelListener::Create());
 
     // The master config object for a master. The default are

--- a/cpp/examples/tls/outstation/main.cpp
+++ b/cpp/examples/tls/outstation/main.cpp
@@ -78,9 +78,18 @@ int main(int argc, char* argv[])
     DNP3Manager manager(1, ConsoleLogger::Create());
 
     // Create a TCP server (listener)
-    auto channel = manager.AddTLSServer("server", logLevels, ServerAcceptMode::CloseExisting, IPEndpoint("0.0.0.0", 20001),
-                                        TLSConfig(peerCertificate, localCertificate, privateKey),
-                                        PrintingChannelListener::Create());
+    auto channel = std::shared_ptr<IChannel>(nullptr);
+    try
+    {
+        channel = manager.AddTLSServer("tlsserver", logLevels, ServerAcceptMode::CloseExisting, IPEndpoint("0.0.0.0", 20001),
+                                            TLSConfig(peerCertificate, localCertificate, privateKey),
+                                            PrintingChannelListener::Create());
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << e.what() << '\n';
+        return -1;
+    }
 
     // The main object for a outstation. The defaults are useable,
     // but understanding the options are important.


### PR DESCRIPTION
Fix #436.