### PR TITLE
Build errors for aarch64-fsl-linux

### DIFF
--- a/cpp/lib/include/opendnp3/app/OctetData.h
+++ b/cpp/lib/include/opendnp3/app/OctetData.h
@@ -101,7 +101,7 @@ public:
 private:
     static const Buffer ToSlice(const char* input);
 
-    std::array<uint8_t, MAX_SIZE> buffer = {0x00};
+    std::array<uint8_t, MAX_SIZE> buffer = {{0x00}};
     uint8_t size;
 };
 

--- a/cpp/lib/src/channel/LoggingConnectionCondition.h
+++ b/cpp/lib/src/channel/LoggingConnectionCondition.h
@@ -25,6 +25,8 @@
 #include "opendnp3/logging/LogLevels.h"
 #include "opendnp3/logging/Logger.h"
 
+#include <system_error>
+
 namespace opendnp3
 {
 


### PR DESCRIPTION
Fixes aarch64-fsl-linux-g++ (Linaro GCC 4.9-2015.03) 4.9.3 20150311 (prerelease) were added. 